### PR TITLE
generic_fifo: Fix `valid_i` and `grant_i` guarantees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add ready/valid handshake delayer
 - Add stream arbiter
 
+### Fixed
+- Fix `valid_i` and `grant_i` guarantees in `generic_fifo` for backward compatibility.
+
 ## 1.9.0 - 2018-11-02
 
 ### Added

--- a/src/deprecated/generic_fifo.sv
+++ b/src/deprecated/generic_fifo.sv
@@ -35,18 +35,18 @@ module generic_fifo #(
     .DATA_WIDTH ( DATA_WIDTH ),
     .DEPTH      ( DATA_DEPTH )
   ) i_fifo (
-    .clk_i       ( clk          ),
-    .rst_ni      ( rst_n        ),
-    .flush_i     ( 1'b0         ),
-    .testmode_i  ( test_mode_i  ),
-    .full_o      ( full         ),
-    .empty_o     ( empty        ),
-    .alm_full_o  (              ),
-    .alm_empty_o (              ),
-    .data_i      ( data_i       ),
-    .push_i      ( valid_i      ),
-    .data_o      ( data_o       ),
-    .pop_i       ( grant_i      )
+    .clk_i       ( clk                ),
+    .rst_ni      ( rst_n              ),
+    .flush_i     ( 1'b0               ),
+    .testmode_i  ( test_mode_i        ),
+    .full_o      ( full               ),
+    .empty_o     ( empty              ),
+    .alm_full_o  (                    ),
+    .alm_empty_o (                    ),
+    .data_i      ( data_i             ),
+    .push_i      ( valid_i && ~full   ),
+    .data_o      ( data_o             ),
+    .pop_i       ( grant_i && ~empty  )
   );
 
 endmodule


### PR DESCRIPTION
The original `generic_fifo` guaranteed that `valid_i` could be asserted even though the FIFO instance was full (i.e., `~grant_o`) and that `grant_i` could be asserted even though the FIFO instance was empty (i.e., `~valid_o`).  Before this commit, the `generic_fifo` in this repository did not fulfill these guarantees (they caused assertion violations in the internally instantiated FIFO).  This commit fixes this without changing any other properties.