### PR TITLE
Substitution Permutation Hash Function and Counting Bloom Filter

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -43,9 +43,11 @@ sources:
   - src/stream_filter.sv
   - src/stream_fork.sv
   - src/stream_mux.sv
+  - src/sub_per_hash.sv
   - src/sync.sv
   - src/sync_wedge.sv
   # Level 1
+  - src/cb_filter.sv
   - src/cdc_fifo_2phase.sv
   - src/cdc_fifo_gray.sv
   - src/counter.sv
@@ -67,6 +69,7 @@ sources:
 
   - target: test
     files:
+      - test/cb_filter_tb.sv
       - test/cdc_2phase_tb.sv
       - test/cdc_fifo_tb.sv
       - test/fifo_tb.sv
@@ -74,6 +77,7 @@ sources:
       - test/id_queue_tb.sv
       - test/popcount_tb.sv
       - test/stream_register_tb.sv
+      - test/sub_per_hash_tb.sv
 
   - target: synth_test
     files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added spubstitution-permutation hash function module
 - Added couning-bloom-filter module
-
-### Added
 - `spill_register`: Added Bypass parameter
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Added
+- Added spubstitution-permutation hash function module
+- Added couning-bloom-filter module
+
+### Added
+- `spill_register`: Added Bypass parameter
+
+### Added
 - `counter`: Added sticky overflow
 - Added counter with variable delta
 - Added counter that tracks its maximum value

--- a/README.md
+++ b/README.md
@@ -72,12 +72,14 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `stream_fork`                | Ready/valid fork                                                               | active         |               |
 | `stream_filter`              | Ready/valid filter                                                             | active         |               |
 | `stream_delay`               | Randomize or delay ready/valid interface                                       | active         |               |
+| `sub_per_hash`               | Substitution-permutation hash function                                         | active         |               |
 | `popcount`                   | Combinatorial popcount (hamming weight)                                        | active         |               |
 
 ### Data Structures
 
 | Name                 | Description                                     | Status         | Superseded By |
 | :------------------- | :---------------------------------------------- | :------------- | :------------ |
+| `cb_filter`          | Counting-Bloom-Filter with combinational lookup | active         |               |
 | `fifo`               | FIFO register with upper threshold              | *deprecated*   | `fifo_v3`     |
 | `fifo_v2`            | FIFO register with upper and lower threshold    | *deprecated*   | `fifo_v3`     |
 | `fifo_v3`            | FIFO register with generic fill counts          | active         |               |

