### PR TITLE
Module `stream_to_mem`

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -90,6 +90,7 @@ sources:
       - test/id_queue_tb.sv
       - test/popcount_tb.sv
       - test/stream_register_tb.sv
+      - test/stream_to_mem_tb.sv
       - test/sub_per_hash_tb.sv
 
   - target: synth_test

--- a/Bender.yml
+++ b/Bender.yml
@@ -69,6 +69,7 @@ sources:
   - src/stream_fork_dynamic.sv
   # Level 2
   - src/fall_through_register.sv
+  - src/stream_to_mem.sv
   - src/stream_arbiter_flushable.sv
   - src/stream_register.sv
   # Level 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- stream_to_mem: Allows to use memories with flow control (req/gnt) for requests but
+  without flow control for output data to be used in streams.
 
 ## 1.18.0 - 2020-04-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `stream_fork_dynamic`        | Ready/valid fork, with selection mask for partial forking                      | active         |               |
 | `stream_filter`              | Ready/valid filter                                                             | active         |               |
 | `stream_delay`               | Randomize or delay ready/valid interface                                       | active         |               |
+| `stream_to_mem`              | Use memories without flow control for output data in streams.                  | active         |               |
 | `sub_per_hash`               | Substitution-permutation hash function                                         | active         |               |
 | `popcount`                   | Combinatorial popcount (hamming weight)                                        | active         |               |
 

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -11,10 +11,11 @@
 // Authors:
 // - Andreas Kurth <akurth@iis.ee.ethz.ch>
 
-/// Stream-to-Mem: Allows to use memories with flow control (req/gnt) for requests but without flow
+/// `stream_to_mem`: Allows to use memories with flow control (`valid`/`ready`) for requests but without flow
 /// control for output data to be used in streams.
