### PR TITLE
Quartus support

### DIFF
--- a/src/cdc_2phase.sv
+++ b/src/cdc_2phase.sv
@@ -17,28 +17,30 @@
 /// the paths async_req, async_ack, async_data.
 /* verilator lint_off DECLFILENAME */
 module cdc_2phase #(
-  parameter type T = logic
+  parameter int unsigned T_w = 1
 )(
   input  logic src_rst_ni,
   input  logic src_clk_i,
-  input  T     src_data_i,
+  input  logic [T_w-1:0] src_data_i,
   input  logic src_valid_i,
   output logic src_ready_o,
 
   input  logic dst_rst_ni,
   input  logic dst_clk_i,
-  output T     dst_data_o,
+  output logic [T_w-1:0] dst_data_o,
   output logic dst_valid_o,
   input  logic dst_ready_i
 );
 
+  typedef logic [T_w-1:0] T;
+
   // Asynchronous handshake signals.
-  (* dont_touch = "true" *) logic async_req;
-  (* dont_touch = "true" *) logic async_ack;
-  (* dont_touch = "true" *) T async_data;
+  logic async_req /* synthesis keep preserve */;
+  logic async_ack /* synthesis keep preserve */;
+  T async_data /* synthesis keep preserve */;
 
   // The sender in the source domain.
-  cdc_2phase_src #(.T(T)) i_src (
+  cdc_2phase_src #(.T_w(T_w)) i_src (
     .rst_ni       ( src_rst_ni  ),
     .clk_i        ( src_clk_i   ),
     .data_i       ( src_data_i  ),
@@ -50,7 +52,7 @@ module cdc_2phase #(
   );
 
   // The receiver in the destination domain.
-  cdc_2phase_dst #(.T(T)) i_dst (
+  cdc_2phase_dst #(.T_w(T_w)) i_dst (
     .rst_ni       ( dst_rst_ni  ),
     .clk_i        ( dst_clk_i   ),
     .data_o       ( dst_data_o  ),
@@ -66,22 +68,22 @@ endmodule
 
 /// Half of the two-phase clock domain crossing located in the source domain.
 module cdc_2phase_src #(
-  parameter type T = logic
+  parameter int unsigned T_w = 1
 )(
   input  logic rst_ni,
   input  logic clk_i,
-  input  T     data_i,
+  input  logic[T_w-1:0] data_i,
   input  logic valid_i,
   output logic ready_o,
   output logic async_req_o,
   input  logic async_ack_i,
-  output T     async_data_o
+  output logic[T_w-1:0] async_data_o
 );
 
-  (* dont_touch = "true" *)
-  logic req_src_q, ack_src_q, ack_q;
-  (* dont_touch = "true" *)
-  T data_src_q;
+  typedef logic[T_w-1:0] T;
+
+  logic req_src_q /* synthesis keep preserve */, ack_src_q /* synthesis keep preserve */, ack_q /* synthesis keep preserve */;
+  T data_src_q /* synthesis keep preserve */;
 
   // The req_src and data_src registers change when a new data item is accepted.
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -116,23 +118,22 @@ endmodule
 /// Half of the two-phase clock domain crossing located in the destination
 /// domain.
 module cdc_2phase_dst #(
-  parameter type T = logic
+  parameter int unsigned T_w = 1
 )(
   input  logic rst_ni,
   input  logic clk_i,
-  output T     data_o,
+  output logic[T_w-1:0] data_o,
   output logic valid_o,
   input  logic ready_i,
   input  logic async_req_i,
   output logic async_ack_o,
-  input  T     async_data_i
+  input  logic[T_w-1:0] async_data_i
 );
 
-  (* dont_touch = "true" *)
-  (* async_reg = "true" *)
-  logic req_dst_q, req_q0, req_q1, ack_dst_q;
-  (* dont_touch = "true" *)
-  T data_dst_q;
+  typedef logic[T_w-1:0] T;
+
+  logic req_dst_q /* synthesis keep preserve */, req_q0 /* synthesis keep preserve */, req_q1 /* synthesis keep preserve */, ack_dst_q /* synthesis keep preserve */;
+  T data_dst_q /* synthesis keep preserve */;
 
   // The ack_dst register changes when a new data item is accepted.
   always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/src/deprecated/fifo_v2.sv