--- a/src/cb_filter.sv
+++ b/src/cb_filter.sv
@@ -1,0 +1,260 @@
+// Copyright (c) 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+// CB FILTER: This module implements a counting bloom filter with parameterizable hash functions.
+// Functionality: A counting bloom filter is a data structure to efficiently implement
+//                set lookups. It does so by hashing its data inputs onto multiple pointers
+//                which serve as indicators for an array of buckets. For lookups can be
+//                false positives, but no false negatives.
+// - Seeding:     The pseudo random generators need seeds at elaboration time to generate
+//                different hashes. In principle any combination of seeds can be used.
+//                But one should look that the hash outputs give sufficient different patterns,
+//                such that the resulting collision rate is low.
+// - Lookup:
+//   - Ports:       `look_data_i`, `look_valid_o`
+//   - Description: Lookup combinational, `look_valid_o` is high, when `look_data_i` was
+//                  previously put into the filter.
+// - Increment:
+//   - Ports:       `incr_data_i`, `incr_valid_i`
+//   - Description: Put data into the counting bloom filter, when valid is high.
+// - Decrement:
+//   - Ports:       `decr_data_i`, `decr_valid_i`
+//   - Description: Remove data from the counting bloom filter. Only remove data that was
+//                  previously put in, otherwise will go in a wrong state.
+// - Status:
+//   - `filter_clear_i`:  Clears the filter and sets all counters to 0.
+//   - `filter_ussage_o`: How many data items are currently in the filter.
+//   - `filter_full_o`:   Filter is full, can no longer hold more items.
+//   - `filter_empty_o`:  Filter is empty.
+//   - `filter_error_o`:  One of the internal counters or buckets overflowed.
+
+// package with the struct definition for the seeds and an example
+package cb_filter_pkg;
+  typedef struct packed {
+    int unsigned PermuteSeed;
+    int unsigned XorSeed;
+  } cb_seed_t;
+
+  // example seeding struct
+  localparam cb_seed_t [2:0] EgSeeds = '{
+    '{PermuteSeed: 32'd299034753, XorSeed: 32'd4094834  },
+    '{PermuteSeed: 32'd19921030,  XorSeed: 32'd995713   },
+    '{PermuteSeed: 32'd294388,    XorSeed: 32'd65146511 }
+  };
+endpackage
+
+// This is a counting bloom filter
+module cb_filter #(
+  parameter int unsigned KHashes     =  32'd3,  // Number of hash functions
+  parameter int unsigned HashWidth   =  32'd4,  // Number of counters is 2**HashWidth
+  parameter int unsigned HashRounds  =  32'd1,  // Number of permutation substitution rounds
+  parameter int unsigned InpWidth    =  32'd32, // Input data width
+  parameter int unsigned BucketWidth =  32'd4,  // Width of Bucket counters
+  parameter cb_filter_pkg::cb_seed_t [KHashes-1:0] Seeds = cb_filter_pkg::EgSeeds
+) (
+  input  logic                 clk_i,   // Clock
+  input  logic                 rst_ni,  // Active low reset
+  // data lookup
+  input  logic [InpWidth-1:0]  look_data_i,
+  output logic                 look_valid_o,
+  // data increment
+  input  logic [InpWidth-1:0]  incr_data_i,
+  input  logic                 incr_valid_i,
+  // data decrement
+  input  logic [InpWidth-1:0]  decr_data_i,
+  input  logic                 decr_valid_i,
+  // status signals
+  input  logic                 filter_clear_i,
+  output logic [HashWidth-1:0] filter_usage_o,
+  output logic                 filter_full_o,
+  output logic                 filter_empty_o,
+  output logic                 filter_error_o
+);
+
+  localparam int unsigned NoCounters  = 2**HashWidth;
+
+  // signal declarations
+  logic [NoCounters-1:0] look_ind; // hash function pointers
+  logic [NoCounters-1:0] incr_ind; // hash function pointers
+  logic [NoCounters-1:0] decr_ind; // hash function pointers
+  // bucket (counter signals)
+  logic [NoCounters-1:0] bucket_en;
+  logic [NoCounters-1:0] bucket_down;
+  logic [NoCounters-1:0] bucket_occupied;
+  logic [NoCounters-1:0] bucket_overflow;
+  logic [NoCounters-1:0] bucket_full;
+  logic [NoCounters-1:0] bucket_empty;
+  // membership lookup signals
+  logic [NoCounters-1:0] data_in_bucket;
+  // tot count signals (filter usage)
+  logic cnt_en;
+  logic cnt_down;
+  logic cnt_overflow;
+
+  // -----------------------------------------
+  // Lookup Hash - Membership Detection
+  // -----------------------------------------
+  hash_block #(
+    .NoHashes     ( KHashes      ),
+    .InpWidth     ( InpWidth     ),
+    .HashWidth    ( HashWidth    ),
+    .NoRounds     ( HashRounds   ),
+    .Seeds        ( Seeds        )
+  ) i_look_hashes (
+    .data_i       ( look_data_i  ),
+    .indicator_o  ( look_ind     )
+  );
+  assign data_in_bucket = look_ind & bucket_occupied;
+  assign look_valid_o   = (data_in_bucket == look_ind) ? 1'b1 : 1'b0;
+
+  // -----------------------------------------
+  // Increment Hash - Add Member to Set
+  // -----------------------------------------
+  hash_block #(
+    .NoHashes     ( KHashes      ),
+    .InpWidth     ( InpWidth     ),
+    .HashWidth    ( HashWidth    ),
+    .NoRounds     ( HashRounds   ),
+    .Seeds        ( Seeds        )
+  ) i_incr_hashes (
+    .data_i       ( incr_data_i  ),
+    .indicator_o  ( incr_ind     )
+  );
+
+  // -----------------------------------------
+  // Decrement Hash - Remove Member from Set
+  // -----------------------------------------
+  hash_block #(
+    .NoHashes     ( KHashes      ),
+    .InpWidth     ( InpWidth     ),
+    .HashWidth    ( HashWidth    ),
+    .NoRounds     ( HashRounds   ),
+    .Seeds        ( Seeds        )
+  ) i_decr_hashes (
+    .data_i       ( decr_data_i  ),
+    .indicator_o  ( decr_ind     )
+  );
+
+  // -----------------------------------------
+  // Control the incr/decr of buckets
+  // -----------------------------------------
+  always_comb begin : proc_bucket_control
+    // default assignments
+    if(decr_valid_i) begin
+      bucket_down = decr_ind;
+    end else begin
+      bucket_down = '0;
+    end
+    // control
+    case ({incr_valid_i, decr_valid_i})
+      2'b00 : bucket_en = '0;
+      2'b10 : bucket_en = incr_ind;
+      2'b01 : bucket_en = decr_ind;
+      2'b11 : bucket_en = incr_ind ^ decr_ind;
+    endcase
+  end
+
+  // -----------------------------------------
+  // Counters
+  // -----------------------------------------
+  for (genvar i = 0; i < NoCounters; i++) begin : gen_buckets
+    logic [BucketWidth-1:0] bucket_content;
+    counter #(
+      .WIDTH( BucketWidth )
+    ) i_bucket (
+      .clk_i      ( clk_i             ),
+      .rst_ni     ( rst_ni            ),
+      .clear_i    ( filter_clear_i    ),
+      .en_i       ( bucket_en[i]      ),
+      .load_i     ( '0                ),
+      .down_i     ( bucket_down[i]    ),
+      .d_i        ( '0                ),
+      .q_o        ( bucket_content    ),
+      .overflow_o ( bucket_overflow[i])
+    );
+    assign bucket_full[i]     =  bucket_overflow[i] | (&bucket_content);
+    assign bucket_occupied[i] = |bucket_content;
+    assign bucket_empty[i]    = ~bucket_occupied[i];
+  end
+
+  // -----------------------------------------
+  // Filter tot item counter
+  // -----------------------------------------
+  assign cnt_en   = incr_valid_i ^ decr_valid_i;
+  assign cnt_down = decr_valid_i;
+  counter #(
+    .WIDTH ( HashWidth )
+  ) i_tot_count (
+    .clk_i     ( clk_i          ),
+    .rst_ni    ( rst_ni         ),
+    .clear_i   ( filter_clear_i ),
+    .en_i      ( cnt_en         ),
+    .load_i    ( '0             ),
+    .down_i    ( cnt_down       ),
+    .d_i       ( '0             ),
+    .q_o       ( filter_usage_o ),
+    .overflow_o( cnt_overflow   )
+  );
+
+  // -----------------------------------------
+  // Filter Output Flags
+  // -----------------------------------------
+  assign filter_full_o  = |bucket_full;
+  assign filter_empty_o = &bucket_empty;
+  assign filter_error_o = |bucket_overflow | cnt_overflow;
+endmodule
+
+// gives out the or 'onehots' of all hash functions
+module hash_block #(
+  parameter int unsigned NoHashes                         = 32'd3,
+  parameter int unsigned InpWidth                         = 32'd11,
+  parameter int unsigned HashWidth                        = 32'd5,
+  parameter int unsigned NoRounds                         = 32'd1,
+  parameter cb_filter_pkg::cb_seed_t [NoHashes-1:0] Seeds = cb_filter_pkg::EgSeeds
+) (
+  input  logic [InpWidth-1:0]     data_i,
+  output logic [2**HashWidth-1:0] indicator_o
+);
+
+  logic [NoHashes-1:0][2**HashWidth-1:0] hashes;
+
+  for (genvar i = 0; i < NoHashes; i++) begin : gen_hashes
+    sub_per_hash #(
+      .InpWidth   ( InpWidth             ),
+      .HashWidth  ( HashWidth            ),
+      .NoRounds   ( NoRounds             ),
+      .PermuteKey ( Seeds[i].PermuteSeed ),
+      .XorKey     ( Seeds[i].XorSeed     )
+    ) i_hash (
+      .data_i        ( data_i    ),
+      .hash_o        (           ), // not used, because we want the onehot
+      .hash_onehot_o ( hashes[i] )
+    );
+  end
+
+  // output assignment
+  always_comb begin : proc_hash_or
+    indicator_o = '0;
+    for (int unsigned i = 0; i < (2**HashWidth); i++) begin
+      for (int unsigned j = 0; j < NoHashes; j++) begin
+        indicator_o[i] = indicator_o[i] | hashes[j][i];
+      end
+    end
+  end
+
+  // assertions
+  initial begin
+    hash_conf: assume (InpWidth > HashWidth) else
+      $fatal(1, "%m:\nA Hash Function reduces the width of the input>\nInpWidth: %s\nOUT_WIDTH: %s",
+          InpWidth, HashWidth);
+  end
+endmodule

--- a/src/sub_per_hash.sv
+++ b/src/sub_per_hash.sv
@@ -1,0 +1,157 @@
+// Copyright (c) 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+// SUB PER HASH: This module implements a fully parameterizable substitution-permutation hash
+//               function. From the seeds it computes a sequence of pseudo random numbers,
+//               which determine the permutations and substitutions. The pseudo random
+//               generator is a multiplicative linear congruential generator and uses different
+//               constants for its computations.
+//               The permutation is a variant of the Fisher-Yates shuffle algorithm.
+//               The substitution is the xor of 3 pseudo random inputs to the stage.
+
+module sub_per_hash #(
+  parameter int unsigned InpWidth   = 32'd11,
+  parameter int unsigned HashWidth  = 32'd5,
+  parameter int unsigned NoRounds   = 32'd1,
+  parameter int unsigned PermuteKey = 32'd299034753,
+  parameter int unsigned XorKey     = 32'd4094834
+) (
+  // is purely combinational
+  input  logic [InpWidth-1:0]     data_i,
+  output logic [HashWidth-1:0]    hash_o,
+  output logic [2**HashWidth-1:0] hash_onehot_o
+);
+
+  // typedefs and respective localparams
+  typedef int unsigned perm_lists_t [NoRounds][InpWidth];
+  localparam perm_lists_t PERMUTATIONS = get_permutations(PermuteKey);
+  // encoding for inner most array:
+  // position 0 indicates the number of inputs, 2 or 3
+  // the other positions 1 - 3 indicate the inputs
+  typedef int unsigned xor_stages_t [NoRounds][InpWidth][3];
+  localparam xor_stages_t XOR_STAGES = get_xor_stages(XorKey);
+
+  // stage signals
+  logic [NoRounds-1:0][InpWidth-1:0] permuted, xored;
+
+  // for each round
+  for (genvar r = 0; r < NoRounds; r++) begin
+    // for each bit
+    for (genvar i = 0; i < InpWidth ; i++) begin
+
+      // assign the permutation
+      if(r == 0) begin
+        assign permuted[r][i] = data_i[PERMUTATIONS[r][i]];
+      end else begin
+        assign permuted[r][i] = permuted[r-1][PERMUTATIONS[r][i]];
+      end
+
+      // assign the xor substitution
+      assign xored[r][i] = permuted[r][XOR_STAGES[r][i][0]] ^
+                           permuted[r][XOR_STAGES[r][i][1]] ^
+                           permuted[r][XOR_STAGES[r][i][2]];
+    end
+  end
+
+  // output assignment, take the bottom bits of the last round
+  assign hash_o = xored[NoRounds-1][HashWidth-1:0];
+  // for onehot run trough a decoder
+  assign hash_onehot_o = 1 << hash_o;
+
+  function automatic perm_lists_t get_permutations(input int unsigned seed);
+    // PRG is MLCG (multiplicative linear congruential generator)
+    // Constant values the same as RtlUniform from Native API
+    // X(n+1) = (a*X(n)+c) mod m
+    // a: large prime
+    // c: increment
+    // m: range
+    // Shuffling is a variation of the Fisher-Yates shuffle algorithm
+
+    perm_lists_t indices;
+    perm_lists_t perm_array;
+    longint unsigned A = 2147483629;
+    longint unsigned C = 2147483587;
+    longint unsigned M = 2**31 - 1;
+    longint unsigned index   = 0;
+    longint unsigned advance = 0;
+    longint unsigned rand_number = (A * seed + C) % M;
+
+    // do it for each round
+    for (int unsigned r = 0; r < NoRounds; r++) begin
+
+      // initialize the index array
+      for (int unsigned i = 0; i < InpWidth; i++) begin
+        indices[r][i] = i;
+      end
+      // do the shuffling
+      for (int unsigned i = 0; i < InpWidth; i++) begin
+        // get the 'random' number
+        if(i > 0) begin
+          rand_number = (A * rand_number + C) % M;
+          index = rand_number % i;
+        end
+        // do the shuffling
+        if(i != index) begin
+          perm_array[r][i]     = perm_array[r][index];
+          perm_array[r][index] = indices[r][i];
+        end
+      end
+      // advance the PRG a bit
+      rand_number = (A * rand_number + C) % M;
+      advance     = rand_number % NoRounds;
+      for (int unsigned i = 0; i < advance; i++) begin
+        rand_number = (A * rand_number + C) % M;
+      end
+    end
+    return perm_array;
+  endfunction : get_permutations
+
+  function automatic xor_stages_t get_xor_stages(input int unsigned seed);
+    // PRG is MLCG (multiplicative linear congruential generator)
+    // Constant values the same as Numerical Recipes
+    // X(n+1) = (a*X(n)+c) mod m
+    // a: large prime
+    // c: increment
+    // m: range
+    xor_stages_t xor_array;
+    longint unsigned A = 1664525;
+    longint unsigned C = 1013904223;
+    longint unsigned M = 2**32;
+    longint unsigned index   = 0;
+    // int unsigned even    = 0;
+    longint unsigned advance = 0;
+    longint unsigned rand_number = (A * seed + C) % M;
+
+    // fill the array with 'randon' inputs
+    // for each xor, a even random number is two input, uneven is tree
+    // for each round
+    for (int unsigned r = 0; r < NoRounds; r++) begin
+      // for each bit
+      for (int unsigned i = 0; i < InpWidth; i++) begin
+        rand_number = (A * rand_number + C) % M;
+        // even = rand_number[3];
+        for (int unsigned j = 0; j < 3; j++) begin
+          rand_number = (A * rand_number + C) % M;
+          index = rand_number % InpWidth;
+          xor_array[r][i][j] = index;
+        end
+      end
+      // advance the PRG a bit
+      rand_number = (A * rand_number + C) % M;
+      advance     = rand_number % NoRounds;
+      for (int unsigned i = 0; i < advance; i++) begin
+        rand_number = (A * rand_number + C) % M;
+      end
+    end
+    return xor_array;
+  endfunction : get_xor_stages
+endmodule

