### PR TITLE
Add stream modules

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -62,6 +62,7 @@ sources:
   - src/rstgen.sv
   - src/stream_delay.sv
   - src/stream_fifo.sv
+  - src/stream_fork_dynamic.sv
   # Level 2
   - src/fall_through_register.sv
   - src/stream_arbiter_flushable.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -46,6 +46,7 @@ sources:
   - src/stream_demux.sv
   - src/stream_filter.sv
   - src/stream_fork.sv
+  - src/stream_join.sv
   - src/stream_mux.sv
   - src/sub_per_hash.sv
   - src/sync.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- stream_fork_dynamic: Wrapper around `stream_fork` for partial forking.
 
 ## 1.17.0 - 2020-04-09
 ### Added
@@ -20,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.16.2 - 2020-02-04
 ### Fixed
-- Fix author section in Bender.yml 
+- Fix author section in Bender.yml
 
 ## 1.16.1 - 2020-02-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - stream_fork_dynamic: Wrapper around `stream_fork` for partial forking.
+- stream_join: Join multiple Ready/Valid handshakes to one common handshake.
 
 ## 1.17.0 - 2020-04-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `stream_mux`                 | Ready/valid interface multiplexer                                              | active         |               |
 | `stream_register`            | Register with ready/valid interface                                            | active         |               |
 | `stream_fork`                | Ready/valid fork                                                               | active         |               |
+| `stream_fork_dynamic`        | Ready/valid fork, with selection mask for partial forking                      | active         |               |
 | `stream_filter`              | Ready/valid filter                                                             | active         |               |
 | `stream_delay`               | Randomize or delay ready/valid interface                                       | active         |               |
 | `sub_per_hash`               | Substitution-permutation hash function                                         | active         |               |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `stream_arbiter`             | Round-robin arbiter for ready/valid stream interface                           | active         |               |
 | `stream_arbiter_flushable`   | Round-robin arbiter for ready/valid stream interface and flush functionality   | active         |               |
 | `stream_demux`               | Ready/valid interface demultiplexer                                            | active         |               |
+| `stream_join`                | Ready/valid handshake join multiple to one common                              | active         |               |
 | `stream_mux`                 | Ready/valid interface multiplexer                                              | active         |               |
 | `stream_register`            | Register with ready/valid interface                                            | active         |               |
 | `stream_fork`                | Ready/valid fork                                                               | active         |               |

--- a/src/stream_fork_dynamic.sv
+++ b/src/stream_fork_dynamic.sv
@@ -1,0 +1,95 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Andreas Kurth <akurth@iis.ee.ethz.ch>
+
+/// Dynamic stream fork: Connects the input stream (ready-valid) handshake to a combination of output
+/// stream handshake.  The combination is determined dynamically through another stream, which
+/// provides a bitmask for the fork.  For each input stream handshake, every output stream handshakes
+/// exactly once. The input stream only handshakes when all output streams have handshaked, but the
+/// output streams do not have to handshake simultaneously.
+///
+/// This module has no data ports because stream data does not need to be forked: the data of the
+/// input stream can just be applied at all output streams.
+module stream_fork_dynamic #(
+  /// Number of output streams
+  parameter int unsigned N_OUP = 32'd0 // Synopsys DC requires a default value for parameters.
+) (
+  /// Clock
+  input  logic             clk_i,
+  /// Asynchronous reset, active low
+  input  logic             rst_ni,
+  /// Input stream valid handshake,
+  input  logic             valid_i,
+  /// Input stream ready handshake
+  output logic             ready_o,
+  /// Selection mask for the output handshake
+  input  logic [N_OUP-1:0] sel_i,
+  /// Selection mask valid
+  input  logic             sel_valid_i,
+  /// Selection mask ready
+  output logic             sel_ready_o,
+  /// Output streams valid handshakes
+  output logic [N_OUP-1:0] valid_o,
+  /// Output streams ready handshakes
+  input  logic [N_OUP-1:0] ready_i
+);
+
+  logic             int_inp_valid,  int_inp_ready;
+  logic [N_OUP-1:0] int_oup_valid,  int_oup_ready;
+
+  // Output handshaking
+  for (genvar i = 0; i < N_OUP; i++) begin : gen_oups
+    always_comb begin
+      valid_o[i]       = 1'b0;
+      int_oup_ready[i] = 1'b0;
+      if (sel_valid_i) begin
+        if (sel_i[i]) begin
+          valid_o[i]       = int_oup_valid[i];
+          int_oup_ready[i] = ready_i[i];
+        end else begin
+          int_oup_ready[i] = 1'b1;
+        end
+      end
+    end
+  end
+
+  // Input handshaking
+  always_comb begin
+    int_inp_valid = 1'b0;
+    ready_o       = 1'b0;
+    sel_ready_o   = 1'b0;
+    if (sel_valid_i) begin
+      int_inp_valid = valid_i;
+      ready_o       = int_inp_ready;
+      sel_ready_o   = int_inp_ready;
+    end
+  end
+
+  stream_fork #(
+    .N_OUP  ( N_OUP )
+  ) i_fork (
+    .clk_i,
+    .rst_ni,
+    .valid_i ( int_inp_valid ),
+    .ready_o ( int_inp_ready ),
+    .valid_o ( int_oup_valid ),
+    .ready_i ( int_oup_ready )
+  );
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (N_OUP >= 1) else $fatal(1, "N_OUP must be at least 1!");
+  end
+`endif
+// pragma translate_on
+endmodule

--- a/src/stream_join.sv
+++ b/src/stream_join.sv
@@ -1,0 +1,43 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Andreas Kurth <akurth@iis.ee.ethz.ch>
+
+/// Stream join: Joins a parametrizable number of input streams (i.e., valid-ready handshaking with
+/// dependency rules as in AXI4) to a single output stream.  The output handshake happens only once
+/// all inputs are valid.  The data channel flows outside of this module.
+module stream_join #(
+  /// Number of input streams
+  parameter int unsigned N_INP = 32'd0 // Synopsys DC requires a default value for parameters.
+) (
+  /// Input streams valid handshakes
+  input  logic  [N_INP-1:0] inp_valid_i,
+  /// Input streams ready handshakes
+  output logic  [N_INP-1:0] inp_ready_o,
+  /// Output stream valid handshake
+  output logic              oup_valid_o,
+  /// Output stream ready handshake
+  input  logic              oup_ready_i
+);
+
+  assign oup_valid_o = (&inp_valid_i);
+  for (genvar i = 0; i < N_INP; i++) begin : gen_inp_ready
+    assign inp_ready_o[i] = oup_valid_o & oup_ready_i;
+  end
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (N_INP >= 1) else $fatal(1, "N_INP must be at least 1!");
+  end
+`endif
+// pragma translate_on
+endmodule


### PR DESCRIPTION
This adds two stream modules:
* `stream_fork_dynamic`: Fork a stream partially with a selection mask, wrapper around stream_fork.
* `stream_join`: Join multiple streams into one, output handshake will only go high if all input streams are valid.