### PR TITLE
V1.12.0

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -48,6 +48,7 @@ sources:
   - src/fifo_v2.sv
   - src/id_queue.sv
   - src/rrarbiter.sv
+  - src/prioarbiter.sv
   - src/rstgen.sv
   - src/stream_delay.sv
   # Level 2

--- a/Bender.yml
+++ b/Bender.yml
@@ -19,6 +19,7 @@ sources:
   # Files in level 1 only depend on files in level 0, files in level 2 on files in levels 1 and 0,
   # etc. Files within a level are ordered alphabetically.
   # Level 0
+  - src/plru_tree.sv
   - src/cdc_2phase.sv
   - src/clk_div.sv
   - src/counter.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Add priority arbiter
+
+### Changed
+- Add priority arbiter implementation
+
 ## 1.11.0 - 2019-03-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add priority arbiter
+- Add Pseudo Least Recently Used tree
 
 ### Changed
 - Add priority arbiter implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - `sync_wedge` use existing synchronizer. This defines a single place where a tech-specific synchronizer can be defined.
+- Add `$onehot0` assertion in one-hot to bin
 
 ### Fixed
 - Fix FIFO push and pop signals in `stream_register` to observe interface prerequisites.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Please note that cells with status *deprecated* are not to be used for new desig
 
 ### Data Path Elements
 
-|            Name            |                                 Description                                  |    Status    |
-|----------------------------|------------------------------------------------------------------------------|--------------|
+| Name                       | Description                                                                  | Status       |
+|:---------------------------|:-----------------------------------------------------------------------------|:-------------|
 | `binary_to_gray`           | Binary to gray code converter                                                | active       |
 | `find_first_one`           | Leading-one finder / leading-zero counter                                    | *deprecated* |
 | `gray_to_binary`           | Gray code to binary converter                                                | active       |
@@ -57,6 +57,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `onehot_to_bin`            | One-hot to binary converter                                                  | active       |
 | `shift_reg`                | Shift register for arbitrary types                                           | active       |
 | `rrarbiter`                | Round-robin arbiter for req/ack interface with look-ahead                    | active       |
+| `prioarbiter`              | Priority arbiter arbiter for req/ack interface with look-ahead               | active       |
 | `fall_through_register`    | Fall-through register with ready/valid interface                             | active       |
 | `spill_register`           | Register with ready/valid interface to cut all combinational interface paths | active       |
 | `stream_arbiter`           | Round-robin arbiter for ready/valid stream interface                         | active       |

--- a/README.md
+++ b/README.md
@@ -72,14 +72,15 @@ Please note that cells with status *deprecated* are not to be used for new desig
 
 ### Data Structures
 
-|        Name        |                  Description                  |    Status    |
-|--------------------|-----------------------------------------------|--------------|
+| Name               | Description                                   | Status       |
+|:-------------------|:----------------------------------------------|:-------------|
 | `fifo`             | FIFO register with upper threshold            | *deprecated* |
 | `fifo_v2`          | FIFO register with upper and lower threshold  | *deprecated* |
 | `fifo_v3`          | FIFO register with generic fill counts        | active       |
 | `generic_fifo`     | FIFO register without thresholds              | *deprecated* |
 | `generic_fifo_adv` | FIFO register without thresholds              | *deprecated* |
 | `sram`             | SRAM behavioral model                         | active       |
+| `plru_tree`        | Pseudo least recently used tree               | active       |
 | `unread`           | Empty module to sink unconnected outputs into | active       |
 
 

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -12,9 +12,10 @@
 
 module onehot_to_bin #(
     parameter int unsigned ONEHOT_WIDTH = 16,
-    parameter int unsigned BIN_WIDTH    = $clog2(ONEHOT_WIDTH)
+    // Do Not Change
+    localparam int unsigned BIN_WIDTH   = $clog2(ONEHOT_WIDTH)
 )(
-    input logic  [ONEHOT_WIDTH-1:0] onehot,
+    input  logic [ONEHOT_WIDTH-1:0] onehot,
     output logic [BIN_WIDTH-1:0]    bin
 );
 
@@ -27,4 +28,12 @@ module onehot_to_bin #(
             end
         assign bin[j] = |(tmp_mask & onehot);
     end
