### PR TITLE
assertions: Add assertion header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- assertions: Assertion include header with macros
 
 ### Fixed
 - `stream_register`: Fix `DATA_WIDTH` of instantiated FIFO.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Added
-- assertions: Assertion include header with macros
+- assertions: Assertion include header with macros (from lowrisc)
 
 ### Fixed
 - `stream_register`: Fix `DATA_WIDTH` of instantiated FIFO.

--- a/README.md
+++ b/README.md
@@ -113,22 +113,38 @@ The header file `registers.svh` contains macros that expand to descriptions of r
 To avoid misuse of `always_ff` blocks, only the following macros shall be used to describe sequential behavior.
 The use of linter rules that flag explicit uses of `always_ff` in source code is encouraged.
 
-| Macro                 | Arguments                                                       | Description                                                             |
-|-----------------------|-----------------------------------------------------------------|-------------------------------------------------------------------------|
-| <code>\`FF</code>     | `q_sig`, `d_sig`, `rst_val`                                     | Flip-flop with asynchronous active-low reset (implicit)                 |
-| <code>\`FFAR</code>   | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `arst_sig`              | Flip-flop with asynchronous active-high reset                           |
-| <code>\`FFARN</code>  | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `arstn_sig`             | Flip-flop with asynchronous active-low reset                            |
-| <code>\`FFSR</code>   | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `rst_sig`               | Flip-flop with synchronous active-high reset                            |
-| <code>\`FFSRN</code>  | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `rstn_sig`              | Flip-flop with synchronous active-low reset                             |
-| <code>\`FFNR</code>   | `q_sig`, `d_sig`, `clk_sig`                                     | Flip-flop without reset                                                 |
-|                       |                                                                 |                                                                         |
-| <code>\`FFL</code>    | `q_sig`, `d_sig`, `load_ena`, `rst_val`                         | Flip-flop with load-enable and asynchronous active-low reset (implicit) |
-| <code>\`FFLAR</code>  | `q_sig`, `d_sig`, `load_ena`, `rst_val`, `clk_sig`, `arst_sig`  | Flip-flop with load-enable and asynchronous active-high reset           |
-| <code>\`FFLARN</code> | `q_sig`, `d_sig`, `load_ena`, `rst_val`, `clk_sig`, `arstn_sig` | Flip-flop with load-enable and asynchronous active-low reset            |
-| <code>\`FFLSR</code>  | `q_sig`, `d_sig`, `load_ena`, `rst_val`, `clk_sig`, `rst_sig`   | Flip-flop with load-enable and synchronous active-high reset            |
-| <code>\`FFLSRN</code> | `q_sig`, `d_sig`, `load_ena`, `rst_val`, `clk_sig`, `rstn_sig`  | Flip-flop with load-enable and synchronous active-low reset             |
-| <code>\`FFLNR</code>  | `q_sig`, `d_sig`, `load_ena`, `clk_sig`                         | Flip-flop with load-enable without reset                                |
+|    Macro     |                            Arguments                            |                               Description                               |
+| ------------ | --------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `` `FF``     | `q_sig`, `d_sig`, `rst_val`                                     | Flip-flop with asynchronous active-low reset (implicit)                 |
+| `` `FFAR``   | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `arst_sig`              | Flip-flop with asynchronous active-high reset                           |
+| `` `FFARN``  | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `arstn_sig`             | Flip-flop with asynchronous active-low reset                            |
+| `` `FFSR``   | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `rst_sig`               | Flip-flop with synchronous active-high reset                            |
+| `` `FFSRN``  | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `rstn_sig`              | Flip-flop with synchronous active-low reset                             |
+| `` `FFNR``   | `q_sig`, `d_sig`, `clk_sig`                                     | Flip-flop without reset                                                 |
+|              |                                                                 |                                                                         |
+| `` `FFL``    | `q_sig`, `d_sig`, `load_ena`, `rst_val`                         | Flip-flop with load-enable and asynchronous active-low reset (implicit) |
+| `` `FFLAR``  | `q_sig`, `d_sig`, `load_ena`, `rst_val`, `clk_sig`, `arst_sig`  | Flip-flop with load-enable and asynchronous active-high reset           |
+| `` `FFLARN`` | `q_sig`, `d_sig`, `load_ena`, `rst_val`, `clk_sig`, `arstn_sig` | Flip-flop with load-enable and asynchronous active-low reset            |
+| `` `FFLSR``  | `q_sig`, `d_sig`, `load_ena`, `rst_val`, `clk_sig`, `rst_sig`   | Flip-flop with load-enable and synchronous active-high reset            |
+| `` `FFLSRN`` | `q_sig`, `d_sig`, `load_ena`, `rst_val`, `clk_sig`, `rstn_sig`  | Flip-flop with load-enable and synchronous active-low reset             |
+| `` `FFLNR``  | `q_sig`, `d_sig`, `load_ena`, `clk_sig`                         | Flip-flop with load-enable without reset                                |
 - *The name of the clock and reset signals for implicit variants is `clk_i` and `rst_ni`, respectively.*
 - *Argument suffix `_sig` indicates signal names for present and next state as well as clocks and resets.*
 - *Argument `rst_val` specifies the value literal to be assigned upon reset.*
 - *Argument `load_ena` specifies the boolean expression that forms the load enable of the register.*
+
+### SystemVerilog Assertion Macros
+
+The header file `assertions.svh` contains macros that expand to assertion blocks.
+These macros should recduce the effort in writing many assertions and make it
+easier to use them.
+
+|        Macro        |                    Arguments                    |                                     Description                                     |
+| ------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `` `ASSERT``        | `__cond`, `__label`                             | Immediate assertion                                                                 |
+| `` `ASSERT_ERR``    | `__cond`, `__err`, `__label`                    | Immediate assertion with custom error message                                       |
+| `` `ASSERTC``       | `__prop`, `__label`                             | Concurrent clocked assertion with implicit clock and reset                          |
+| `` `ASSERTC_ERR``   | `__prop`, `__err`, `__label`                    | Concurrent clocked assertion with implicit clock and reset and custom error message |
+| `` `ASSERTC_CR``    | `__prop`, `__clk`, `__rstn`, `__label`          | Concurrent clocked assertion                                                        |
+| `` `ASSERTC_CRERR`` | `__prop`, `__clk`, `__rstn`, `__err`, `__label` | Concurrent clocked assertion with custom error message                              |
+- *The name of the clock and reset signals for implicit variants is `clk_i` and `rst_ni`, respectively.*

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 
 ### Clocks and Resets
 
-| Name                    | Description                                         | Status       | Superseded By |
+|           Name          |                     Description                     |    Status    | Superseded By |
 |-------------------------|-----------------------------------------------------|--------------|---------------|
 | `clk_div`               | Clock divider with integer divisor                  | active       |               |
 | `clock_divider`         | Clock divider with configuration registers          | *deprecated* | `clk_div`     |
@@ -43,7 +43,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 
 ### Counters and Shift Registers
 
-| Name                | Description                                                       | Status       | Superseded By |
+|         Name        |                   Description                                     |    Status    | Superseded By |
 |---------------------|-------------------------------------------------------------------|--------------|---------------|
 | `counter`           | Generic up/down counter with overflow detection                   | active       |               |
 | `delta_counter`     | Up/down counter with variable delta and overflow detection        | active       |               |
@@ -113,8 +113,8 @@ The header file `registers.svh` contains macros that expand to descriptions of r
 To avoid misuse of `always_ff` blocks, only the following macros shall be used to describe sequential behavior.
 The use of linter rules that flag explicit uses of `always_ff` in source code is encouraged.
 
-| Macro        | Arguments                                                       | Description                                                             |
-|--------------|-----------------------------------------------------------------|-------------------------------------------------------------------------|
+|    Macro     |                            Arguments                            |                               Description                               |
+| ------------ | --------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `` `FF``     | `q_sig`, `d_sig`, `rst_val`                                     | Flip-flop with asynchronous active-low reset (implicit)                 |
 | `` `FFAR``   | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `arst_sig`              | Flip-flop with asynchronous active-high reset                           |
 | `` `FFARN``  | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `arstn_sig`             | Flip-flop with asynchronous active-low reset                            |

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ The header file `registers.svh` contains macros that expand to descriptions of r
 To avoid misuse of `always_ff` blocks, only the following macros shall be used to describe sequential behavior.
 The use of linter rules that flag explicit uses of `always_ff` in source code is encouraged.
 