--- a/src/sub_per_hash.sv
+++ b/src/sub_per_hash.sv
@@ -10,13 +10,31 @@
 
 // Author: Wolfgang Roenninger <wroennin@ethz.ch>
 
-// SUB PER HASH: This module implements a fully parameterizable substitution-permutation hash
-//               function. From the seeds it computes a sequence of pseudo random numbers,
-//               which determine the permutations and substitutions. The pseudo random
-//               generator is a multiplicative linear congruential generator and uses different
-//               constants for its computations.
-//               The permutation is a variant of the Fisher-Yates shuffle algorithm.
-//               The substitution is the xor of 3 pseudo random inputs to the stage.
+// This module implements a fully parameterizable substitution-permutation hash
+// function. The hash is structured in stages consisting of a shuffle of the input bits
+// and then xoring for each bit 3 pseudo-random bits of the shuffeled vector.
+// The hash function is NOT cryptographically secure!
+// From the keys it computes a sequence of pseudo-random numbers, which determine the permutations
+// and substitutions. As pseudo random generator a multiplicative linear congruential
+// generator is used and uses different constants for the computation of the permutation
+// and substitution respectively.
+// The permutation shuffles the bits using a variant of the Fisher-Yates shuffle algorithm.
+// The substitution per stage is the xor of 3 pseudo random bits of the previous stage.
+// As shifting and xoring of a signal do not change its distribution, the distribution
+// of the output hash is the same as the one of the input data.
+//
+// Parameters:
+// - `InpWidth`:   The input width of the vector `data_i`.
+// - `HashWidth`:  The output width of the substitution-permutation hash.
+// - `NoRounds`:   The amount of permutation, substitution stages generated. Translates
+//                 into how many levels of xor's there will be before optimization.
+// - `PermuteKey`: The Key for the pseudo-random generator used for determining the exact
+//                 permutation (shuffled wiring between each xor stage) at compile/elaboration.
+//                 Any `int unsigned` value can be used as key, however one should examine the
+//                 output of the hash function.
+// - `XorKey`:     The Key for the pseudo-random generator used for determining the xor
+//                 of bits between stages. The same principles as for `PermuteKey` applies,
+//                 however one should look that both keys have a greatest common divisor of 1.
 
 module sub_per_hash #(
   parameter int unsigned InpWidth   = 32'd11,
