### PR TITLE
:space_invader: Fix streaming operator in ternary for synth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Fix `valid_i` and `grant_i` guarantees in `generic_fifo` for backward compatibility.
+- lzc: Synthesis of streaming operators in ternary operators
 
 ## 1.9.0 - 2018-11-02
 

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -41,7 +41,11 @@ module lzc #(
   logic [WIDTH-1:0] in_tmp;
 
   // reverse vector if required
-  assign in_tmp = MODE ? {<<{in_i}} : in_i;
+  always_comb begin : flip_vector
+    in_tmp = in_i;
+    if (MODE)
+      in_tmp = {<< {in_i}};
+  end
 
   for (genvar j = 0; j < WIDTH; j++) begin : g_index_lut
     assign index_lut[j] = j;


### PR DESCRIPTION
Some synthesis tools that shall not be named don't support streaming operators as ternary operands.