### PR TITLE
Add formal verification properties for some IPs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 /Bender.local
 build
 formal/fifo_v3
+formal/counter
+formal/fall_through_register
 *.check

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /Bender.lock
 /Bender.local
 build
+formal/fifo_v3
+*.check

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -1,0 +1,26 @@
+# Copyright (c) 2019 ETH Zurich, University of Bologna
+#
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 0.51 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# Author: Robert Balas <balasr@iis.ee.ethz.ch>
+
+YOSYS	?= yosys
+SBY	?= sby
+RM	?= rm
+
+all: fifo_v3.check
+
+fifo_v3.check: fifo_v3.sby ../src/fifo_v3.sv fifo_v3_properties.sv
+	$(SBY) -f $<
+	touch $@
+
+.PHONY: clean
+clean:
+	$(RM) -r fifo_v3.check fifo_v3/

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -15,12 +15,23 @@ YOSYS	?= yosys
 SBY	?= sby
 RM	?= rm
 
-all: fifo_v3.check
+all: fifo_v3.check counter.check
 
 fifo_v3.check: fifo_v3.sby ../src/fifo_v3.sv fifo_v3_properties.sv
 	$(SBY) -f $<
 	touch $@
 
+# delta_counter.check: delta_counter.sby ../src/delta_counter.sv delta_counter_properties.sv
+# 	$(SBY) -f $<
+# 	touch $@
+
+counter.check: counter.sby ../src/counter.sv counter_properties.sv
+	$(SBY) -f $<
+	touch $@
+
+
 .PHONY: clean
 clean:
 	$(RM) -r fifo_v3.check fifo_v3/
+#	$(RM) -r delta_counter.check delta_counter/
+	$(RM) -r counter.check counter/

--- a/formal/Makefile
+++ b/formal/Makefile
@@ -15,23 +15,28 @@ YOSYS	?= yosys
 SBY	?= sby
 RM	?= rm
 
-all: fifo_v3.check counter.check
+all: fifo_v3.check counter.check fall_through_register.check
 
 fifo_v3.check: fifo_v3.sby ../src/fifo_v3.sv fifo_v3_properties.sv
 	$(SBY) -f $<
 	touch $@
 
 # delta_counter.check: delta_counter.sby ../src/delta_counter.sv delta_counter_properties.sv
-# 	$(SBY) -f $<
-# 	touch $@
+#	$(SBY) -f $<
+#	touch $@
 
-counter.check: counter.sby ../src/counter.sv counter_properties.sv
+counter.check: counter.sby ../src/counter.sv ../src/delta_counter.sv counter_properties.sv
 	$(SBY) -f $<
 	touch $@
 
+fall_through_register.check: fall_through_register.sby ../src/fall_through_register.sv \
+				../src/fifo_v3.sv ../src/deprecated/fifo_v2.sv
+	$(SBY) -f $<
+	touch $@
 
 .PHONY: clean
 clean:
 	$(RM) -r fifo_v3.check fifo_v3/
 #	$(RM) -r delta_counter.check delta_counter/
 	$(RM) -r counter.check counter/
+	$(RM) -r fall_through_register.check fall_through_register/

--- a/formal/README.md
+++ b/formal/README.md
@@ -1,0 +1,15 @@
+# Formal Verification Properties
+These formal properties (`*_properties.sv`) and scripts (`*.sby`) are used for
+formal verification of `common_cells` IPs and are meant to be used with
+`SymbiYosys`.
+
+## Note on Tools
+Make sure you have the commercial `Yosys` and `SymbiYosys`version installed and
+in your path or point the `YOSYS` and `SBY` variable to it. We have tested it
+with the Symbiotic EDA Edition [20190105A]. Note that the FOSS version won't
+work because its SystemVerilog parser does not support all the required
+features.
+
+## Usage
+Call `make all` to run all tests.
+

--- a/formal/counter.sby
+++ b/formal/counter.sby
@@ -1,0 +1,17 @@
+[options]
+mode prove
+depth 100
+
+[engines]
+smtbmc
+
+[script]
+read -formal delta_counter.sv
+read -formal counter.sv
+read -formal counter_properties.sv
+prep -top counter
+
+[files]
+counter_properties.sv
+../src/counter.sv
+../src/delta_counter.sv