+++ b/src/deprecated/fifo_v2.sv
@@ -16,7 +16,7 @@ module fifo_v2 #(
     parameter int unsigned DEPTH        = 8,    // depth can be arbitrary from 0 to 2**32
     parameter int unsigned ALM_EMPTY_TH = 1,    // almost empty threshold (when to assert alm_empty_o)
     parameter int unsigned ALM_FULL_TH  = 1,    // almost full threshold (when to assert alm_full_o)
-    parameter type dtype                = logic [DATA_WIDTH-1:0],
+    parameter int unsigned dtype_w      = DATA_WIDTH,
     // DO NOT OVERWRITE THIS PARAMETER
     parameter int unsigned ADDR_DEPTH   = (DEPTH > 1) ? $clog2(DEPTH) : 1
 )(
@@ -30,16 +30,17 @@ module fifo_v2 #(
     output logic  alm_full_o,       // FIFO fillstate >= the specified threshold
     output logic  alm_empty_o,      // FIFO fillstate <= the specified threshold
     // as long as the queue is not full we can push new data
-    input  dtype  data_i,           // data to push into the queue
+    input  logic[dtype_w-1:0] data_i,  // data to push into the queue
     input  logic  push_i,           // data is valid and can be pushed to the queue
     // as long as the queue is not empty we can pop new elements
-    output dtype  data_o,           // output data
+    output logic[dtype_w-1:0] data_o,  // output data
     input  logic  pop_i             // pop head from queue
 );
 
     logic [ADDR_DEPTH-1:0] usage;
 
     // generate threshold parameters
+    generate
     if (DEPTH == 0) begin
         assign alm_full_o  = 1'b0; // that signal does not make any sense in a FIFO of depth 0
         assign alm_empty_o = 1'b0; // that signal does not make any sense in a FIFO of depth 0
@@ -47,12 +48,13 @@ module fifo_v2 #(
         assign alm_full_o   = (usage >= ALM_FULL_TH[ADDR_DEPTH-1:0]);
         assign alm_empty_o  = (usage <= ALM_EMPTY_TH[ADDR_DEPTH-1:0]);
     end
+    endgenerate
 
     fifo_v3 #(
         .FALL_THROUGH ( FALL_THROUGH ),
         .DATA_WIDTH   ( DATA_WIDTH   ),
         .DEPTH        ( DEPTH        ),
-        .dtype        ( dtype        )
+        .dtype_w      ( dtype_w      )
     ) i_fifo_v3 (
         .clk_i,
         .rst_ni,

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -19,15 +19,18 @@ module onehot_to_bin #(
     output logic [BIN_WIDTH-1:0]    bin
 );
 
-    for (genvar j = 0; j < BIN_WIDTH; j++) begin : jl
+    generate
+    genvar i, j;
+    for (j = 0; j < BIN_WIDTH; j++) begin : jl
         logic [ONEHOT_WIDTH-1:0] tmp_mask;
-            for (genvar i = 0; i < ONEHOT_WIDTH; i++) begin : il
+            for (i = 0; i < ONEHOT_WIDTH; i++) begin : il
                 logic [BIN_WIDTH-1:0] tmp_i;
                 assign tmp_i = i;
                 assign tmp_mask[i] = tmp_i[j];
             end
         assign bin[j] = |(tmp_mask & onehot);
     end
+    endgenerate
 
 // pragma translate_off
 `ifndef VERILATOR


### PR DESCRIPTION
In reference to: pulp-platform/pulpissimo#78

Fixed issues:

- [type parameters](https://marekpikula.github.io/quartus-sv-gotchas/Intel%20Quartus%20SystemVerilog%20gotchas.html#6203-type-parameters)
- [conditional generate](https://marekpikula.github.io/quartus-sv-gotchas/Intel%20Quartus%20SystemVerilog%20gotchas.html#275-conditional-generate-constructs)
- [loop generate](https://marekpikula.github.io/quartus-sv-gotchas/Intel%20Quartus%20SystemVerilog%20gotchas.html#274-loop-generate-constructs-3)
- changed Vivado's `dont_touch` synthesis flag to Quartus' `preserve keep`.