### PR TITLE
Throughput fairness for rr_arb_tree

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -92,6 +92,7 @@ sources:
       - test/graycode_tb.sv
       - test/id_queue_tb.sv
       - test/popcount_tb.sv
+      - test/rr_arb_tree_tb.sv
       - test/stream_test.sv
       - test/stream_register_tb.sv
       - test/stream_to_mem_tb.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - stream_to_mem: Allows to use memories with flow control (req/gnt) for requests but
   without flow control for output data to be used in streams.
 - isochronous_spill_register: Isochronous clock domain crossing cutting all paths.
+- `rr_arb_tree_tb`: Systemverilog testbench for `rr_arb_tree`, which checks for fair throughput.
 
 ### Fixed
 - Improve tool compatibility.
+- `rr_arb_tree`: Add parameter `FairArb` to distribute throughput of input requests evenly when
+  not all inputs have requests active.
 
 ## 1.18.0 - 2020-04-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Improve tool compatibility.
+- `rr_arb_tree`: Properly degenerate `rr_i` and `idx_o` signals.
 - `rr_arb_tree`: Add parameter `FairArb` to distribute throughput of input requests evenly when
   not all inputs have requests active.
 

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -15,11 +15,11 @@
 /// The rr_arb_tree employs non starving round robin arbitration - i.e. the priorities
 /// rotate each cycle.
 module rr_arb_tree #(
-  /// Number of handshaked inputs which get arbitrated.
+  /// Number of inputs to be arbitrated.
   parameter int unsigned NumIn      = 64,
   /// Data width of the payload in bits. Not needed if `DataType` is overwritten.
   parameter int unsigned DataWidth  = 32,
-  /// Data type of the payload, can be overwritten with custom type.
+  /// Data type of the payload, can be overwritten with custom type. Only use of `DataWidth`.
   parameter type         DataType   = logic [DataWidth-1:0],
   /// The `ExtPrio` option allows to override the internal round robin counter via the
   /// `rr_i` signal. This can be useful in case multiple arbiters need to have
@@ -41,23 +41,38 @@ module rr_arb_tree #(
   parameter bit          LockIn     = 1'b0,
   /// When set, ensures that throughput gets distributed evenly between all inputs.
   /// Set to `1'b0` to disable.
-  parameter bit          FairArb    = 1'b1
+  parameter bit          FairArb    = 1'b1,
+  /// Dependent parameter, do **not** overwrite.
+  /// Width of the arbitration priority signal and the arbitrated index.
+  parameter int unsigned IdxWidth   = (NumIn > 32'd1) ? unsigned'($clog2(NumIn)) : 32'd1,
+  /// Dependent parameter, do **not** overwrite.
+  /// Type for defining the arbitration priority and arbitrated index signal.
+  parameter type         idx_t      = logic [IdxWidth-1:0]
 ) (
-  input  logic                             clk_i,
-  input  logic                             rst_ni,
-  input  logic                             flush_i, // clears the arbiter state
-  input  logic [$clog2(NumIn)-1:0]         rr_i,    // external RR prio (needs to be enabled above)
-  // input requests and data
-  input  logic [NumIn-1:0]                 req_i,
+  /// Clock, positive edge triggered.
+  input  logic                clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                rst_ni,
+  /// Clears the arbiter state. Only used if `ExtPrio` is `1'b0` or `LockIn` is `1'b1`.
+  input  logic                flush_i,
+  /// External round-robin priority. Only used if `ExtPrio` is `1'b1.`
+  input  idx_t                rr_i,
+  /// Input requests arbitration.
+  input  logic    [NumIn-1:0] req_i,
   /* verilator lint_off UNOPTFLAT */
-  output logic [NumIn-1:0]                 gnt_o,
+  /// Input request is granted.
+  output logic    [NumIn-1:0] gnt_o,
   /* verilator lint_on UNOPTFLAT */
-  input  DataType [NumIn-1:0]              data_i,
-  // arbitrated output
-  input  logic                             gnt_i,
-  output logic                             req_o,
-  output DataType                          data_o,
-  output logic [$clog2(NumIn)-1:0]         idx_o
+  /// Input data for arbitration.
+  input  DataType [NumIn-1:0] data_i,
+  /// Output request is valid.
+  output logic                req_o,
+  /// Output request is granted.
+  input  logic                gnt_i,
+  /// Output data.
+  output DataType             data_o,
+  /// Index from which input the data came from.
+  output idx_t                idx_o
 );
 
   // pragma translate_off
