### PR TITLE
handle degenerate onehot cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Handle degenerated `onehot_to_bin` with `ONEHOT_WIDTH == 1`
+- Handle degenerated `id_queue` with `CAPACITY == 1` or `HT_CAPACITY == 1`
+
 ## 1.15.0 - 2019-12-09
 ### Added
 - Added address map decoder module

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -73,12 +73,14 @@ module id_queue #(
     // indices.
     localparam int N_IDS = 2**ID_WIDTH;
     localparam int HT_CAPACITY = (N_IDS <= CAPACITY) ? N_IDS : CAPACITY;
+    localparam int unsigned HT_IDX_WIDTH = HT_CAPACITY == 1 ? 1 : $clog2(HT_CAPACITY);
+    localparam int unsigned LD_IDX_WIDTH = CAPACITY    == 1 ? 1 : $clog2(CAPACITY);
 
     // Type for indexing the head-tail table.
-    typedef logic [$clog2(HT_CAPACITY)-1:0] ht_idx_t;
+    typedef logic [HT_IDX_WIDTH-1:0] ht_idx_t;
 
     // Type for indexing the lined data table.
-    typedef logic [$clog2(CAPACITY)-1:0] ld_idx_t;
+    typedef logic [LD_IDX_WIDTH-1:0] ld_idx_t;
 
     // Type of an entry in the head-tail table.
     typedef struct packed {

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -13,8 +13,8 @@
 module onehot_to_bin #(
     parameter int unsigned ONEHOT_WIDTH = 16,
     // Do Not Change
-    parameter int unsigned BIN_WIDTH   = $clog2(ONEHOT_WIDTH)
-)(
+    parameter int unsigned BIN_WIDTH    = ONEHOT_WIDTH == 1 ? 1 : $clog2(ONEHOT_WIDTH)
+)   (
     input  logic [ONEHOT_WIDTH-1:0] onehot,
     output logic [BIN_WIDTH-1:0]    bin
 );
@@ -31,7 +31,8 @@ module onehot_to_bin #(
 
 // pragma translate_off
 `ifndef VERILATOR
-    assert final ($onehot0(onehot)) else $fatal(1, "[onehot_to_bin] More than two bit set in the one-hot signal");
+    assert final ($onehot0(onehot)) else
+        $fatal(1, "[onehot_to_bin] More than two bit set in the one-hot signal");
 `endif
 // pragma translate_on
 endmodule


### PR DESCRIPTION
### Fixed
- Handle degenerated `onehot_to_bin` with `ONEHOT_WIDTH == 1`
- Handle degenerated `id_queue` with `CAPACITY == 1` or `HT_CAPACITY == 1`