+
+// pragma translate_off
+`ifndef VERILATOR
+    initial begin
+        assert($onehot0(onehot)) else $fatal(1, "[onehot_to_bin] More than two bit set in the one-hot signal");
+    end
+`endif
+// pragma translate_on
 endmodule

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -1,0 +1,109 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: David Schaffenrath, TU Graz
+// Author: Florian Zaruba, ETH Zurich
+//
+// Description: Pseudo Least Recently Used Tree (PLRU)
+// See: https://en.wikipedia.org/wiki/Pseudo-LRU
+
+module plru_tree #(
+  parameter int unsigned ENTRIES = 16
+) (
+  input  logic               clk_i,
+  input  logic               rst_ni,
+  input  logic [ENTRIES-1:0] used_i, // element i was used (one hot)
+  output logic [ENTRIES-1:0] plru_o  // element i is the least recently used (one hot)
+);
+
+    logic [2*(ENTRIES-1)-1:0] plru_tree_q, plru_tree_n;
+
+    always_comb begin : plru_replacement
+        plru_tree_n = plru_tree_q;
+        // The PLRU-tree indexing:
+        // lvl0        0
+        //            / \
+        //           /   \
+        // lvl1     1     2
+        //         / \   / \
+        // lvl2   3   4 5   6
+        //       / \ /\/\  /\
+        //      ... ... ... ...
+        // Just predefine which nodes will be set/cleared
+        // E.g. for a TLB with 8 entries, the for-loop is semantically
+        // equivalent to the following pseudo-code:
+        // unique case (1'b1)
+        // used_i[7]: plru_tree_n[0, 2, 6] = {1, 1, 1};
+        // used_i[6]: plru_tree_n[0, 2, 6] = {1, 1, 0};
+        // used_i[5]: plru_tree_n[0, 2, 5] = {1, 0, 1};
+        // used_i[4]: plru_tree_n[0, 2, 5] = {1, 0, 0};
+        // used_i[3]: plru_tree_n[0, 1, 4] = {0, 1, 1};
+        // used_i[2]: plru_tree_n[0, 1, 4] = {0, 1, 0};
+        // used_i[1]: plru_tree_n[0, 1, 3] = {0, 0, 1};
+        // used_i[0]: plru_tree_n[0, 1, 3] = {0, 0, 0};
+        // default: begin /* No hit */ end
+        // endcase
+        for (int unsigned i = 0; i < ENTRIES; i++) begin
+            automatic int unsigned idx_base, shift, new_index;
+            // we got a hit so update the pointer as it was least recently used
+            if (used_i[i]) begin
+                // Set the nodes to the values we would expect
+                for (int unsigned lvl = 0; lvl < $clog2(ENTRIES); lvl++) begin
+                  idx_base = $unsigned((2**lvl)-1);
+                  // lvl0 <=> MSB, lvl1 <=> MSB-1, ...
+                  shift = $clog2(ENTRIES) - lvl;
+                  // to circumvent the 32 bit integer arithmetic assignment
+                  new_index =  ~((i >> (shift-1)) & 32'b1);
+                  plru_tree_n[idx_base + (i >> shift)] = new_index[0];
+                end
+            end
+        end
+        // Decode tree to write enable signals
+        // Next for-loop basically creates the following logic for e.g. an 8 entry
+        // TLB (note: pseudo-code obviously):
+        // plru_o[7] = &plru_tree_q[ 6, 2, 0]; //plru_tree_q[0,2,6]=={1,1,1}
+        // plru_o[6] = &plru_tree_q[~6, 2, 0]; //plru_tree_q[0,2,6]=={1,1,0}
+        // plru_o[5] = &plru_tree_q[ 5,~2, 0]; //plru_tree_q[0,2,5]=={1,0,1}
+        // plru_o[4] = &plru_tree_q[~5,~2, 0]; //plru_tree_q[0,2,5]=={1,0,0}
+        // plru_o[3] = &plru_tree_q[ 4, 1,~0]; //plru_tree_q[0,1,4]=={0,1,1}
+        // plru_o[2] = &plru_tree_q[~4, 1,~0]; //plru_tree_q[0,1,4]=={0,1,0}
+        // plru_o[1] = &plru_tree_q[ 3,~1,~0]; //plru_tree_q[0,1,3]=={0,0,1}
+        // plru_o[0] = &plru_tree_q[~3,~1,~0]; //plru_tree_q[0,1,3]=={0,0,0}
+        // For each entry traverse the tree. If every tree-node matches,
+        // the corresponding bit of the entry's index, this is
+        // the next entry to replace.
+        for (int unsigned i = 0; i < ENTRIES; i += 1) begin
+            automatic logic en;
+            automatic int unsigned idx_base, shift, new_index;
+            en = 1'b1;
+            for (int unsigned lvl = 0; lvl < $clog2(ENTRIES); lvl++) begin
+                idx_base = $unsigned((2**lvl)-1);
+                // lvl0 <=> MSB, lvl1 <=> MSB-1, ...
+                shift = $clog2(ENTRIES) - lvl;
+                // en &= plru_tree_q[idx_base + (i>>shift)] == ((i >> (shift-1)) & 1'b1);
+                new_index =  (i >> (shift-1)) & 32'b1;
+                if (new_index[0]) begin
+                  en &= plru_tree_q[idx_base + (i>>shift)];
+                end else begin
+                  en &= ~plru_tree_q[idx_base + (i>>shift)];
+                end
+            end
+            plru_o[i] = en;
+        end
+    end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (!rst_ni) begin
+            plru_tree_q <= '0;
+        end else begin
+            plru_tree_q <= plru_tree_n;
+        end
+    end
+endmodule

--- a/src/prioarbiter.sv
+++ b/src/prioarbiter.sv
@@ -1,0 +1,87 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>, ETH Zurich
+// Date: 16.03.2019
+// Description: Priority arbiter with Lock in
+
+// Dependencies: relies on fast leading zero counter tree "onehot_to_bin" in common_cells
+module prioarbiter #(
+  parameter int unsigned NUM_REQ = 13,
+  parameter int unsigned LOCK_IN = 0
+) (
+  input logic                         clk_i,
+  input logic                         rst_ni,
+
+  input logic                         flush_i, // clears the fsm and control signal registers
+  input logic                         en_i,    // arbiter enable
+  input logic [NUM_REQ-1:0]           req_i,   // request signals
+
+  output logic [NUM_REQ-1:0]          ack_o,   // acknowledge signals
+  output logic                        vld_o,   // request ack'ed
+  output logic [$clog2(NUM_REQ)-1:0]  idx_o    // idx output
+);
+
+  localparam SEL_WIDTH = $clog2(NUM_REQ);
+
+  logic [SEL_WIDTH-1:0] arb_sel_lock_d, arb_sel_lock_q;
+  logic lock_d, lock_q;
+
+  logic [$clog2(NUM_REQ)-1:0] idx;
+
+  // shared
+  assign vld_o = (|req_i) & en_i;
+  assign idx_o  = (lock_q) ? arb_sel_lock_q : idx;
+
+  // Arbiter
+  // Port 0 has priority over all other ports
+  assign ack_o[0] = (req_i[0]) ? en_i : 1'b0;
+  // check that the priorities
+  for (genvar i = 1; i < NUM_REQ; i++) begin : arb_req_ports
+      // for every subsequent port check the priorities of the previous port
+      assign ack_o[i] = (req_i[i] & ~(|ack_o[i-1:0])) ? en_i : 1'b0;
+  end
+
+  onehot_to_bin #(
+    .ONEHOT_WIDTH ( NUM_REQ )
+  ) i_onehot_to_bin (
+    .onehot ( ack_o ),
+    .bin    ( idx   )
+  );
+
+  if (LOCK_IN) begin : g_lock_in
+    // latch decision in case we got at least one req and no acknowledge
+    assign lock_d         = (|req_i) & ~en_i;
+    assign arb_sel_lock_d = idx_o;
+  end else begin
+    // disable
+    assign lock_d         = '0;
+    assign arb_sel_lock_d = '0;
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+    if (!rst_ni) begin
+      lock_q         <= 1'b0;
+      arb_sel_lock_q <= '0;
+    end else begin
+      if (flush_i) begin
+        lock_q         <= 1'b0;
+        arb_sel_lock_q <= '0;
+      end else begin
+        lock_q         <= lock_d;
+        arb_sel_lock_q <= arb_sel_lock_d;
+      end
+    end
+  end
+
+endmodule : prioarbiter
+
+
+