@@ -67,15 +85,14 @@ module sub_per_hash #(
   // for onehot run trough a decoder
   assign hash_onehot_o = 1 << hash_o;
 
+  // PRG is MLCG (multiplicative linear congruential generator)
+  // Constant values the same as RtlUniform from Native API
+  // X(n+1) = (a*X(n)+c) mod m
+  // a: large prime
+  // c: increment
+  // m: range
+  // Shuffling is a variation of the Fisher-Yates shuffle algorithm
   function automatic perm_lists_t get_permutations(input int unsigned seed);
-    // PRG is MLCG (multiplicative linear congruential generator)
-    // Constant values the same as RtlUniform from Native API
-    // X(n+1) = (a*X(n)+c) mod m
-    // a: large prime
-    // c: increment
-    // m: range
-    // Shuffling is a variation of the Fisher-Yates shuffle algorithm
-
     perm_lists_t indices;
     perm_lists_t perm_array;
     longint unsigned A = 2147483629;
@@ -87,7 +104,6 @@ module sub_per_hash #(
 
     // do it for each round
     for (int unsigned r = 0; r < NoRounds; r++) begin
-
       // initialize the index array
       for (int unsigned i = 0; i < InpWidth; i++) begin
         indices[r][i] = i;
@@ -95,12 +111,12 @@ module sub_per_hash #(
       // do the shuffling
       for (int unsigned i = 0; i < InpWidth; i++) begin
         // get the 'random' number
-        if(i > 0) begin
+        if (i > 0) begin
           rand_number = (A * rand_number + C) % M;
           index = rand_number % i;
         end
         // do the shuffling
-        if(i != index) begin
+        if (i != index) begin
           perm_array[r][i]     = perm_array[r][index];
           perm_array[r][index] = indices[r][i];
         end