-|    Macro     |                            Arguments                            |                               Description                               |
-| ------------ | --------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Macro        | Arguments                                                       | Description                                                             |
+|--------------|-----------------------------------------------------------------|-------------------------------------------------------------------------|
 | `` `FF``     | `q_sig`, `d_sig`, `rst_val`                                     | Flip-flop with asynchronous active-low reset (implicit)                 |
 | `` `FFAR``   | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `arst_sig`              | Flip-flop with asynchronous active-high reset                           |
 | `` `FFARN``  | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `arstn_sig`             | Flip-flop with asynchronous active-low reset                            |
@@ -137,14 +137,42 @@ The use of linter rules that flag explicit uses of `always_ff` in source code is
 
 The header file `assertions.svh` contains macros that expand to assertion blocks.
 These macros should recduce the effort in writing many assertions and make it
-easier to use them.
+easier to use them. They are identical with the macros used by [lowrisc](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_assert.sv)
+and just re-implemented here for the sake of easier use in PULP projects (the same include guard is used so they should not clash).
 
-|        Macro        |                    Arguments                    |                                     Description                                     |
-| ------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `` `ASSERT``        | `__cond`, `__label`                             | Immediate assertion                                                                 |
-| `` `ASSERT_ERR``    | `__cond`, `__err`, `__label`                    | Immediate assertion with custom error message                                       |
-| `` `ASSERTC``       | `__prop`, `__label`                             | Concurrent clocked assertion with implicit clock and reset                          |
-| `` `ASSERTC_ERR``   | `__prop`, `__err`, `__label`                    | Concurrent clocked assertion with implicit clock and reset and custom error message |
-| `` `ASSERTC_CR``    | `__prop`, `__clk`, `__rstn`, `__label`          | Concurrent clocked assertion                                                        |
-| `` `ASSERTC_CRERR`` | `__prop`, `__clk`, `__rstn`, `__err`, `__label` | Concurrent clocked assertion with custom error message                              |
+#### Simple Assertion and Cover Macros
+| Macro              | Arguments                              | Description                                                                |
+|--------------------|----------------------------------------|----------------------------------------------------------------------------|
+| `` `ASSERT_I``     | `__name`, `__prop`                     | Immediate assertion                                                        |
+| `` `ASSERT_INIT``  | `__name`, `__prop`                     | Assertion in initial block. Can be used for things like parameter checking |
+| `` `ASSERT_FINAL`` | `__name`, `__prop`                     | Assertion in final block                                                   |
+| `` `ASSERT``       | `__name`, `__prop`, (`__clk`, `__rst`) | Assert a concurrent property directly                                      |
+| `` `ASSERT_NEVER`` | `__name`, `__prop`, (`__clk`, `__rst`) | Assert a concurrent property NEVER happens                                 |
+| `` `ASSERT_KNOWN`` | `__name`, `__sig`, (`__clk`, `__rst`)  | Concurrent clocked assertion with custom error message                     |
+| `` `COVER``        | `__name`, `__prop`, (`__clk`, `__rst`) | Cover a concurrent property                                                |
+- *The name of the clock and reset signals for implicit variants is `clk_i` and `rst_ni`, respectively.*
+
+#### Complex Assertion Macros
+| Macro                 | Arguments                                          | Description                                                                                       |
+|-----------------------|----------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `` `ASSERT_PULSE``    | `__name`, `__sig`, (`__clk`, `__rst`)              | Assert that signal is an active-high pulse with pulse length of 1 clock cycle                     |
+| `` `ASSERT_IF``       | `__name`, `__prop`, `__enable`, (`__clk`, `__rst`) | Assert that a property is true only when an enable signal is set                                  |
+| `` `ASSERT_KNOWN_IF`` | `__name`, `__sig`, `__enable`, (`__clk`, `__rst`)  | Assert that signal has a known value (each bit is either '0' or '1') after reset if enable is set |
+- *The name of the clock and reset signals for implicit variants is `clk_i` and `rst_ni`, respectively.*
+
+#### Assumption Macros
+
+| Macro          | Arguments                              | Description                  |
+|----------------|----------------------------------------|------------------------------|
+| `` `ASSUME``   | `__name`, `__prop`, (`__clk`, `__rst`) | Assume a concurrent property |
+| `` `ASSUME_I`` | `__name`, `__prop`                     | Assume an immediate property |
+- *The name of the clock and reset signals for implicit variants is `clk_i` and `rst_ni`, respectively.*
+
+#### Formal Verification Macros
+
+| Macro              | Arguments                              | Description                                                  |
+|--------------------|----------------------------------------|--------------------------------------------------------------|
+| `` `ASSUME_FPV``   | `__name`, `__prop`, (`__clk`, `__rst`) | Assume a concurrent property during formal verification only |
+| `` `ASSUME_I_FPV`` | `__name`, `__prop`                     | Assume a concurrent property during formal verification only |
+| `` `COVER_FPV``    | `__name`, `__prop`, (`__clk`, `__rst`) | Cover a concurrent property during formal verification       |
 - *The name of the clock and reset signals for implicit variants is `clk_i` and `rst_ni`, respectively.*