@@ -75,16 +90,16 @@ module rr_arb_tree #(
     assign idx_o    = '0;
   // non-degenerate cases
   end else begin
-    localparam int unsigned NumLevels = $clog2(NumIn);
+    localparam int unsigned NumLevels = unsigned'($clog2(NumIn));
 
     /* verilator lint_off UNOPTFLAT */
-    logic [2**NumLevels-2:0][NumLevels-1:0]  index_nodes; // used to propagate the indices
-    DataType [2**NumLevels-2:0]              data_nodes;  // used to propagate the data
-    logic [2**NumLevels-2:0]                 gnt_nodes;   // used to propagate the grant to masters
-    logic [2**NumLevels-2:0]                 req_nodes;   // used to propagate the requests to slave
+    idx_t    [2**NumLevels-2:0] index_nodes; // used to propagate the indices
+    DataType [2**NumLevels-2:0] data_nodes;  // used to propagate the data
+    logic    [2**NumLevels-2:0] gnt_nodes;   // used to propagate the grant to masters
+    logic    [2**NumLevels-2:0] req_nodes;   // used to propagate the requests to slave
     /* lint_off */
-    logic [NumLevels-1:0]                    rr_q;
-    logic [NumIn-1:0]                        req_d;
+    idx_t                       rr_q;
+    logic [NumIn-1:0]           req_d;
 
     // the final arbitration decision can be taken from the root of the tree
     assign req_o        = req_nodes[0];
@@ -95,7 +110,7 @@ module rr_arb_tree #(
       assign rr_q       = rr_i;
       assign req_d      = req_i;
     end else begin : gen_int_rr
-      logic [NumLevels-1:0] rr_d;
+      idx_t rr_d;
 
       // lock arbiter decision in case we got at least one req and no acknowledge
       if (LockIn) begin : gen_lock
@@ -120,14 +135,16 @@ module rr_arb_tree #(
         // pragma translate_off
         `ifndef VERILATOR
           lock: assert property(
-            @(posedge clk_i) LockIn |-> req_o && !gnt_i |=> idx_o == $past(idx_o))
-              else $fatal (1, "Lock implies same arbiter decision in next cycle if output is not ready.");
+            @(posedge clk_i) LockIn |-> req_o && !gnt_i |=> idx_o == $past(idx_o)) else
+                $fatal (1, "Lock implies same arbiter decision in next cycle if output is not \
+                            ready.");
 
           logic [NumIn-1:0] req_tmp;
           assign req_tmp = req_q & req_i;
           lock_req: assume property(
-            @(posedge clk_i) LockIn |-> lock_d |=> req_tmp == req_q)
-              else $fatal (1, "It is disallowed to deassert unserved request signals when LockIn is enabled.");
+            @(posedge clk_i) LockIn |-> lock_d |=> req_tmp == req_q) else
+                $fatal (1, "It is disallowed to deassert unserved request signals when LockIn is \
+                            enabled.");
         `endif
         // pragma translate_on
 
@@ -147,9 +164,9 @@ module rr_arb_tree #(
       end
 
       if (FairArb) begin : gen_fair_arb
-        logic [NumIn-1:0]     upper_mask,  lower_mask;
-        logic [NumLevels-1:0] upper_idx,   lower_idx,   next_idx;
-        logic                 upper_empty, lower_empty;
+        logic [NumIn-1:0] upper_mask,  lower_mask;
+        idx_t             upper_idx,   lower_idx,   next_idx;
+        logic             upper_empty, lower_empty;
 
         for (genvar i = 0; i < NumIn; i++) begin : gen_mask
           assign upper_mask[i] = (i >  rr_q) ? req_d[i] : 1'b0;
@@ -178,7 +195,7 @@ module rr_arb_tree #(
         assign rr_d     = (gnt_i && req_o) ? next_idx  : rr_q;
 
       end else begin : gen_unfair_arb