@@ -115,13 +131,13 @@ module sub_per_hash #(
     return perm_array;
   endfunction : get_permutations
 
+  // PRG is MLCG (multiplicative linear congruential generator)
+  // Constant values the same as Numerical Recipes
+  // X(n+1) = (a*X(n)+c) mod m
+  // a: large prime
+  // c: increment
+  // m: range
   function automatic xor_stages_t get_xor_stages(input int unsigned seed);
-    // PRG is MLCG (multiplicative linear congruential generator)
-    // Constant values the same as Numerical Recipes
-    // X(n+1) = (a*X(n)+c) mod m
-    // a: large prime
-    // c: increment
-    // m: range
     xor_stages_t xor_array;
     longint unsigned A = 1664525;
     longint unsigned C = 1013904223;

--- a/src/sub_per_hash.sv
+++ b/src/sub_per_hash.sv
@@ -62,9 +62,9 @@ module sub_per_hash #(
   logic [NoRounds-1:0][InpWidth-1:0] permuted, xored;
 
   // for each round
-  for (genvar r = 0; r < NoRounds; r++) begin
+  for (genvar r = 0; r < NoRounds; r++) begin : gen_round
     // for each bit
-    for (genvar i = 0; i < InpWidth ; i++) begin
+    for (genvar i = 0; i < InpWidth ; i++) begin : gen_sub_per
 
       // assign the permutation
       if(r == 0) begin