+`include "common_cells/registers.svh"
 module stream_to_mem #(
-  /// Memory request payload type, usually write enable, write data, etc
+  /// Memory request payload type, usually write enable, write data, etc.
   parameter type         mem_req_t  = logic,
   /// Memory response payload type, usually read data
   parameter type         mem_resp_t = logic,
@@ -99,13 +100,7 @@ module stream_to_mem #(
     );
 
     // Register
-    always_ff @(posedge clk_i, negedge rst_ni) begin
-      if (!rst_ni) begin
-        cnt_q <= '0;
-      end else begin
-        cnt_q <= cnt_d;
-      end
-    end
+    `FFARN(cnt_q, cnt_d, '0, clk_i, rst_ni)
 
   end else begin : gen_no_buf
     // Control request, memory request, and response interface handshakes.

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -1,0 +1,139 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Andreas Kurth <akurth@iis.ee.ethz.ch>
+
+/// Stream-to-Mem: Allows to use memories with flow control (req/gnt) for requests but without flow
+/// control for output data to be used in streams.
+module stream_to_mem #(
+  /// Memory request payload type, usually write enable, write data, etc
+  parameter type         mem_req_t  = logic,
+  /// Memory response payload type, usually read data
+  parameter type         mem_resp_t = logic,
+  /// Number of buffered responses (fall-through, thus no additional latency).  This defines the
+  /// maximum number of outstanding requests on the memory interface. If the attached memory
+  /// responds in the same cycle a request is applied, this MUST be 0. If the attached memory
+  /// responds at least one cycle after a request, this MUST be >= 1 and should be equal to the
+  /// response latency of the memory to saturate bandwidth.
+  parameter int unsigned BufDepth   = 32'd1
+) (
+  /// Clock
+  input  logic      clk_i,
+  /// Asynchronous reset, active low
+  input  logic      rst_ni,
+  /// Request stream interface, payload
+  input  mem_req_t  req_i,
+  /// Request stream interface, payload is valid for transfer
+  input  logic      req_valid_i,
+  /// Request stream interface, payload can be accepted
+  output logic      req_ready_o,
+  /// Response stream interface, payload
+  output mem_resp_t resp_o,
+  /// Response stream interface, payload is valid for transfer
+  output logic      resp_valid_o,
+  /// Response stream interface, payload can be accepted
+  input  logic      resp_ready_i,
+  /// Memory request interface, payload
+  output mem_req_t  mem_req_o,
+  /// Memory request interface, payload is valid for transfer
+  output logic      mem_req_valid_o,
+  /// Memory request interface, payload can be accepted
+  input  logic      mem_req_ready_i,
+  /// Memory response interface, payload
+  input  mem_resp_t mem_resp_i,
+  /// Memory response interface, payload is valid
+  input  logic      mem_resp_valid_i
+);
+
+  typedef logic [$clog2(BufDepth+1):0] cnt_t;
+
+  cnt_t cnt_d, cnt_q;
+  logic buf_ready,
+        req_ready;
+
+  if (BufDepth > 0) begin : gen_buf
+    // Count number of outstanding requests.
+    always_comb begin
+      cnt_d = cnt_q;
+      if (req_valid_i && req_ready_o) begin
+        cnt_d++;
+      end
+      if (resp_valid_o && resp_ready_i) begin
+        cnt_d--;
+      end
+    end
+
+    // Can issue another request if the counter is not at its limit or a response is delivered in
+    // the current cycle.
+    assign req_ready = (cnt_q < BufDepth) | (resp_valid_o & resp_ready_i);
+
+    // Control request and memory request interface handshakes.
+    assign req_ready_o = mem_req_ready_i & req_ready;
+    assign mem_req_valid_o = req_valid_i & req_ready;
+
+    // Buffer responses.
+    stream_fifo #(
+      .FALL_THROUGH ( 1'b1       ),
+      .DEPTH        ( BufDepth   ),
+      .T            ( mem_resp_t )
+    ) i_resp_buf (
+      .clk_i,
+      .rst_ni,
+      .flush_i    ( 1'b0             ),
+      .testmode_i ( 1'b0             ),
+      .data_i     ( mem_resp_i       ),
+      .valid_i    ( mem_resp_valid_i ),
+      .ready_o    ( buf_ready        ),
+      .data_o     ( resp_o           ),
+      .valid_o    ( resp_valid_o     ),
+      .ready_i    ( resp_ready_i     ),
+      .usage_o    ( /* unused */     )
+    );
+
+    // Register
+    always_ff @(posedge clk_i, negedge rst_ni) begin
+      if (!rst_ni) begin
+        cnt_q <= '0;
+      end else begin
+        cnt_q <= cnt_d;
+      end
+    end
+
+  end else begin : gen_no_buf
+    // Control request, memory request, and response interface handshakes.
+    assign mem_req_valid_o = req_valid_i;
+    assign resp_valid_o = mem_req_valid_o & mem_req_ready_i & mem_resp_valid_i;
+    assign req_ready_o = resp_ready_i;
+
+    // Forward responses.
+    assign resp_o = mem_resp_i;
+  end
+
+  // Forward requests.
+  assign mem_req_o = req_i;
+
+// Assertions
+// pragma translate_off
+`ifndef VERILATOR
+  if (BufDepth > 0) begin : gen_buf_asserts
+    assert property (@(posedge clk_i) mem_resp_valid_i |-> buf_ready)
+      else $error("Memory response lost!");
+    assert property (@(posedge clk_i) cnt_q == '0 |=> cnt_q != '1)
+      else $error("Counter underflowed!");
+    assert property (@(posedge clk_i) cnt_q == BufDepth |=> cnt_q != BufDepth + 1)
+      else $error("Counter overflowed!");
+  end else begin : gen_no_buf_asserts
+    assume property (@(posedge clk_i) mem_req_valid_o & mem_req_ready_i |-> mem_resp_valid_i)
+      else $error("Without BufDepth = 0, the memory must respond in the same cycle!");
+  end
+`endif
+// pragma translate_on
+endmodule

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -105,8 +105,8 @@ module stream_to_mem #(
   end else begin : gen_no_buf
     // Control request, memory request, and response interface handshakes.
     assign mem_req_valid_o = req_valid_i;
-    assign resp_valid_o = mem_req_valid_o & mem_req_ready_i & mem_resp_valid_i;
-    assign req_ready_o = resp_ready_i;
+    assign resp_valid_o    = mem_req_valid_o & mem_req_ready_i & mem_resp_valid_i;
+    assign req_ready_o     = resp_ready_i    & resp_valid_o;
 
     // Forward responses.
     assign resp_o = mem_resp_i;

--- a/test/simulate.sh
+++ b/test/simulate.sh
@@ -27,3 +27,7 @@ call_vsim() {
 for tb in cdc_2phase_tb fifo_tb graycode_tb id_queue_tb popcount_tb stream_register_tb; do
     call_vsim $tb
 done
+
+for depth in 0 1 2; do
+	call_vsim stream_to_mem_tb -GBufDepth=$depth -coverage -voptargs="+acc +cover=bcesfx"
+done

--- a/test/stream_to_mem_tb.sv
+++ b/test/stream_to_mem_tb.sv
@@ -1,0 +1,155 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Authors:
+// - Wolfgang Rönninger <wroennin@iis.ee.ethz.ch>
+
+// Test bench for `stream_to_mem`
+module stream_to_mem_tb #(
+  parameter int unsigned NumReq   = 32'd10000,
+  parameter int unsigned BufDepth = 32'd1
+);
+  timeunit 1ns;
+  timeprecision 10ps;
+
+  localparam time CyclTime = 10ns;
+  localparam time ApplTime = 2ns;
+  localparam time TestTime = 8ns;
+
+  typedef logic [15:0] payload_t;
+
+
+  // Signals
+  logic     clk,       rst_n,      sim_done;
+  payload_t req,       resp,       mem_req,       mem_resp;
+  logic     req_valid, resp_valid, mem_req_valid, mem_resp_valid;
+  logic     req_ready, resp_ready, mem_req_ready;
+
+  // check FIFO
+  payload_t data_fifo[$];
+
+  // Generate Stream data
+  initial begin : proc_stream_master
+    automatic payload_t    test_data;
+    automatic int unsigned stall_cycles;
+    @(posedge rst_n);
+    req       = '0;
+    req_valid = '0;
+    repeat (5) @(posedge clk);
+    for (int unsigned i = 0; i < NumReq; i++) begin
+      stall_cycles = $urandom_range(0, 5);
+      repeat (stall_cycles) @(posedge clk);
+      test_data = payload_t'($urandom());
+      data_fifo.push_back(test_data);
+      req       <= #ApplTime payload_t'(test_data);
+      req_valid <= #ApplTime 1'b1;
+      #TestTime;
+      while (!req_ready) begin
+        @(posedge clk);
+        #TestTime;
+      end
+      @(posedge clk);
+      req       <= #ApplTime '0;
+      req_valid <= #ApplTime 1'b0;
+    end
+  end
+
+  // consume stream data and check that the result matches
+  initial begin : proc_stream_slave
+    automatic int unsigned stall_cycles;
+    automatic payload_t    test_data;
+    automatic int unsigned num_tested = 32'd0;
+    sim_done = 0;
+    @(posedge rst_n);
+    resp_ready = '0;
+    repeat (5) @(posedge clk);
+    while (num_tested < NumReq) begin
+      resp_ready <= #ApplTime $urandom();
+      #TestTime;
+      if (resp_valid && resp_ready) begin
+        test_data = data_fifo.pop_front();
+        assert(test_data === resp) else $error("test_data: %h, resp_data: %0h", test_data, resp);
+        num_tested++;
+      end
+      @(posedge clk);
+    end
+    repeat (50) @(posedge clk);
+    sim_done = 1'b1;
+  end
+
+  // reflect the payload exactly `BufDepth` Cycles later, standin for memory
+  initial begin : proc_mem_reflect
+    automatic payload_t reflect_fifo[$];
+    @(posedge rst_n);
+    mem_req_ready  = '0;
+    mem_resp       = '0;
+    mem_resp_valid = '0;
+    forever begin
+      mem_req_ready <= #ApplTime $urandom();
+      #(CyclTime / 2);
+      if (mem_req_valid && mem_req_ready) begin
+        reflect_fifo.push_back(mem_req);
+        // respond with a one cycle pule BufDepth cycles later
+        fork
+          begin
+            if (BufDepth) begin
+              repeat (BufDepth) @(posedge clk);
+              #ApplTime;
+            end
+            mem_resp       = reflect_fifo.pop_front();
+            mem_resp_valid = 1'b1;
+            @(posedge clk);
+            #(ApplTime / 2);
+            mem_resp_valid = 1'b0;
+          end
+        join_none
+      end
+      @(posedge clk);
+    end
+  end
+
+  // stop the simulation
+  initial begin : proc_sim_stop
+    @(posedge rst_n);
+    wait (sim_done);
+    $stop();
+  end
+
+  // CLK generator
+  clk_rst_gen #(
+    .CLK_PERIOD     ( CyclTime ),
+    .RST_CLK_CYCLES ( 10       )
+  ) i_clk_rst_gen (
+    .clk_o  ( clk   ),
+    .rst_no ( rst_n )
+  );
+
+  // DUT
+  stream_to_mem #(
+    .mem_req_t  ( payload_t ),
+    .mem_resp_t ( payload_t ),
+    .BufDepth   ( BufDepth  )
+  ) i_stream_to_mem_dut (
+    .clk_i            ( clk            ),
+    .rst_ni           ( rst_n          ),
+    .req_i            ( req            ),
+    .req_valid_i      ( req_valid      ),
+    .req_ready_o      ( req_ready      ),
+    .resp_o           ( resp           ),
+    .resp_valid_o     ( resp_valid     ),
+    .resp_ready_i     ( resp_ready     ),
+    .mem_req_o        ( mem_req        ),
+    .mem_req_valid_o  ( mem_req_valid  ),
+    .mem_req_ready_i  ( mem_req_ready  ),
+    .mem_resp_i       ( mem_resp       ),
+    .mem_resp_valid_i ( mem_resp_valid )
+  );
+
+endmodule


### PR DESCRIPTION
Stream-to-Mem: Allows to use memories with flow control (req/gnt) for requests but without flow
control for output data to be used in streams (valid/ready).