-        assign rr_d = (gnt_i && req_o) ? ((rr_q == NumLevels'(NumIn-1)) ? '0 : rr_q + 1'b1) : rr_q;
+        assign rr_d = (gnt_i && req_o) ? ((rr_q == idx_t'(NumIn-1)) ? '0 : rr_q + 1'b1) : rr_q;
       end
 
       // this holds the highest priority
@@ -215,7 +232,7 @@ module rr_arb_tree #(
             // arbitration: round robin
             assign sel =  ~req_d[l*2] | req_d[l*2+1] & rr_q[NumLevels-1-level];
 
-            assign index_nodes[idx0] = NumLevels'(sel);
+            assign index_nodes[idx0] = idx_t'(sel);
             assign data_nodes[idx0]  = (sel) ? data_i[l*2+1] : data_i[l*2];
             assign gnt_o[l*2]        = gnt_nodes[idx0] & (AxiVldRdy | req_d[l*2])   & ~sel;
             assign gnt_o[l*2+1]      = gnt_nodes[idx0] & (AxiVldRdy | req_d[l*2+1]) & sel;
@@ -241,8 +258,8 @@ module rr_arb_tree #(
           // arbitration: round robin
           assign sel =  ~req_nodes[idx1] | req_nodes[idx1+1] & rr_q[NumLevels-1-level];
 
-          assign index_nodes[idx0] = (sel) ? NumLevels'({1'b1, index_nodes[idx1+1][NumLevels-unsigned'(level)-2:0]}) :
-                                             NumLevels'({1'b0, index_nodes[idx1][NumLevels-unsigned'(level)-2:0]});
+          assign index_nodes[idx0] = (sel) ? idx_t'({1'b1, index_nodes[idx1+1][NumLevels-unsigned'(level)-2:0]}) :
+                                             idx_t'({1'b0, index_nodes[idx1][NumLevels-unsigned'(level)-2:0]});
           assign data_nodes[idx0]  = (sel) ? data_nodes[idx1+1] : data_nodes[idx1];
           assign gnt_nodes[idx1]   = gnt_nodes[idx0] & ~sel;
           assign gnt_nodes[idx1+1] = gnt_nodes[idx0] & sel;

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -9,10 +9,11 @@
 // specific language governing permissions and limitations under the License.
 //
 // Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+//         Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>, ETH Zurich
 // Date: 02.04.2019
 // Description: logarithmic arbitration tree with round robin arbitration scheme.
 
-/// The rr_arb_tree employs non starving round robin arbitration - i.e. the priorities
+/// The rr_arb_tree employs non-starving round robin-arbitration - i.e., the priorities
 /// rotate each cycle.
 ///
 /// ## Fair vs. unfair Arbitration
@@ -24,26 +25,25 @@
 /// request. Otherwise a *random* other active input is selected. The parameter `FairArb` is used
 /// to distinguish between two methods of calculating the next state.
 /// * `1'b0`: The next state is calculated by advancing the current state by one. This leads to the
-///           state be being calculated without context of the active request. Leading to
+///           state being calculated without the context of the active request. Leading to an
 ///           unfair throughput distribution if not all inputs have active requests.
 /// * `1'b1`: The next state jumps to the next unserved request with higher index.
 ///           This is achieved by using two trailing-zero-counters (`lzc`). The upper has the masked
-///           `req_i` signal with all indicies which will have a higher priority in the next state.
+///           `req_i` signal with all indices which will have a higher priority in the next state.
 ///           The trailing zero count defines the input index with the next highest priority after
 ///           the current one is served. When the upper is empty the lower `lzc` provides the
 ///           wrapped index if there are outstanding requests with lower or same priority.
 /// The implication of throughput fairness on the module timing are:
 /// * The trailing zero counter (`lzc`) has a loglog relation of input to output timing. This means
-///   that in this module the input to register path scales also with Log(Log(O)) in relation to
-///   the number of inputs.
+///   that in this module the input to register path scales with Log(Log(`NumIn`)).
 /// * The `rr_arb_tree` data multiplexing scales with Log(O). This means that the input to output
 ///   timing path of this module also scales scales with Log(O).
 /// This implies that in this module the input to output path is always longer than the input to
 /// register path. As the output data usually also terminates in a register the parameter `FairArb`
-/// only has implications on the area. When it is `1'b0`a static plus one adder is instantiated.
+/// only has implications on the area. When it is `1'b0` a static plus one adder is instantiated.
 /// If it is `1'b1` two `lzc`, a masking logic stage and a two input multiplexer are instantiated.
 /// However these are small in respect of the data multiplexers needed, as the width of the `req_i`
-/// signal is usually less as the `DataWidth`.
+/// signal is usually less as than `DataWidth`.
 module rr_arb_tree #(
   /// Number of inputs to be arbitrated.
   parameter int unsigned NumIn      = 64,

--- a/test/rr_arb_tree_tb.sv
+++ b/test/rr_arb_tree_tb.sv
@@ -10,8 +10,6 @@
 
 // Author: Wolfgang Roennigner <wroennin@iis.ee.ethz.ch>
 
-timeunit 1ns/1ps;
-
 /// Testbench for the module `rr_arb_tree`
 module rr_arb_tree_tb #(
   /// Number of input streams to the DUT
@@ -212,7 +210,8 @@ module rr_arb_tree_tb #(
           exp_through = real'(1)/real'(j);
           error       = throughput - exp_through;
           if (FairArb && LockIn) begin
-            assert(error < error_threshold && error > -error_threshold);
+            assert(error < error_threshold && error > -error_threshold) else
+                $warning("Line: %0d is unfair!");
           end
           $display("Line: %0d, TotActice: %0d Throughput: %0f Ideal: %0f Diff: %0f",
               i, j, throughput, exp_through, error);        end

--- a/test/rr_arb_tree_tb.sv
+++ b/test/rr_arb_tree_tb.sv
@@ -1,0 +1,266 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roennigner <wroennin@iis.ee.ethz.ch>
+
+timeunit 1ns/1ps;
+
+/// Testbench for the module `rr_arb_tree`
+module rr_arb_tree_tb #(
+  /// Number of input streams to the DUT
+  parameter int unsigned NumInp    = 32'd7,
+  /// Number of requests per input
+  parameter int unsigned NumReqs   = 32'd20000,
+  /// Handshaking as in AXI
+  parameter bit          AxiVldRdy = 1'b1,
+  /// Do not deassert the input request
+  parameter bit          LockIn    = 1'b1,
+  /// Enable fair arbitration, when disabled, no assertion for fairness
+  parameter bit          FairArb   = 1'b1
+);
+
+  localparam time CyclTime = 10ns;
+  localparam time ApplTime = 2ns;
+  localparam time TestTime = 8ns;
+
+  // throw an error if the measured throughput and expected throughput differ
+  // more than this value
+  localparam real error_threshold = 0.1;
+
+  localparam int unsigned IdxWidth  = $clog2(NumInp);
+  localparam int unsigned DataWidth = 32'd45;
+  typedef logic [IdxWidth-1:0]  idx_t;
+  typedef logic [DataWidth-1:0] data_t;
+
+  // clock signal
+  logic               clk;
+  logic               rst_n;
+  logic               flush;
+  idx_t               rr,       idx;
+  logic  [NumInp-1:0] req_inp,  gnt_inp, end_of_sim;
+  data_t [NumInp-1:0] data_inp;
+  logic               req_oup,  gnt_oup;
+  data_t              data_oup;
+
+  // clock and rst gen
+  clk_rst_gen #(
+    .CLK_PERIOD     ( CyclTime ),
+    .RST_CLK_CYCLES ( 5        )
+  ) i_clk_rst_gen (
+    .clk_o  ( clk   ),
+    .rst_no ( rst_n )
+  );
+
+  // drive input streams
+  // Can not use `stream_driver`, as this also tests for requests taken away.
+  for (genvar i = 0; i < NumInp; i++) begin : gen_stream_gen
+    initial begin : proc_stream_gen
+      automatic data_t       stimuli;
+      automatic int unsigned rand_wait;
+
+      end_of_sim[i] = 1'b0;
+      @(posedge rst_n);
+      data_inp[i] = '0;
+      req_inp[i]  = 1'b0;
+
+      // First have them continuously active for a number of time
+      for (int unsigned j = 0; j < (i+1) * NumReqs; j++) begin
+        data_inp[i] <= #ApplTime data_t'(i);
+        req_inp[i]  <= #ApplTime 1'b1;
+        @(posedge clk);
+      end
+      data_inp[i] <= #ApplTime '0;
+      req_inp[i]  <= #ApplTime 1'b0;
+
+      // wait until all other processes have their fixed request finished.
+      repeat ((NumInp-i)*NumReqs) @(posedge clk);
+      repeat (1000) @(posedge clk);
+
+      // First have them continuously active for a number of time
+      for (int unsigned j = 0; j < (NumInp-i) * NumReqs; j++) begin
+        data_inp[i] <= #ApplTime data_t'(i);
+        req_inp[i]  <= #ApplTime 1'b1;
+        @(posedge clk);
+      end
+      data_inp[i] <= #ApplTime '0;
+      req_inp[i]  <= #ApplTime 1'b0;
+
+      repeat ((1+i)*NumReqs) @(posedge clk);
+      repeat (1000) @(posedge clk);
+
+      // First have them continuously active for a number of time
+      for (int unsigned j = 0; j < (NumInp-i) * NumReqs; j++) begin
+        if ((i % 2) == 0) begin
+          data_inp[i] <= #ApplTime data_t'(i);
+          req_inp[i]  <= #ApplTime 1'b1;
+        end
+        @(posedge clk);
+      end
+      data_inp[i] <= #ApplTime '0;
+      req_inp[i]  <= #ApplTime 1'b0;
+
+      repeat ((1+i)*NumReqs) @(posedge clk);
+      repeat (1000) @(posedge clk);
+
+
+      // have random stimuli
+      for (int unsigned j = 0; j < NumReqs; j++) begin
+        data_inp[i] <= #ApplTime new_stimuli();
+        req_inp[i]  <= #ApplTime 1'b1;
+        rand_wait = $urandom_range(1, 2*NumInp);
+        if (LockIn) begin
+          #TestTime;
+          while (!gnt_inp[i]) begin
+            @(posedge clk);
+            #TestTime;
+          end
+        end else begin
+          repeat (rand_wait) @(posedge clk);
+        end
+        @(posedge clk);
+        data_inp[i] <= #ApplTime '0;
+        req_inp[i]  <= #ApplTime 1'b0;
+
+        rand_wait = $urandom_range(0, NumInp);
+        repeat (rand_wait) @(posedge clk);
+      end
+
+      end_of_sim[i] = 1'b1;
+    end
+  end
+
+  function data_t new_stimuli();
+    for (int unsigned i = 0; i < DataWidth; i++) begin
+      new_stimuli[i] = $urandom();
+    end
+  endfunction : new_stimuli
+
+  // consume streams
+  initial begin : proc_stream_consume
+    @(posedge rst_n);
+    gnt_oup = 1'b0;
+    forever begin
+      gnt_oup <= #ApplTime 1'b1;
+      @(posedge clk);
+    end
+  end
+
+  // flush sometimes
+  initial begin : proc_flush
+    automatic int unsigned rand_wait;
+    flush = 1'b0;
+    @(posedge rst_n);
+    forever begin
+      rand_wait = $urandom_range(2000, 20000);
+      repeat (rand_wait) @(posedge clk);
+      flush <= #ApplTime 1'b1;
+      @(posedge clk);
+      flush <= #ApplTime 1'b0;
+    end
+  end
+
+  // end simulation
+  initial begin : proc_sim_end
+    @(posedge rst_n);
+    wait (&end_of_sim);
+    repeat (10) @(posedge clk);
+    $stop();
+  end
+
+  // Check throughput
+  for (genvar i = 0; i < NumInp; i++) begin : gen_throughput_checker
+    initial begin : proc_throughput_checker
+      automatic longint unsigned tot_active [NumInp:1];
+      automatic longint unsigned tot_served [NumInp:1];
+      automatic int     unsigned num_active;
+      automatic real             throughput, exp_through, error;
+      for (int unsigned j = 0; j < NumInp; j++) begin
+       tot_active[j] = 0;
+       tot_served[j] = 0;
+      end
+
+      @(posedge rst_n);
+      while (!(&end_of_sim)) begin
+        #TestTime;
+
+        if (req_inp[i] && gnt_oup) begin
+          num_active = 0;
+          for (int unsigned j = 0; j < NumInp; j++) begin
+            if (req_inp[j]) begin
+              num_active++;
+            end
+          end
+
+          tot_active[num_active] = tot_active[num_active] + 1;
+          if (gnt_inp[i]) begin
+            tot_served[num_active] = tot_served[num_active] + 1;
+          end
+        end
+        @(posedge clk);
+      end
+
+      for (int unsigned j = 1; j <= NumInp; j++) begin
+        if (tot_active[j] > 0) begin
+          throughput  = real'(tot_served[j])/real'(tot_active[j]);
+          exp_through = real'(1)/real'(j);
+          error       = throughput - exp_through;
+          if (FairArb && LockIn) begin
+            assert(error < error_threshold && error > -error_threshold);
+          end
+          $display("Line: %0d, TotActice: %0d Throughput: %0f Ideal: %0f Diff: %0f",
+              i, j, throughput, exp_through, error);        end
+      end
+    end
+  end
+
+  // check data
+  initial begin : proc_check_data
+    automatic data_t data_queues[NumInp-1:0][$];
+    automatic data_t exp_data;
+    forever begin
+      @(posedge clk);
+      #TestTime;
+      // Put exp data into the queues
+      for (int unsigned i = 0; i < NumInp; i++) begin
+        if (req_inp[i] && gnt_inp[i]) begin
+          data_queues[i].push_back(data_inp[i]);
+        end
+      end
+
+      // check that the right data is observed
+      if (req_oup && gnt_oup) begin
+        exp_data = data_queues[idx].pop_front();
+        assert(exp_data === data_oup);
+      end
+    end
+  end
+
+  // DUT
+  rr_arb_tree #(
+    .NumIn     ( NumInp    ),
+    .DataWidth ( DataWidth ),
+    .ExtPrio   ( 1'b0      ),
+    .AxiVldRdy ( AxiVldRdy ),
+    .LockIn    ( LockIn    ),
+    .FairArb   ( FairArb   )
+  ) i_rr_arb_tree_dut (
+    .clk_i  ( clk      ),
+    .rst_ni ( rst_n    ),
+    .flush_i( flush    ),
+    .rr_i   ( '0       ),
+    .req_i  ( req_inp  ),
+    .gnt_o  ( gnt_inp  ),
+    .data_i ( data_inp ),
+    .gnt_i  ( gnt_oup  ),
+    .req_o  ( req_oup  ),
+    .data_o ( data_oup ),
+    .idx_o  ( idx      )
+  );
+endmodule

--- a/test/rr_arb_tree_tb.sv
+++ b/test/rr_arb_tree_tb.sv
@@ -34,7 +34,7 @@ module rr_arb_tree_tb #(
   // more than this value
   localparam real error_threshold = 0.1;
 
-  localparam int unsigned IdxWidth  = $clog2(NumInp);
+  localparam int unsigned IdxWidth  = (NumInp > 32'd1) ? unsigned'($clog2(NumInp)) : 32'd1;
   localparam int unsigned DataWidth = 32'd45;
   typedef logic [IdxWidth-1:0]  idx_t;
   typedef logic [DataWidth-1:0] data_t;

--- a/test/simulate.sh
+++ b/test/simulate.sh
@@ -31,3 +31,7 @@ done
 for depth in 0 1 2; do
 	call_vsim stream_to_mem_tb -GBufDepth=$depth -coverage -voptargs="+acc +cover=bcesfx"
 done
+
+for num in 1 4 7; do
+  call_vsim rr_arb_tree_tb -GNumInp=$num -coverage -voptargs="+acc +cover=bcesfx"
+done


### PR DESCRIPTION
The module `rr_arb_tree` does not distribute the throughput evenly when not all input requests are active.

This adds additional logic, which jumps the internal round robin state to the next active input request in respect to the currently served one.
In addition there is now a dedicated testbench for `rr_arb_tree`, which checks for the throughput and validity of arbitrated data.