### PR TITLE
[onehot-to-bin] Fix immediate assertion

### DIFF
--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -31,9 +31,7 @@ module onehot_to_bin #(
 
 // pragma translate_off
 `ifndef VERILATOR
-    initial begin
-        assert($onehot0(onehot)) else $fatal(1, "[onehot_to_bin] More than two bit set in the one-hot signal");
-    end
+    assert final ($onehot0(onehot)) else $fatal(1, "[onehot_to_bin] More than two bit set in the one-hot signal");
 `endif
 // pragma translate_on
 endmodule


### PR DESCRIPTION
The immediate assertion in `onehot_to_bin.sv` was inside an initial block, and was only checked at the beginning of the simulation.

Because the module has no clock, I added the "final" attribute to postpone the evaluation of the assertion until the signals settle. I checked it with ModelSim 10.6, but previous versions of the simulator might have issues with final deferred assertions.