--- a/test/cb_filter_tb.sv
+++ b/test/cb_filter_tb.sv
@@ -1,0 +1,301 @@
+// Copyright (c) 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+// TB CBF: Test bench for the counting bloom filter
+//         Randomly puts in data items into the filter.
+//         Removes the put in items after some time.
+//         Random lookup in each cycle
+
+module cb_filter_tb;
+  // TB parameters
+  localparam time TCycle = 10ns;
+  localparam time TAppli =  2ns;
+  localparam time TTest  =  8ns;
+  localparam int unsigned RunCycles  = 10000000;
+
+  // DUT parameters
+  localparam int unsigned NoHashes    = 32'd3;
+  localparam int unsigned HashWidth   = 32'd6;
+  localparam int unsigned HashRounds  = 32'd1;
+  localparam int unsigned DataWidth   = 32'd11;
+  localparam int unsigned BucketWidth = 32'd3;
+
+  typedef logic [DataWidth-1:0] data_t;
+
+  localparam cb_filter_pkg::cb_seed_t [NoHashes-1:0] Seeds = '{
+    '{PermuteSeed: 32'd299034753, XorSeed: 32'd4094834 },
+    '{PermuteSeed: 32'd19921030,  XorSeed: 32'd995713  },
+    '{PermuteSeed: 32'd294388,    XorSeed: 32'd65146511}
+  };
+
+//---------------------------------------------------------
+// Associative array as model
+//---------------------------------------------------------
+  logic control_array [*];
+  int unsigned max_items;
+  int unsigned min_items;
+//---------------------------------------------------------
+// Bookkeeping
+//---------------------------------------------------------
+  longint unsigned no_tests;
+  longint unsigned no_positives;
+  longint unsigned no_false_positives;
+  longint unsigned no_negatives;
+  longint unsigned no_false_negatives;
+
+//---------------------------------------------------------
+// DUT signals
+//---------------------------------------------------------
+
+  logic  clk;
+  logic  rst_n;
+  logic  sim_done;
+
+  data_t look_data;
+  logic  look_valid;
+  data_t incr_data;
+  logic  incr_valid;
+  data_t decr_data;
+  logic  decr_valid;
+
+  logic                  filter_clear;
+  logic  [HashWidth-1:0] filter_usage;
+  logic                  filter_full,  filter_empty, filter_error;
+
+  // -------------
+  // Clock generator
+  // -------------
+  clk_rst_gen #(
+    .CLK_PERIOD     ( TCycle ),
+    .RST_CLK_CYCLES (       5 )
+  ) i_clk_gen (
+    .clk_o  (   clk ),
+    .rst_no ( rst_n )
+  );
+
+  // ------------------------
+  // Test Bench
+  // ------------------------
+  program test_cbf;
+    initial begin : stimulus
+      sim_done = 1'b0;
+      no_tests           = 64'd0;
+      no_positives       = 64'd0;
+      no_false_positives = 64'd0;
+      no_negatives       = 64'd0;
+      no_false_negatives = 64'd0;
+      init_signals();
+      fork
+        begin
+          // simulation control branch
+          max_items = 10;
+          min_items =  3;
+          @(posedge rst_n);
+          repeat (RunCycles) @(posedge clk);
+          sim_done = 1'b1;
+        end
+        begin
+          @(posedge rst_n);
+          run_lookup(sim_done);
+        end
+        begin
+          @(posedge rst_n);
+          run_increment(sim_done, decr_valid);
+        end
+        begin
+          @(posedge rst_n);
+          run_decrement(sim_done);
+        end
+      join
+      print_result(no_tests, no_positives, no_false_positives, no_negatives, no_false_negatives);
+      empty_filter();
+      $stop();
+    end
+
+    task cycle_start();
+      #TTest;
+    endtask : cycle_start
+
+    task cycle_end();
+      @(posedge clk);
+    endtask : cycle_end
+
+    task reset_filter();
+      filter_clear <= #TAppli '1;
+      cycle_end();
+      filter_clear <= #TAppli '0;
+    endtask : reset_filter
+
+    task init_signals();
+      look_data    <= #TAppli '0;
+      incr_data    <= #TAppli '0;
+      incr_valid   <= #TAppli '0;
+      decr_data    <= #TAppli '0;
+      decr_valid   <= #TAppli '0;
+      filter_clear <= #TAppli '0;
+    endtask : init_signals
+
+    // runs each cycle a lookup and tests if the output is expected
+    task automatic run_lookup(ref logic sim_done);
+      while (!sim_done) begin
+        logic [DataWidth-1:0] lookup = $urandom_range(0,2**DataWidth-1);;
+        rand_wait(0,6);
+        look_data    <= #TAppli lookup;
+        cycle_start();
+        no_tests++;
+        // check the result
+        if(control_array.exists(lookup)) begin
+          // the result has to be right
+          if(!look_valid) begin
+            $warning(1, "Had a false negative!!!\nIndex: %d", lookup);
+            no_false_negatives++;
+          end else begin
+            no_positives++;
+          end
+        end else begin
+          // here we can check for false positives
+          if(look_valid) begin
+            //$display("Had a false positive!\nIndex: %d", lookup);
+            no_false_positives++;
+          end else begin
+            //$display("Item correctly not in Set.\nIndex: %d", lookup);
+            no_negatives++;
+          end
+        end
+        cycle_end();
+      end
+    endtask : run_lookup
+
+    // randomly put data into the filter
+    task automatic run_increment(ref logic sim_done, ref logic decr_valid);
+      while (!sim_done) begin
+        logic [DataWidth-1:0] data = $urandom_range(0,2**DataWidth-1);
+        if(!control_array.exists(data)) begin
+          rand_wait(0,5);
+          incr_data <= #TAppli data;
+          while (filter_full | (control_array.num() > max_items))
+              begin if (sim_done | decr_valid) break; cycle_end(); end
+          incr_valid <= #TAppli 1'b1;
+          cycle_end();
+          control_array[data] = 1'b1;
+          incr_data  <= #TAppli '0;
+          incr_valid <= #TAppli '0;
+        end else begin
+          cycle_end();
+        end
+      end
+    endtask : run_increment
+
+    // remove randomly an item from the filter
+    task automatic run_decrement(ref logic sim_done);
+      int unsigned nb_tryes = 0;
+      while (!sim_done) begin
+        logic [DataWidth-1:0] data = $urandom_range(0,2**DataWidth-1);;
+        if(control_array.exists(data)) begin
+          if(control_array.num() > min_items) begin
+            rand_wait(0,5);
+            decr_data  <= #TAppli data;
+            decr_valid <= #TAppli 1'b1;
+            cycle_start();
+            control_array.delete(data);
+            cycle_end();
+            decr_data  <= #TAppli '0;
+            decr_valid <= #TAppli 1'b0;
+          end else begin
+            cycle_end();
+          end
+        end else begin
+          if(nb_tryes < 100) begin
+            nb_tryes++;
+          end else begin
+            nb_tryes = 0;
+            cycle_end();
+          end
+        end
+      end
+    endtask : run_decrement
+
+    // clear the filter from all items
+    task empty_filter();
+      rand_wait(10,15);
+      for (int unsigned i = 0; i < 2**DataWidth; i++) begin
+        if(control_array.exists(i)) begin
+          decr_data  <= #TAppli i;
+          decr_valid <= #TAppli 1'b1;
+          cycle_start();
+          control_array.delete(i);
+          cycle_end();
+        end
+      end
+      // check empty flag
+      decr_data  <= #TAppli '0;
+      decr_valid <= #TAppli 1'b0;
+      cycle_start();
+      cycle_end();
+      $display("Filter empty is: %b", filter_empty);
+    endtask : empty_filter
+
+    task print_result(input longint unsigned n_test, n_pos, n_f_pos, n_neg, n_f_neg);
+      $info(   "######################################################");
+      if (n_f_neg == 64'h0) begin
+        $display("***SUCCESS***");
+      end else begin
+        $display("!!!FAILED!!!");
+      end
+      $display("Finished Tests");
+      $display("NO Testes:    %d", n_test);
+      $display("NO Positive:  %d", n_pos);
+      $display("NO False Pos: %d", n_f_pos);
+      $display("NO Negatives: %d", n_neg);
+      $display("NO False Neg: %d <--- Success if this is 0!", n_f_neg);
+      $display("######################################################");
+    endtask : print_result
+
+    task automatic rand_wait(input int unsigned min, max);
+      int unsigned rand_success, cycles;
+      rand_success = std::randomize(cycles) with {
+        cycles >= min;
+        cycles <= max;
+      };
+      assert (rand_success) else $error("Failed to randomize wait cycles!");
+      repeat (cycles) @(posedge clk);
+    endtask : rand_wait
+
+  endprogram
+
+  cb_filter #(
+    .KHashes       ( NoHashes    ), // Number of hash functions
+    .HashWidth     ( HashWidth   ), // Number of counters is 2**HASH_WIDTH
+    .HashRounds    ( HashRounds  ),
+    .InpWidth      ( DataWidth   ), // Input data width
+    .BucketWidth   ( BucketWidth ), // Width of Bucket counters
+    .Seeds         ( Seeds       )
+  ) i_dut (
+    .clk_i  ( clk   ),  // Clock
+    .rst_ni ( rst_n ),  // Active low reset
+    // data lookup
+    .look_data_i    ( look_data    ),
+    .look_valid_o   ( look_valid   ),
+    // data increment
+    .incr_data_i    ( incr_data    ),
+    .incr_valid_i   ( incr_valid   ),
+    // data decrement
+    .decr_data_i    ( decr_data    ),
+    .decr_valid_i   ( decr_valid   ),
+    // status signals
+    .filter_clear_i ( filter_clear ),
+    .filter_usage_o ( filter_usage ),
+    .filter_full_o  ( filter_full  ),
+    .filter_empty_o ( filter_empty ),
+    .filter_error_o ( filter_error )
+  );
+endmodule

--- a/test/cb_filter_tb.sv
+++ b/test/cb_filter_tb.sv
@@ -10,10 +10,18 @@
 
 // Author: Wolfgang Roenninger <wroennin@ethz.ch>
 
