### PR TITLE
test: Update to `bender script`

### DIFF
--- a/test/simulate.sh
+++ b/test/simulate.sh
@@ -12,12 +12,14 @@
 
 set -e
 
-bender vsim -t test
-
 [ ! -z "$VSIM" ] || VSIM=vsim
 
+bender script vsim -t test > compile.tcl
+
+"$VSIM" -c -do 'source compile.tcl; quit'
+
 call_vsim() {
-	echo "run -all" | $VSIM "$@" | tee vsim.log 2>&1
+	echo "run -all" | "$VSIM" "$@" | tee vsim.log 2>&1
 	grep "Errors: 0," vsim.log
 }
 

--- a/test/synth.sh
+++ b/test/synth.sh
@@ -15,7 +15,7 @@ set -e
 [ ! -z "$SYNOPSYS_DC" ] || SYNOPSYS_DC="synopsys dc_shell -64"
 
 echo 'remove_design -all' > ./synth.tcl
-bender synopsys -t synth_test >> ./synth.tcl
+bender script synopsys -t synth_test >> ./synth.tcl
 echo 'elaborate synth_bench' >> ./synth.tcl
 
 cat ./synth.tcl | $SYNOPSYS_DC | tee synth.log 2>&1


### PR DESCRIPTION
`bender vsim` is not supported on the latest bender [release](https://github.com/fabianschuiki/bender/releases/tag/v0.13.3) anymore. Use `bender script vsim` instead.