### PR TITLE
fix altera quartus compile error

### DIFF
--- a/src/stream_demux.sv
+++ b/src/stream_demux.sv
@@ -17,7 +17,7 @@
 module stream_demux #(
   parameter integer N_OUP = 1,
   /// Dependent parameters, DO NOT OVERRIDE!
-  localparam integer LOG_N_OUP = $clog2(N_OUP)
+  parameter integer LOG_N_OUP = $clog2(N_OUP)
 ) (
   input  logic                  inp_valid_i,
   output logic                  inp_ready_o,

--- a/src/stream_mux.sv
+++ b/src/stream_mux.sv
@@ -15,7 +15,7 @@ module stream_mux #(
   parameter type DATA_T = logic,  // Vivado requires a default value for type parameters.
   parameter integer N_INP = 0,    // Synopsys DC requires a default value for value parameters.
   /// Dependent parameters, DO NOT OVERRIDE!
-  localparam integer LOG_N_INP = $clog2(N_INP)
+  parameter integer LOG_N_INP = $clog2(N_INP)
 ) (
   input  DATA_T [N_INP-1:0]     inp_data_i,
   input  logic  [N_INP-1:0]     inp_valid_i,


### PR DESCRIPTION
Change localparam to parameter to fix quartus compile error. This error also has been discussed in https://stackoverflow.com/questions/29717467/modelsim-wrong-scope-for-localparam 