--- a/formal/counter_properties.sv
+++ b/formal/counter_properties.sv
@@ -1,0 +1,98 @@
+// Copyright 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Robert Balas <balasr@iis.ee.ethz.ch>
+
+module counter_properties #(
+    parameter int unsigned WIDTH = 4,
+    parameter bit STICKY_OVERFLOW = 1'b0
+)(
+    input logic             clk_i,
+    input logic             rst_ni,
+    input logic             clear_i, // synchronous clear
+    input logic             en_i, // enable the counter
+    input logic             load_i, // load a new value
+    input logic             down_i, // downcount, default is up
+    input logic [WIDTH-1:0] d_i,
+    input logic [WIDTH-1:0] q_o,
+    input logic             overflow_o
+);
+
+    logic resetting;
+    logic count_up;
+    logic count_down;
+
+    // very first clock indicator
+    logic init = 1'b0;
+    always_ff @(posedge clk_i) init <= 1'b1;
+
+    // make sure that we touch the reset but otherwise we don't constrain it in
+    // any way
+    assume property (@(posedge clk_i) (!init) |-> !rst_ni);
+
+    // if we are not regulary using the counter
+    assign resetting = (clear_i || load_i);
+
+    // direction
+    assign count_up = en_i && !down_i;
+    assign count_down = en_i && down_i;
+
+    // test if we can count up
+    assert property (@(posedge clk_i)
+        disable iff (!rst_ni)
+        (count_up && !resetting) |=> q_o == $past(q_o) + {{WIDTH-1{1'b0}}, 1'b1});
+
+    // and count down
+    assert property (@(posedge clk_i)
+        disable iff (!rst_ni)
+        (count_down && !resetting) |=> q_o == $past(q_o) - {{WIDTH-1{1'b0}}, 1'b1});
+
+    // can we clear the counter synchronously
+    assert property (@(posedge clk_i)
+        disable iff (!rst_ni)
+        clear_i |=> q_o == '0);
+
+    // does loading work, considering that clearing has priority
+    assert property (@(posedge clk_i)
+        disable iff (!rst_ni)
+        (load_i && !clear_i) |=> q_o == $past(d_i));
+
+    // do we set overflow flags correctly
+    // if we count up and overflow do we set it?
+    assert property (@(posedge clk_i)
+        disable iff (!rst_ni)
+        (($past(q_o) > q_o) && $past(count_up) && $past(!resetting) && $past(!overflow_o))
+        |-> (overflow_o));
+    assert property (@(posedge clk_i)
+        disable iff (!rst_ni)
+        (($past(q_o) < q_o) && $past(count_down) && $past(!resetting) && $past(!overflow_o))
+        |-> (overflow_o));
+
+    // in sticky mode the overflow flag can only be cleared with a clear or load
+    if (STICKY_OVERFLOW == 1'b1) begin
+        assert property(@(posedge clk_i)
+            disable iff (!rst_ni)
+            (overflow_o && !resetting |=> overflow_o));
+    end
+
+    // cover sequence should touch interesting cases
+    cover property (@(posedge clk_i)
+        overflow_o == 1'b1);
+    cover property (@(posedge clk_i)
+        clear_i == 1'b1);
+    cover property (@(posedge clk_i)
+        load_i == 1'b1);
+
+endmodule // counter_properties
+
+// propagate parameters from counter to properties
+bind counter counter_properties #(
+    .WIDTH(WIDTH), .STICKY_OVERFLOW(STICKY_OVERFLOW)
+) i_counter_properties(.*);

--- a/formal/fall_through_register.sby
+++ b/formal/fall_through_register.sby
@@ -1,0 +1,19 @@
+[options]
+mode bmc
+depth 100
+
+[engines]
+smtbmc
+
+[script]
+read -formal fifo_v3.sv
+read -formal fifo_v2.sv
+read -formal fall_through_register.sv
+read -formal fall_through_register_properties.sv
+prep -top fall_through_register
+
+[files]
+fall_through_register_properties.sv
+../src/fall_through_register.sv
+../src/fifo_v3.sv
+../src/deprecated/fifo_v2.sv

--- a/formal/fall_through_register_properties.sv
+++ b/formal/fall_through_register_properties.sv
@@ -1,0 +1,86 @@
+// Copyright 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Robert Balas <balasr@iis.ee.ethz.ch>
+
+module fall_through_register_properties #(
+    parameter type T = logic  // Vivado requires a default value for type parameters.
+)(
+    input  logic    clk_i,          // Clock
+    input  logic    rst_ni,         // Asynchronous active-low reset
+    input  logic    clr_i,          // Synchronous clear
+    input  logic    testmode_i,     // Test mode to bypass clock gating
+    // Input port
+    input  logic    valid_i,
+    input  logic    ready_o,
+    input  T        data_i,
+    // Output port
+    input  logic    valid_o,
+    input  logic    ready_i,
+    input  T        data_o
+);
+    int    stalls = 0;
+    // very first clock indicator
+    logic init = 1'b0;
+    always_ff @(posedge clk_i) init <= 1'b1;
+
+    // make sure that we touch the reset but otherwise we don't constrain it in
+    // any way
+    assume property (@(posedge clk_i) (!init) |-> !rst_ni);
+
+    // TODO: relax this constraint
+    assume property (@(posedge clk_i) clr_i == 1'b0);
+
+    // assume valid/ready handshake as input
+    assume property (@(posedge clk_i)
+        disable iff (!rst_ni)
+        (valid_i && !ready_o |=> valid_i && $stable(data_i))); // data stability
+
+    // assert valid/ready handshake at output
+    assert property (@(posedge clk_i)
+        disable iff (!rst_ni)
+        (valid_o && !ready_i |=> valid_o && $stable(data_o))); // data stability
+
+    // test combinatorial forwarding
+    assert property (@(posedge clk_i)
+        disable iff (!rst_ni)
+        ((valid_i && ready_o) && ready_i |-> valid_o && (data_i == data_o)));
+
+    // count stalls
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        // reset stall on rst, no transaction happening or transaction accepted
+        if (!rst_ni || !valid_i || ready_o) begin
+            stalls <= 0;
+        end else if (valid_i && !ready_o) begin
+            stalls <= stalls + 1;
+        end
+    end
+    // we want the input to appear at the output at within 2 cycles
+    // TODO: for that we would have to constrain ready_i too, does that even make sense?
+    // assert property(@(posedge clk_i)
+    //     disable iff (!rst_ni) (stalls < 4));
+
+    // we want to make sure we can handle transactions
+    cover property (@(posedge clk_i)
+        (valid_i && ready_o));
+    cover property (@(posedge clk_i)
+        (valid_o && ready_i));
+    // stall for a bit
+    cover property (@(posedge clk_i)
+        !ready_i ##5 ready_i);
+    cover property (@(posedge clk_i)
+        stalls > 10);
+
+endmodule // counter_properties
+
+// propagate parameters from counter to properties
+bind fall_through_register fall_through_register_properties #(
+    .T(T)
+) i_fall_through_register_properties(.*);

--- a/formal/fifo_v3.sby
+++ b/formal/fifo_v3.sby
@@ -1,0 +1,15 @@
+[options]
+mode prove
+depth 100
+
+[engines]
+smtbmc
+
+[script]
+read -formal fifo_v3.sv
+read -formal fifo_v3_properties.sv
+prep -top fifo_v3
+
+[files]
+fifo_v3_properties.sv
+../src/fifo_v3.sv

--- a/formal/fifo_v3_properties.sv
+++ b/formal/fifo_v3_properties.sv
@@ -1,0 +1,136 @@
+// Copyright 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Robert Balas <balasr@iis.ee.ethz.ch>
+
+module fifo_v3_properties #(
+    parameter bit          FALL_THROUGH = 1'b0, // fifo is in fall-through mode
+    parameter int unsigned DATA_WIDTH   = 32,   // default data width if the fifo is of type logic
+    parameter int unsigned DEPTH        = 8,    // depth can be arbitrary from 0 to 2**32
+    parameter type dtype                = logic [DATA_WIDTH-1:0],
+    // DO NOT OVERWRITE THIS PARAMETER
+    parameter int unsigned ADDR_DEPTH   = (DEPTH > 1) ? $clog2(DEPTH) : 1
+) (
+    input logic                    clk_i, // Clock
+    input logic                    rst_ni, // Asynchronous reset active low
+    input logic                    flush_i, // flush the queue
+    input logic                    testmode_i, // test_mode to bypass clock gating
+    // status flags
+    input logic                    full_o, // queue is full
+    input logic                    empty_o, // queue is empty
+    input logic [ADDR_DEPTH-1:0]   usage_o, // fill pointer
+    // as long as the queue is not full we can push new data
+    input logic                    push_i, // data is valid and can be pushed to the queue
+    // as long as the queue is not empty we can pop new elements
+    input logic                    pop_i, // pop head from queue
+
+    input logic [ADDR_DEPTH - 1:0] read_pointer_n,
+    input logic [ADDR_DEPTH - 1:0] read_pointer_q,
+    input logic [ADDR_DEPTH - 1:0] write_pointer_n,
+    input logic [ADDR_DEPTH - 1:0] write_pointer_q,
+
+    input logic [ADDR_DEPTH:0]     status_cnt_n, // counter to keep track of the current queue status
+    input logic [ADDR_DEPTH:0]     status_cnt_q
+);
+
+    localparam int unsigned FIFO_DEPTH = (DEPTH > 0) ? DEPTH : 1;
+    // verbatim from fifo_v3
+    localparam int unsigned FIFO_SIZE  = FIFO_DEPTH[ADDR_DEPTH:0];
+
+    logic [ADDR_DEPTH-1:0] fill_level;
+    logic                  read_incr;
+    logic                  write_incr;
+    int                    writes = 0; // number of writes to fifo
+    int                    reads  = 0; // number of reads from fifo
+
+    // We use this as a workaround to trigger and initial event at the beginning
+    // of the simulation. I can't think of a better way with the subset of sv
+    // yosys supports.
+    logic init = 1'b0;
+    always_ff @(posedge clk_i) init <= 1'b1;
+
+    // make sure that we touch the reset but otherwise we don't constrain it in
+    // any way
+    assume property (@(posedge clk_i) (!init) |-> !rst_ni);
+
+    // we don't have tests for FALL_THROUGH mode
+    always_comb assert (FALL_THROUGH == 1'b0);
+
+    // assume we are good boys and dont try to mess with the queue
+    // It doesn't look like we need these assumptions
+    // assume property(@(posedge clk_i)
+    //     disable iff (!rst_ni) (full_o |-> !push_i));
+
+    // assume property(@(posedge clk_i)
+    //     disable iff (!rst_ni) (empty_o |-> !pop_i));
+
+
+    assign fill_level = writes - reads;
+    assign read_incr = read_pointer_n - read_pointer_q;
+    assign write_incr = write_pointer_n - write_pointer_q;
+
+    // writes and reads track the number of writes and reads to the fifo. Our
+    // assumption and assertions make sure that these values stay logically
+    // consistent.
+    always_ff @(posedge clk_i, negedge rst_ni) begin
+        if (!rst_ni) begin
+            writes <= 0;
+            reads  <= 0;
+        end else begin
+            if (flush_i) begin
+                writes <= 0;
+                reads  <= 0;
+            end else begin
+                writes <= writes + write_incr;
+                reads  <= reads + read_incr;
+            end
+        end
+    end
+
+    // assume that we test for a finite amount of transactions otherwise the
+    // solver tries to be cute by overflowing the writes and reads variables
+    assume property (@(posedge clk_i)
+        (reads < 1024 && writes < 1024));
+    // start induction with correct internal fill level
+    assume property (@(posedge clk_i)
+        ((writes - reads) == status_cnt_q));
+
+    // don't underflow
+    assert property (@(posedge clk_i)
+        (writes >= reads));
+    // don't overflow
+    assert property (@(posedge clk_i)
+        ((writes - reads) <= FIFO_SIZE));
+
+    // do we set fill indicators properly
+    assert property (@(posedge clk_i)
+        ((writes == reads) |-> empty_o));
+    assert property (@(posedge clk_i)
+        (((writes - reads) == FIFO_SIZE) |-> full_o));
+    // check if we compute fill level correctly
+    assert property (@(posedge clk_i)
+        disable iff (!rst_ni) (fill_level == usage_o));
+
+    // sanity of internal vars
+    assert property (@(posedge clk_i)
+        status_cnt_q <= FIFO_SIZE);
+
+    // make sure we hit the interesting cases
+    cover property (@(posedge clk_i)
+        full_o == 1'b1);
+    cover property (@(posedge clk_i)
+        empty_o == 1'b1);
+
+endmodule // fifo_v3_properties
+
+// propagate parameters from fifo_v3 to properties
+bind fifo_v3 fifo_v3_properties #(
+    .FALL_THROUGH(FALL_THROUGH), .DATA_WIDTH(DATA_WIDTH), .DEPTH(DEPTH)
+) i_fifo_v3_properties(.*);


### PR DESCRIPTION
Leverage `Yosys` and `SymbiYosys` (commercial version with the verific
parser) to formally proof properties of `fifo_v3`. We don't touch the IPs themselves by using SystemVerilog's `bind`.