### PR TITLE
:space_invader: Fix "cast to constant" in LZC

### DIFF
--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -87,7 +87,7 @@ module lzc #(
     end
   end
 
-  assign cnt_o   = NUM_LEVELS > unsigned'(0) ? index_nodes[0] : $clog2(WIDTH)'(0);
+  assign cnt_o   = NUM_LEVELS > unsigned'(0) ? index_nodes[0] : {($clog2(WIDTH)){1'b0}};
   assign empty_o = NUM_LEVELS > unsigned'(0) ? ~sel_nodes[0]  : ~(|in_i);
 
 endmodule : lzc


### PR DESCRIPTION
The cast `$clog2(WIDTH)'(0)` causes errors in older synthesis tools, and is probably not what was intended here. The code casts the integer value 0 to a constant function call, which seems to work properly only with the `$bits()` function across tools (if at all).

I believe the goal was to be explicit about the width of the signal, which would require the replication operator, as suggested in the commit, i.e. `{($clog2(WIDTH)){1'b0}}`
Just putting a literal `0` there should also work I think, as this is cast to the proper width implicitly. I am aware that the cast was put in place initially because of linter warnings, but the initial code contained an assignment to `'0` which is different from the integer literal `0`, so maybe try that first to reduce the code clutter.