### PR TITLE
sram: Add FPGA cpabilities and random initialization

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -10,6 +10,7 @@ package:
 dependencies:
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1 }
   tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.1.1 }
+  fpga-support:       { git: "https://github.com/pulp-platform/fpga-support.git",       version: 0.3.2 }
 
 export_include_dirs:
   - include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add fall-through register
 - Add stream filter
 - Add ID queue
+- Add randomization capabilities to SRAM `sram.sv`
+- Add FPGA inferable SRAM to `sram.sv`
 
 ### Fixed
 - Fix FIFO push and pop signals in `stream_register` to observe interface prerequisites.

--- a/src/sram.sv
+++ b/src/sram.sv
@@ -1,4 +1,4 @@
-// Copyright 2017, 2018 ETH Zurich and University of Bologna.
+// Copyright 2018 ETH Zurich and University of Bologna.
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
 // compliance with the License.  You may obtain a copy of the License at
@@ -8,39 +8,69 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 //
-// Date: 13.10.2017
-// Description: SRAM Behavioral Model
+// Author: Florian Zaruba    <zarubaf@iis.ee.ethz.ch>, ETH Zurich
+//         Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 15.08.2018
+// Description: SRAM wrapper for FPGA (depends on FPGA support)
+//
+// Note: the wrapped module contains two different implementations for
+// ALTERA and XILINX tools, since these follow different coding styles for
+// inferrable RAMS with byte enable. define `FPGA_TARGET_XILINX or
+// `FPGA_TARGET_ALTERA in your build environment (default is ALTERA)
 
 module sram #(
-    int unsigned DATA_WIDTH = 64,
-    int unsigned NUM_WORDS  = 1024
+    parameter int unsigned DATA_WIDTH = 64,
+    parameter int unsigned NUM_WORDS  = 1024,
+    parameter bit          OUT_REGS   = 0,    // enables output registers in FPGA macro (read lat = 2)
+    parameter int unsigned SIM_INIT   = 0     // for simulation only, will not be synthesized
+                                              // 0: no init, 1: zero init, 2: random init
+                                              // note: on verilator, 2 is not supported. define the VERILATOR macro to work around.
 )(
    input  logic                          clk_i,
-
+   input  logic                          rst_ni,
    input  logic                          req_i,
    input  logic                          we_i,
    input  logic [$clog2(NUM_WORDS)-1:0]  addr_i,
    input  logic [DATA_WIDTH-1:0]         wdata_i,
-   input  logic [DATA_WIDTH-1:0]         be_i,
+   input  logic [(DATA_WIDTH+7)/8-1:0]   be_i,
    output logic [DATA_WIDTH-1:0]         rdata_o
 );
-    localparam ADDR_WIDTH = $clog2(NUM_WORDS);
 
-    logic [DATA_WIDTH-1:0] ram [NUM_WORDS-1:0];
-    logic [ADDR_WIDTH-1:0] raddr_q;
+localparam DATA_WIDTH_ALIGNED = ((DATA_WIDTH + 63) / 64) * 64;
+localparam BE_WIDTH_ALIGNED   = (((DATA_WIDTH + 7) / 8 + 7) / 8) * 8;
 
-    // 1. randomize array
-    // 2. randomize output when no request is active
-    always_ff @(posedge clk_i) begin
-        if (req_i) begin
-            if (!we_i)
-                raddr_q <= addr_i;
-            else
-            for (int i = 0; i < DATA_WIDTH; i++)
-                if (be_i[i]) ram[addr_i][i] <= wdata_i[i];
-        end
-    end
+logic [DATA_WIDTH_ALIGNED-1:0]  wdata_aligned;
+logic [BE_WIDTH_ALIGNED-1:0]    be_aligned;
+logic [DATA_WIDTH_ALIGNED-1:0]  rdata_aligned;
 
-    assign rdata_o = ram[raddr_q];
+// align to 64 bits for inferrable macro below
+always_comb begin : p_align
+    wdata_aligned                    ='0;
+    be_aligned                       ='0;
+    wdata_aligned[DATA_WIDTH-1:0]    = wdata_i;
+    be_aligned[BE_WIDTH_ALIGNED-1:0] = be_i;
+    // output
+    rdata_o = rdata_aligned[DATA_WIDTH-1:0];
+end
+
+
+for (genvar k = 0; k < (DATA_WIDTH + 63) / 64; k++) begin
+    // unused byte-enable segments (8 bits) are culled by the tool
+    SyncSpRamBeNx64 #(
+      .ADDR_WIDTH ( $clog2(NUM_WORDS) ),
+      .DATA_DEPTH ( NUM_WORDS         ),
+      .OUT_REGS   ( OUT_REGS          ),
+      .SIM_INIT   ( SIM_INIT          )
+    ) i_ram (
+       .Clk_CI    ( clk_i                       ),
+       .Rst_RBI   ( rst_ni                      ),
+       .CSel_SI   ( req_i                       ),
+       .WrEn_SI   ( we_i                        ),
+       .BEn_SI    ( be_aligned[(k * 8)+:8]      ),
+       .WrData_DI ( wdata_aligned[(k * 64)+:64] ),
+       .Addr_DI   ( addr_i                      ),
+       .RdData_DO ( rdata_aligned[(k*64)+:64]   )
+    );
+end
 
 endmodule


### PR DESCRIPTION
I was wondering if I can sneak in another change into the `1.11` CL? This one adds improved SRAM capabilities. In particular it adds:

1. sim initialization: either don't initialize, zero, random values or the usual `0xdeadbeef`
2. In an FPGA setting, they will properly be inferred as BRAMs. The drawback that this adds a dependency to the `fpga-support` module. But imho it is very convenient to have inferrable SRAMs.