--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -1,0 +1,113 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Stefan Mach <smach@iis.ee.ethz.ch>
+
+// Common assertion and coverage defines for RTL designs
+`ifndef COMMON_CELLS_ASSERTIONS_SVH_
+`define COMMON_CELLS_ASSERTIONS_SVH_
+
+// Abridged Summary of available assertion and coverage macros:
+// `ASSERT:         immediate
+// `ASSERT_ERR:     immediate with custom error message
+// `ASSERTC:        concurrent clocked with implicit clock and reset
+// `ASSERTC_ERR:    concurrent clocked with implicit clock and reset and custom error message
+// `ASSERTC_CR:     concurrent clocked
+// `ASSERTC_CRERR:  concurrent clocked with custom error message
+
+
+// Immediate assertion
+// __cond: Boolean expression that is asserted
+// __label: Label to give this assertion
+`define ASSERT(__cond, __label) \
+  /``* pragma translate_off *``/ \
+`ifndef VERILATOR \
+  initial begin \
+    __label : assert (__cond) else $error(`"__cond`"); \
+  end \
+`endif \
+  /``* pragma translate_on *``/
+
+// Immediate assertion with custom error message
+// __cond: Boolean expression that is asserted
+// __err: String containing the error message
+// __label: Label to give this assertion
+`define ASSERT_ERR(__cond, __err, __label) \
+  /``* pragma translate_off *``/ \
+`ifndef VERILATOR \
+  initial begin \
+    __label : assert (__cond) else $error(`"__err`"); \
+  end \
+`endif \
+  /``* pragma translate_on *``/
+
+// Concurrent clocked assertion with implicit clock and reset
+// __prop: Property expression
+// __label: Label to give this assertion
+// Implicit:
+// clk_i: clock signal
+// rst_ni: reset signal (active low)
+`define ASSERTC(__prop, __label) \
+  /``* pragma translate_off *``/ \
+`ifndef VERILATOR \
+  __label : assert property (@(posedge clk_i) disable iff (!rst_ni) \
+                             __prop) \
+      else $error(`"__prop`"); \
+`endif \
+  /``* pragma translate_on *``/
+
+// Concurrent clocked assertion with implicit clock and reset and custom error message
+// __prop: Property expression
+// __err: String containing the error message
+// __label: Label to give this assertion
+// Implicit:
+// clk_i: clock signal
+// rst_ni: reset signal (active low)
+`define ASSERTC_ERR(__prop, __err, __label) \
+  /``* pragma translate_off *``/ \
+`ifndef VERILATOR \
+  __label : assert property (@(posedge clk_i) disable iff (!rst_ni) \
+                             __prop) \
+      else $error(`"__err`"); \
+`endif \
+  /``* pragma translate_on *``/
+
+// Concurrent clocked assertion
+// __prop: Property expression
+// __clk: clock signal
+// __rstn: reset signal (active low)
+// __label: Label to give this assertion
+`define ASSERTC_CR(__prop, __clk, __rstn, __label) \
+  /``* pragma translate_off *``/ \
+`ifndef VERILATOR \
+  __label : assert property (@(posedge __clk) disable iff (!__rstn) \
+                             __prop) \
+      else $error(`"__prop`"); \
+`endif \
+  /``* pragma translate_on *``/
+
+// Concurrent clocked assertion with custom error message
+// __prop: Property expression
+// __err: String containing the error message
+// __clk: clock signal
+// __rstn: reset signal (active low)
+// __label: Label to give this assertion
+`define ASSERTC_CRERR(__prop, __clk, __rstn, __err, __label) \
+  /``* pragma translate_off *``/ \
+`ifndef VERILATOR \
+  __label : assert property (@(posedge __clk) disable iff (!__rstn) \
+                             __prop) \
+      else $error(`"__err`"); \
+`endif \
+  /``* pragma translate_on *``/
+
+`endif
+


### PR DESCRIPTION
Analogously to the register macro definitions in include header
`registers.svh`, this commit adds macro definitions for assertions.