### PR TITLE
Extend counter features: overflow latch, variable delta, maximum latch

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -23,7 +23,7 @@ sources:
   - src/cdc_2phase.sv
   - src/cf_math_pkg.sv
   - src/clk_div.sv
-  - src/counter.sv
+  - src/delta_counter.sv
   - src/edge_propagator_tx.sv
   - src/fifo_v3.sv
   - src/graycode.sv
@@ -48,6 +48,7 @@ sources:
   # Level 1
   - src/cdc_fifo_2phase.sv
   - src/cdc_fifo_gray.sv
+  - src/counter.sv
   - src/edge_detect.sv
   - src/id_queue.sv
   - src/rstgen.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -51,6 +51,7 @@ sources:
   - src/counter.sv
   - src/edge_detect.sv
   - src/id_queue.sv
+  - src/max_counter.sv
   - src/rstgen.sv
   - src/stream_delay.sv
   # Level 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `counter`: Added overflow latch
 - Added counter with variable delta
+- Added counter with maximum latch
 
 ## 1.13.1 - 2019-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `counter`: Added overflow latch
+- Added counter with variable delta
 
 ## 1.13.1 - 2019-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+- `counter`: Added overflow latch
+
 ## 1.13.1 - 2019-06-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
-- `counter`: Added overflow latch
+- `counter`: Added sticky overflow
 - Added counter with variable delta
-- Added counter with maximum latch
+- Added counter that tracks its maximum value
 
 ## 1.13.1 - 2019-06-01
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `lfsr_8bit`         | 8-bit linear feedback shift register (LFSR)                       | active       |               |
 | `lfsr_16bit`        | 16-bit linear feedback shift register (LFSR)                      | active       |               |
 | `lfsr`              | 4...64-bit parametric Galois LFSR with optional whitening feature | active       |               |
+| `max_counter`       | Up/down counter with variable delta and maximum latch             | active       |               |
 | `mv_filter`         | **ZARUBAF ADD DESCRIPTION**                                       | active       |               |
 
 ### Data Path Elements

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `lfsr_8bit`         | 8-bit linear feedback shift register (LFSR)                       | active       |               |
 | `lfsr_16bit`        | 16-bit linear feedback shift register (LFSR)                      | active       |               |
 | `lfsr`              | 4...64-bit parametric Galois LFSR with optional whitening feature | active       |               |
-| `max_counter`       | Up/down counter with variable delta and maximum latch             | active       |               |
+| `max_counter`       | Up/down counter with variable delta that tracks its maximum value | active       |               |
 | `mv_filter`         | **ZARUBAF ADD DESCRIPTION**                                       | active       |               |
 
 ### Data Path Elements

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 |         Name        |                   Description                                     |    Status    | Superseded By |
 |---------------------|-------------------------------------------------------------------|--------------|---------------|
 | `counter`           | Generic up/down counter with overflow detection                   | active       |               |
+| `delta_counter`     | Up/down counter with variable delta and overflow detection        | active       |               |
 | `generic_LFSR_8bit` | 8-bit linear feedback shift register (LFSR)                       | *deprecated* | `lfsr_8bit`   |
 | `lfsr_8bit`         | 8-bit linear feedback shift register (LFSR)                       | active       |               |
 | `lfsr_16bit`        | 16-bit linear feedback shift register (LFSR)                      | active       |               |

--- a/src/counter.sv
+++ b/src/counter.sv
@@ -13,7 +13,7 @@
 
 module counter #(
     parameter int unsigned WIDTH = 4,
-    parameter bit LATCH_OVERFLOW = 1'b0
+    parameter bit STICKY_OVERFLOW = 1'b0
 )(
     input  logic             clk_i,
     input  logic             rst_ni,
@@ -27,7 +27,7 @@ module counter #(
 );
     delta_counter #(
         .WIDTH          (WIDTH),
-        .LATCH_OVERFLOW (LATCH_OVERFLOW)
+        .STICKY_OVERFLOW (STICKY_OVERFLOW)
     ) i_counter (
         .clk_i,
         .rst_ni,

--- a/src/counter.sv
+++ b/src/counter.sv
@@ -25,56 +25,19 @@ module counter #(
     output logic [WIDTH-1:0] q_o,
     output logic             overflow_o
 );