--- a/src/stream_arbiter.sv
+++ b/src/stream_arbiter.sv
@@ -15,7 +15,8 @@
 
 module stream_arbiter #(
     parameter type      DATA_T = logic,   // Vivado requires a default value for type parameters.
-    parameter integer   N_INP = -1        // Synopsys DC requires a default value for parameters.
+    parameter integer   N_INP = -1,       // Synopsys DC requires a default value for parameters.
+    parameter           ARBITER = "rr"    // "rr" or "prio"
 ) (
     input  logic              clk_i,
     input  logic              rst_ni,
@@ -31,7 +32,8 @@ module stream_arbiter #(
 
   stream_arbiter_flushable #(
     .DATA_T (DATA_T),
-    .N_INP  (N_INP)
+    .N_INP  (N_INP),
+    .ARBITER (ARBITER)
   ) i_arb (
     .clk_i        (clk_i),
     .rst_ni       (rst_ni),

--- a/src/stream_arbiter_flushable.sv
+++ b/src/stream_arbiter_flushable.sv
@@ -15,7 +15,8 @@
 
 module stream_arbiter_flushable #(
     parameter type      DATA_T = logic,   // Vivado requires a default value for type parameters.
-    parameter integer   N_INP = -1        // Synopsys DC requires a default value for parameters.
+    parameter integer   N_INP = -1,       // Synopsys DC requires a default value for parameters.
+    parameter           ARBITER = "rr"    // "rr" or "prio"
 ) (
     input  logic              clk_i,
     input  logic              rst_ni,
@@ -32,23 +33,43 @@ module stream_arbiter_flushable #(
 
   logic [$clog2(N_INP)-1:0] idx;
 
-  rrarbiter #(
-    .NUM_REQ  (N_INP),
-    // Lock arbitration decision once the output is valid and until the handshake happens.
-    .LOCK_IN  (1)
-  ) i_arbiter (
-    .clk_i    (clk_i),
-    .rst_ni   (rst_ni),
-    .flush_i  (flush_i),
-    .en_i     (oup_ready_i),
-    .req_i    (inp_valid_i),
-    .ack_o    (inp_ready_o),
-    // The `vld_o` port of `rrarbiter` combinatorially depends on `en_i`.  In the stream protocol,
-    // a valid may not depend on a ready, so we drive `oup_valid_o` from the `inp_valid_i`s in (1)
-    // and leave `vld_o` unconnected.
-    .vld_o    (),
-    .idx_o    (idx)
-  );
+  if (ARBITER == "rr") begin
+    rrarbiter #(
+      .NUM_REQ  (N_INP),
+      // Lock arbitration decision once the output is valid and until the handshake happens.
+      .LOCK_IN  (1)
+    ) i_arbiter (
+      .clk_i    (clk_i),
+      .rst_ni   (rst_ni),
+      .flush_i  (flush_i),
+      .en_i     (oup_ready_i),
+      .req_i    (inp_valid_i),
+      .ack_o    (inp_ready_o),
+      // The `vld_o` port of `rrarbiter` combinatorially depends on `en_i`.  In the stream protocol,
+      // a valid may not depend on a ready, so we drive `oup_valid_o` from the `inp_valid_i`s in (1)
+      // and leave `vld_o` unconnected.
+      .vld_o    (),
+      .idx_o    (idx)
+    );
+  end else if (ARBITER == "prio") begin
+    prioarbiter #(
+      .NUM_REQ  (N_INP),
+      // Lock arbitration decision once the output is valid and until the handshake happens.
+      .LOCK_IN  (1)
+    ) i_arbiter (
+      .clk_i    (clk_i),
+      .rst_ni   (rst_ni),
+      .flush_i  (flush_i),
+      .en_i     (oup_ready_i),
+      .req_i    (inp_valid_i),
+      .ack_o    (inp_ready_o),
+      // The `vld_o` port of `rrarbiter` combinatorially depends on `en_i`.  In the stream protocol,
+      // a valid may not depend on a ready, so we drive `oup_valid_o` from the `inp_valid_i`s in (1)
+      // and leave `vld_o` unconnected.
+      .vld_o    (),
+      .idx_o    (idx)
+    );
+  end
 
   assign oup_valid_o = (|inp_valid_i); // (1), see reference above.
   assign oup_data_o = inp_data_i[idx];

--- a/src_files.yml
+++ b/src_files.yml
@@ -4,6 +4,7 @@ common_cells_all:
     # package. Files in level 1 only depend on files in level 0, files in level 2 on files in
     # levels 1 and 0, etc. Files within a level are ordered alphabetically.
     # Level 0
+    - src/plru_tree.sv
     - src/cdc_2phase.sv
     - src/clk_div.sv
     - src/counter.sv

--- a/src_files.yml
+++ b/src_files.yml
@@ -29,6 +29,7 @@ common_cells_all:
     - src/fifo_v2.sv
     - src/id_queue.sv
     - src/rrarbiter.sv
+    - src/prioarbiter.sv
     - src/rstgen.sv
     - src/stream_delay.sv
     # Level 2


### PR DESCRIPTION
Two new modules:

- Priority arbiter implementation
- Pseudo-least recently used tree (refactored from Ariane's TLB impmentation)

Add `onehot` assertion in `onehot_to_bin` module. Gives an extra sanity check for everybody using this module.

@accuminium Do you have anything else which could go into this release?