-// TB CBF: Test bench for the counting bloom filter
-//         Randomly puts in data items into the filter.
-//         Removes the put in items after some time.
-//         Random lookup in each cycle
+// Test bench for the counting bloom filter
+// Randomly puts in data items into the filter.
+// Removes the put in items after some time.
+// One random lookup in each cycle.
+// The test bench has a `control_array`, which serves as the golden model for the lookups.
+// Each time a value gets put or removed into the filter, the array gets updated.
+// On each lookup in the DUT it gets cross checked with the array.
+// The test bench keeps book for each lookup and prints at the end the number of lookups,
+// and the number of positive, false positive, negative and false negative lookups.
+// The number of false negatives has to be 0 as it would indicate that the lookup was negative,
+// even when the data was put in the filter. False positives are ok, because they are the result
+// of hash-collisions, inherit to a counting bloom filter.
 
 module cb_filter_tb;
   // TB parameters

--- a/test/cb_filter_tb.sv
+++ b/test/cb_filter_tb.sv
@@ -14,14 +14,14 @@
 // Randomly puts in data items into the filter.
 // Removes the put in items after some time.
 // One random lookup in each cycle.
-// The test bench has a `control_array`, which serves as the golden model for the lookups.
+// The testbench has a `control_array`, which serves as the golden model for the lookups.
 // Each time a value gets put or removed into the filter, the array gets updated.
 // On each lookup in the DUT it gets cross checked with the array.
 // The test bench keeps book for each lookup and prints at the end the number of lookups,
 // and the number of positive, false positive, negative and false negative lookups.
 // The number of false negatives has to be 0 as it would indicate that the lookup was negative,
 // even when the data was put in the filter. False positives are ok, because they are the result
-// of hash-collisions, inherit to a counting bloom filter.
+// of hash-collisions, inherent to a counting bloom filter.
 
 module cb_filter_tb;
   // TB parameters
@@ -51,6 +51,7 @@ module cb_filter_tb;
   logic control_array [*];
   int unsigned max_items;
   int unsigned min_items;
+
 //---------------------------------------------------------
 // Bookkeeping
 //---------------------------------------------------------
@@ -63,7 +64,6 @@ module cb_filter_tb;
 //---------------------------------------------------------
 // DUT signals
 //---------------------------------------------------------
-
   logic  clk;
   logic  rst_n;
   logic  sim_done;

--- a/test/sub_per_hash_tb.sv
+++ b/test/sub_per_hash_tb.sv
@@ -12,7 +12,6 @@
 
 // This testbench can be used to look at the `sub_per_hash` function outputs.
 // The stimuli increment the input per clock cycle up to a max amount of cycles.
-
 module sub_per_hash_tb;
   //---------------------------------------------------------
   // TB parameters

--- a/test/sub_per_hash_tb.sv
+++ b/test/sub_per_hash_tb.sv
@@ -10,8 +10,8 @@
 
 // Author: Wolfgang Roenninger <wroennin@ethz.ch>
 
-// SUB PER HASH TB: This testbench can be used to look at the `sub_per_hash` function outputs.
-//                  The stimuli increment the input per clock cycle up to a max amount of cycles.
+// This testbench can be used to look at the `sub_per_hash` function outputs.
+// The stimuli increment the input per clock cycle up to a max amount of cycles.
 
 module sub_per_hash_tb;
   //---------------------------------------------------------

--- a/test/sub_per_hash_tb.sv
+++ b/test/sub_per_hash_tb.sv
@@ -1,0 +1,117 @@
+// Copyright (c) 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+// SUB PER HASH TB: This testbench can be used to look at the `sub_per_hash` function outputs.
+//                  The stimuli increment the input per clock cycle up to a max amount of cycles.
+
+module sub_per_hash_tb;
+  //---------------------------------------------------------
+  // TB parameters
+  //---------------------------------------------------------
+  localparam time TCycle = 10ns;
+  localparam time TAppli =  2ns;
+  localparam time TTest  =  8ns;
+  localparam longint unsigned MaxCycles = 64'd100000000;
+
+  //---------------------------------------------------------
+  // DUT parameters / signals
+  //---------------------------------------------------------
+  localparam int unsigned DataWidth   = 32'd11;
+  localparam int unsigned HashWidth   = 32'd5;
+  localparam int unsigned NoHashes    = 32'd3;
+  localparam int unsigned NoRounds    = 32'd1;
+  typedef logic [DataWidth-1:0]    data_t;
+  typedef logic [HashWidth-1:0]    hash_t;
+  typedef logic [2**HashWidth-1:0] onehot_hash_t;
+
+  localparam cb_filter_pkg::cb_seed_t [NoHashes-1:0] Seeds = '{
+    '{PermuteSeed: 32'd299034753, XorSeed: 32'd4094834 },
+    '{PermuteSeed: 32'd19921030,  XorSeed: 32'd995713  },
+    '{PermuteSeed: 32'd294388,    XorSeed: 32'd65146511}
+  };
+
+  logic  clk;
+  logic  rst_n;
+
+  data_t                       data;
+  hash_t        [NoHashes-1:0] hash;
+  onehot_hash_t [NoHashes-1:0] onehot_hash;
+
+  // -------------
+  // Clock generator
+  // -------------
+  clk_rst_gen #(
+    .CLK_PERIOD     ( TCycle ),
+    .RST_CLK_CYCLES (      1 )
+  ) i_clk_gen (
+    .clk_o  (   clk ),
+    .rst_no ( rst_n )
+  );
+
+  // ------------------------
+  // Test Bench
+  // ------------------------
+  program test_cbf;
+    initial begin : shutdown_sim
+      repeat (MaxCycles) @(posedge clk);
+      $info("Stop, because max cycles was reached.");
+      $stop();
+    end
+
+    initial begin : stimulus
+      set_data(0);
+      // wait for reset
+      @(posedge rst_n);
+      repeat (10) @(posedge clk);
+
+      for (longint unsigned i = 0; i < 2**DataWidth; i++) begin
+        set_data(i);
+      end
+
+      repeat (10) @(posedge clk);
+      $info("Stop, because all possible inputs were applied.");
+      $stop();
+    end
+
+    task cycle_start();
+      #TTest;
+    endtask : cycle_start
+
+    task cycle_end();
+      @(posedge clk);
+    endtask : cycle_end
+
+    task set_data (input longint unsigned nbr);
+      data <= #TAppli data_t'(nbr);
+      cycle_end();
+    endtask : set_data
+
+    task init_signals();
+      data <= '0;
+    endtask : init_signals
+  endprogram
+
+  // generate duts
+  for (genvar i = 0; i < NoHashes; i++) begin : gen_hash_dut
+    sub_per_hash #(
+      .InpWidth   ( DataWidth            ),
+      .HashWidth  ( HashWidth            ),
+      .NoRounds   ( NoRounds             ),
+      .PermuteKey ( Seeds[i].PermuteSeed ),
+      .XorKey     ( Seeds[i].XorSeed     )
+    ) i_hash (
+      .data_i        ( data           ),
+      .hash_o        ( hash[i]        ),
+      .hash_onehot_o ( onehot_hash[i] )
+    );
+  end
+endmodule