-    logic [WIDTH:0] counter_q, counter_d;
-    if (LATCH_OVERFLOW) begin: gen_latch_overflow
-        logic overflow_d, overflow_q;
-        always_comb begin
-            overflow_d = overflow_q;
-            if (clear_i || load_i) begin
-                overflow_d = 1'b0;
-            end else if (!overflow_q && en_i) begin
-                if (down_i) begin
-                    overflow_d = (counter_q == '0);
-                end else begin
-                    overflow_d = (counter_q[WIDTH-1:0] == '1);
-                end
-            end
-        end
-        assign overflow_o = overflow_q;
-        always_ff @(posedge clk_i or negedge rst_ni) begin
-            if (!rst_ni) begin
-                overflow_q <= 1'b0;
-            end else begin
-                overflow_q <= overflow_d;
-            end
-        end
-    end else begin
-        // counter overflowed if the MSB is set
-        assign overflow_o = counter_q[WIDTH];
-    end
-    assign q_o = counter_q[WIDTH-1:0];
-
-    always_comb begin
-        counter_d = counter_q;
-
-        if (clear_i) begin
-            counter_d = '0;
-        end else if (load_i) begin
-            counter_d = {1'b0, d_i};
-        end else if (en_i) begin
-            if (down_i) begin
-                counter_d = counter_q - 1;
-            end else begin
-                counter_d = counter_q + 1;
-            end
-        end
-    end
-
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
-           counter_q <= '0;
-        end else begin
-           counter_q <= counter_d;
-        end
-    end
+    delta_counter #(
+        .WIDTH          (WIDTH),
+        .LATCH_OVERFLOW (LATCH_OVERFLOW)
+    ) i_counter (
+        .clk_i,
+        .rst_ni,
+        .clear_i,
+        .en_i,
+        .load_i,
+        .down_i,
+        .delta_i({{WIDTH-1{1'b0}}, 1'b1}),
+        .d_i,
+        .q_o,
+        .overflow_o
+    );
 endmodule

--- a/src/delta_counter.sv
+++ b/src/delta_counter.sv
@@ -26,7 +26,7 @@ module delta_counter #(
     output logic             overflow_o
 );
     logic [WIDTH:0] counter_q, counter_d;
-    if (LATCH_OVERFLOW) begin: gen_latch_overflow
+    if (LATCH_OVERFLOW) begin : gen_latch_overflow
         logic overflow_d, overflow_q;
         always_ff @(posedge clk_i or negedge rst_ni) overflow_q <= ~rst_ni ? 1'b0 : overflow_d;
         always_comb begin
@@ -65,7 +65,7 @@ module delta_counter #(
     end
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
-        if (~rst_ni) begin
+        if (!rst_ni) begin
            counter_q <= '0;
         end else begin
            counter_q <= counter_d;

--- a/src/delta_counter.sv
+++ b/src/delta_counter.sv
@@ -12,7 +12,7 @@
 
 module delta_counter #(
     parameter int unsigned WIDTH = 4,
-    parameter bit LATCH_OVERFLOW = 1'b0
+    parameter bit STICKY_OVERFLOW = 1'b0
 )(
     input  logic             clk_i,
     input  logic             rst_ni,
@@ -26,7 +26,7 @@ module delta_counter #(
     output logic             overflow_o
 );
     logic [WIDTH:0] counter_q, counter_d;
-    if (LATCH_OVERFLOW) begin : gen_latch_overflow
+    if (STICKY_OVERFLOW) begin : gen_sticky_overflow
         logic overflow_d, overflow_q;
         always_ff @(posedge clk_i or negedge rst_ni) overflow_q <= ~rst_ni ? 1'b0 : overflow_d;
         always_comb begin

--- a/src/delta_counter.sv
+++ b/src/delta_counter.sv
@@ -1,0 +1,74 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Up/down counter with variable delta
+
+module delta_counter #(
+    parameter int unsigned WIDTH = 4,
+    parameter bit LATCH_OVERFLOW = 1'b0
+)(
+    input  logic             clk_i,
+    input  logic             rst_ni,
+    input  logic             clear_i, // synchronous clear
+    input  logic             en_i,    // enable the counter
+    input  logic             load_i,  // load a new value
+    input  logic             down_i,  // downcount, default is up
+    input  logic [WIDTH-1:0] delta_i,
+    input  logic [WIDTH-1:0] d_i,
+    output logic [WIDTH-1:0] q_o,
+    output logic             overflow_o
+);
+    logic [WIDTH:0] counter_q, counter_d;
+    if (LATCH_OVERFLOW) begin: gen_latch_overflow
+        logic overflow_d, overflow_q;
+        always_ff @(posedge clk_i or negedge rst_ni) overflow_q <= ~rst_ni ? 1'b0 : overflow_d;
+        always_comb begin
+            overflow_d = overflow_q;
+            if (clear_i || load_i) begin
+                overflow_d = 1'b0;
+            end else if (!overflow_q && en_i) begin
+                if (down_i) begin
+                    overflow_d = delta_i > counter_q[WIDTH-1:0];
+                end else begin
+                    overflow_d = counter_q[WIDTH-1:0] > ({WIDTH{1'b1}} - delta_i);
+                end
+            end
+        end
+        assign overflow_o = overflow_q;
+    end else begin
+        // counter overflowed if the MSB is set
+        assign overflow_o = counter_q[WIDTH];
+    end
+    assign q_o = counter_q[WIDTH-1:0];
+
+    always_comb begin
+        counter_d = counter_q;
+
+        if (clear_i) begin
+            counter_d = '0;
+        end else if (load_i) begin
+            counter_d = {1'b0, d_i};
+        end else if (en_i) begin
+            if (down_i) begin
+                counter_d = counter_q - delta_i;
+            end else begin
+                counter_d = counter_q + delta_i;
+            end
+        end
+    end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (~rst_ni) begin
+           counter_q <= '0;
+        end else begin
+           counter_q <= counter_d;
+        end
+    end
+endmodule

--- a/src/delta_counter.sv
+++ b/src/delta_counter.sv
@@ -42,7 +42,7 @@ module delta_counter #(
             end
         end
         assign overflow_o = overflow_q;
-    end else begin
+    end else begin : gen_transient_overflow
         // counter overflowed if the MSB is set
         assign overflow_o = counter_q[WIDTH];
     end

--- a/src/max_counter.sv
+++ b/src/max_counter.sv
@@ -8,7 +8,7 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-// Up/down counter with maximum latch
+// Up/down counter that tracks its maximum value
 
 module max_counter #(
     parameter int unsigned WIDTH = 4
@@ -31,8 +31,8 @@ module max_counter #(
     logic overflow_max_d, overflow_max_q;
 
     delta_counter #(
-        .WIDTH          (WIDTH),
-        .LATCH_OVERFLOW (1'b1)
+        .WIDTH           (WIDTH),
+        .STICKY_OVERFLOW (1'b1)
     ) i_counter (
         .clk_i,
         .rst_ni,

--- a/src/max_counter.sv
+++ b/src/max_counter.sv
@@ -1,0 +1,77 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Up/down counter with maximum latch
+
+module max_counter #(
+    parameter int unsigned WIDTH = 4
+)(
+    input  logic             clk_i,
+    input  logic             rst_ni,
+    input  logic             clear_i,       // synchronous clear for counter
+    input  logic             clear_max_i,   // synchronous clear for maximum value
+    input  logic             en_i,          // enable the counter
+    input  logic             load_i,        // load a new value
+    input  logic             down_i,        // downcount, default is up
+    input  logic [WIDTH-1:0] delta_i,       // counter delta
+    input  logic [WIDTH-1:0] d_i,
+    output logic [WIDTH-1:0] q_o,
+    output logic [WIDTH-1:0] max_o,
+    output logic             overflow_o,
+    output logic             overflow_max_o
+);
+    logic [WIDTH-1:0] max_d, max_q;
+    logic overflow_max_d, overflow_max_q;
+
+    delta_counter #(
+        .WIDTH          (WIDTH),
+        .LATCH_OVERFLOW (1'b1)
+    ) i_counter (
+        .clk_i,
+        .rst_ni,
+        .clear_i,
+        .en_i,
+        .load_i,
+        .down_i,
+        .delta_i,
+        .d_i,
+        .q_o,
+        .overflow_o
+    );
+
+    always_comb begin
+        max_d = max_q;
+        max_o = max_q;
+        overflow_max_d = overflow_max_q;
+        if (clear_max_i) begin
+            max_d = '0;
+            overflow_max_d = 1'b0;
+        end else if (q_o > max_q) begin
+            max_d = q_o;
+            max_o = q_o;
+            if (overflow_o) begin
+                overflow_max_d = 1'b1;
+            end
+        end
+    end
+
+    assign overflow_max_o = overflow_max_q;
+
+    always_ff @(posedge clk_i, negedge rst_ni) begin
+        if (!rst_ni) begin
+           max_q <= '0;
+           overflow_max_q <= 1'b0;
+        end else begin
+           max_q <= max_d;
+           overflow_max_q <= overflow_max_d;
+        end
+    end
+
+endmodule

--- a/src/max_counter.sv
+++ b/src/max_counter.sv
@@ -12,7 +12,7 @@
 
 module max_counter #(
     parameter int unsigned WIDTH = 4
-)(
+) (
     input  logic             clk_i,
     input  logic             rst_ni,
     input  logic             clear_i,       // synchronous clear for counter

--- a/src_files.yml
+++ b/src_files.yml
@@ -30,6 +30,7 @@ common_cells_all:
     - src/counter.sv
     - src/edge_detect.sv
     - src/id_queue.sv
+    - src/max_counter.sv
     - src/rstgen.sv
     - src/stream_delay.sv
     # Level 2

--- a/src_files.yml
+++ b/src_files.yml
@@ -6,7 +6,7 @@ common_cells_all:
     # Level 0
     - src/cdc_2phase.sv
     - src/clk_div.sv
-    - src/counter.sv
+    - src/delta_counter.sv
     - src/edge_propagator_tx.sv
     - src/fifo_v3.sv
     - src/lfsr_8bit.sv
@@ -27,6 +27,7 @@ common_cells_all:
     - src/sync.sv
     - src/sync_wedge.sv
     # Level 1
+    - src/counter.sv
     - src/edge_detect.sv
     - src/id_queue.sv
     - src/rstgen.sv


### PR DESCRIPTION
I propose to extend the counter in this repository by three features:
- Latch overflows if the `LATCH_OVERFLOW` parameter is set.
- A variable counter step / delta, implemented as `delta_counter` (`counter` now just instantiates a `delta_counter` with a hardwired delta of `1`). I created a new module to not break the existing `counter`.
- A counter that latches the maximum value, implemented as `max_counter`.