### PR TITLE
src_files: added include dir

### DIFF
--- a/src_files.yml
+++ b/src_files.yml
@@ -1,4 +1,6 @@
 common_cells_all:
+  incdirs:
+    - include
   files:
     # Source files grouped in levels. Files in level 0 have no dependencies on files in this
     # package. Files in level 1 only depend on files in level 0, files in level 2 on files in


### PR DESCRIPTION
missing `incdirs` field in src_files killed IPApproX.