--- a/test/waves/cb_filter_tb.wave.do
+++ b/test/waves/cb_filter_tb.wave.do
@@ -1,0 +1,30 @@
+log -r /*
+
+add wave -position end -label Clock -color "light blue"  sim:/cb_filter_tb/i_dut/clk_i
+add wave -position end -label Reset -color "orange"      sim:/cb_filter_tb/i_dut/rst_ni
+
+add wave -position end -divider "Lookup Hashes"
+add wave -position end -label LOOK_DATA      -color "green" sim:/cb_filter_tb/i_dut/i_look_hashes/data_i
+add wave -position end -label LOOK_HASH      -color "pink"  sim:/cb_filter_tb/i_dut/i_look_hashes/hashes
+add wave -position end -label LOOKUP_VALID_O -color "blue"  sim:/cb_filter_tb/i_dut/look_valid_o
+
+
+add wave -position end -divider "Increment Hashes"
+add wave -position end -label INCR_DATA  -color "green" sim:/cb_filter_tb/i_dut/i_incr_hashes/data_i
+add wave -position end -label INCR_VALID -color "blue"  sim:/cb_filter_tb/i_dut/incr_valid_i
+add wave -position end -label INCR_HASH  -color "pink"  sim:/cb_filter_tb/i_dut/i_incr_hashes/hashes
+add wave -position end -label INCR_IND   -color "pink"  sim:/cb_filter_tb/i_dut/i_incr_hashes/indicator_o
+
+
+add wave -position end -divider "Decrement Hashes"
+add wave -position end -label DECR_DATA  -color "green" sim:/cb_filter_tb/i_dut/i_decr_hashes/data_i
+add wave -position end -label DECR_VALID -color "blue"  sim:/cb_filter_tb/i_dut/decr_valid_i
+add wave -position end -label DECR_HASH  -color "pink"  sim:/cb_filter_tb/i_dut/i_decr_hashes/hashes
+add wave -position end -label DECR_IND   -color "pink"  sim:/cb_filter_tb/i_dut/i_incr_hashes/indicator_o
+
+add wave -position end -divider "Filter Flags"
+add wave -position end -label OCCUPIED  -color "orange"   sim:/cb_filter_tb/i_dut/bucket_occupied
+add wave -position end -label USAGE     -color "pink"     sim:/cb_filter_tb/i_dut/filter_usage_o
+add wave -position end -label FULL      -color "magenta"  sim:/cb_filter_tb/i_dut/filter_full_o
+add wave -position end -label EMPTY     -color "green"    sim:/cb_filter_tb/i_dut/filter_empty_o
+add wave -position end -label ERROR     -color "red"      sim:/cb_filter_tb/i_dut/filter_error_o

--- a/test/waves/sub_per_hash_tb.wave.do
+++ b/test/waves/sub_per_hash_tb.wave.do
@@ -1,0 +1,27 @@
+log -r /*
+git SetDefaultTree
+onerror {resume}
+quietly WaveActivateNextPane {} 0
+add wave -noupdate /sub_per_hash_tb/clk
+add wave -noupdate /sub_per_hash_tb/rst_n
+add wave -noupdate /sub_per_hash_tb/data
+add wave -noupdate /sub_per_hash_tb/hash
+add wave -noupdate -expand -subitemconfig {{/sub_per_hash_tb/onehot_hash[2]} -expand {/sub_per_hash_tb/onehot_hash[1]} -expand {/sub_per_hash_tb/onehot_hash[0]} -expand} /sub_per_hash_tb/onehot_hash
+TreeUpdate [SetDefaultTree]
+WaveRestoreCursors {{Cursor 1} {0 ns} 0}
+quietly wave cursor active 0
+configure wave -namecolwidth 207
+configure wave -valuecolwidth 100
+configure wave -justifyvalue left
+configure wave -signalnamewidth 0
+configure wave -snapdistance 10
+configure wave -datasetprefix 0
+configure wave -rowmargin 4
+configure wave -childrowmargin 2
+configure wave -gridoffset 0
+configure wave -gridperiod 1
+configure wave -griddelta 40
+configure wave -timeline 0
+configure wave -timelineunits ns
+update
+WaveRestoreZoom {0 ns} {42432 ns}


### PR DESCRIPTION
Added two new modules and it's respective test-benches:
 - `sub_per_hash.sv` : Implements a fully seedable substitution-permutation non-crypto hash function.
 - `cb_filter.sv`: Implements a counting-bloom-filter with combinational lookup