### PR TITLE
id_queue: Fix generation of `head_tail_q` registers

### DIFF
--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -241,15 +241,22 @@ module id_queue #(
     end
 
     // Registers
-    for (genvar i = 0; i < CAPACITY; i++) begin: gen_ffs
+    for (genvar i = 0; i < HT_CAPACITY; i++) begin: gen_ht_ffs
         always_ff @(posedge clk_i, negedge rst_ni) begin
             if (!rst_ni) begin
-                head_tail_q[i]      <= '{free: 1'b1, default: 'x};
+                head_tail_q[i] <= '{free: 1'b1, default: 'x};
+            end else begin
+                head_tail_q[i] <= head_tail_d[i];
+            end
+        end
+    end
+    for (genvar i = 0; i < CAPACITY; i++) begin: gen_data_ffs
+        always_ff @(posedge clk_i, negedge rst_ni) begin
+            if (!rst_ni) begin
                 // Set free bit of linked data entries, all other bits are don't care.
                 linked_data_q[i]    <= 'x;
                 linked_data_q[i][0] <= 1'b1;
             end else begin
-                head_tail_q[i]      <= head_tail_d[i];
                 linked_data_q[i]    <= linked_data_d[i];
             end
         end


### PR DESCRIPTION
There are `HT_CAPACITY` registers behind the `head_tail_q` signal, and the value of `HT_CAPACITY` need not necessarily be the same as `CAPACITY`.