### PR TITLE
Isochronous spill register

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -31,6 +31,7 @@ sources:
   - src/exp_backoff.sv
   - src/fifo_v3.sv
   - src/graycode.sv
+  - src/isochronous_spill_register.sv
   - src/lfsr.sv
   - src/lfsr_16bit.sv
   - src/lfsr_8bit.sv
@@ -95,6 +96,8 @@ sources:
       - test/stream_register_tb.sv
       - test/stream_to_mem_tb.sv
       - test/sub_per_hash_tb.sv
+      # Level 1
+      - test/isochronous_spill_register_tb.sv
 
   - target: synth_test
     files:

--- a/Bender.yml
+++ b/Bender.yml
@@ -47,6 +47,7 @@ sources:
   - src/stream_demux.sv
   - src/stream_filter.sv
   - src/stream_fork.sv
+  - src/stream_intf.sv
   - src/stream_join.sv
   - src/stream_mux.sv
   - src/sub_per_hash.sv
@@ -81,6 +82,7 @@ sources:
 
   - target: test
     files:
+      # Level 0
       - test/addr_decode_tb.sv
       - test/cb_filter_tb.sv
       - test/cdc_2phase_tb.sv
@@ -89,6 +91,7 @@ sources:
       - test/graycode_tb.sv
       - test/id_queue_tb.sv
       - test/popcount_tb.sv
+      - test/stream_test.sv
       - test/stream_register_tb.sv
       - test/stream_to_mem_tb.sv
       - test/sub_per_hash_tb.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - stream_to_mem: Allows to use memories with flow control (req/gnt) for requests but
   without flow control for output data to be used in streams.
+- isochronous_spill_register: Isochronous clock domain crossing cutting all paths.
 
 ### Fixed
 - Improve tool compatibility.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 
 ### Clocks and Resets
 
-|           Name          |                     Description                     |    Status    | Superseded By |
+| Name                    | Description                                         | Status       | Superseded By |
 |-------------------------|-----------------------------------------------------|--------------|---------------|
 | `clk_div`               | Clock divider with integer divisor                  | active       |               |
 | `clock_divider`         | Clock divider with configuration registers          | *deprecated* | `clk_div`     |
@@ -25,24 +25,25 @@ Please note that cells with status *deprecated* are not to be used for new desig
 
 ### Clock Domains and Asynchronous Crossings
 
-|         Name         |                                   Description                                    |    Status    | Superseded By |
-|----------------------|----------------------------------------------------------------------------------|--------------|---------------|
-| `cdc_2phase`         | Clock domain crossing using two-phase handshake, with ready/valid interface      | active       |               |
-| `cdc_fifo_2phase`    | Clock domain crossing FIFO using two-phase handshake, with ready/valid interface | active       |               |
-| `cdc_fifo_gray`      | Clock domain crossing FIFO using a gray-counter, with ready/valid interface      | active       |               |
-| `edge_detect`        | Rising/falling edge detector                                                     | active       |               |
-| `edge_propagator`    | **ANTONIO ADD DESCRIPTION**                                                      | active       |               |
-| `edge_propagator_rx` | **ANTONIO ADD DESCRIPTION**                                                      | active       |               |
-| `edge_propagator_tx` | **ANTONIO ADD DESCRIPTION**                                                      | active       |               |
-| `pulp_sync`          | Serial line synchronizer                                                         | *deprecated* | `sync`        |
-| `pulp_sync_wedge`    | Serial line synchronizer with edge detector                                      | *deprecated* | `sync_wedge`  |
-| `serial_deglitch`    | Serial line deglitcher                                                           | active       |               |
-| `sync`               | Serial line synchronizer                                                         | active       |               |
-| `sync_wedge`         | Serial line synchronizer with edge detector                                      | active       |               |
+| Name                         | Description                                                                      | Status       | Superseded By |
+|------------------------------|----------------------------------------------------------------------------------|--------------|---------------|
+| `cdc_2phase`                 | Clock domain crossing using two-phase handshake, with ready/valid interface      | active       |               |
+| `cdc_fifo_2phase`            | Clock domain crossing FIFO using two-phase handshake, with ready/valid interface | active       |               |
+| `cdc_fifo_gray`              | Clock domain crossing FIFO using a gray-counter, with ready/valid interface      | active       |               |
+| `edge_detect`                | Rising/falling edge detector                                                     | active       |               |
+| `edge_propagator`            | **ANTONIO ADD DESCRIPTION**                                                      | active       |               |
+| `edge_propagator_rx`         | **ANTONIO ADD DESCRIPTION**                                                      | active       |               |
+| `edge_propagator_tx`         | **ANTONIO ADD DESCRIPTION**                                                      | active       |               |
+| `isochronous_spill_register` | Isochronous clock domain crossing and full handshake (like `spill_register`)     | active       |               |
+| `pulp_sync`                  | Serial line synchronizer                                                         | *deprecated* | `sync`        |
+| `pulp_sync_wedge`            | Serial line synchronizer with edge detector                                      | *deprecated* | `sync_wedge`  |
+| `serial_deglitch`            | Serial line deglitcher                                                           | active       |               |
+| `sync`                       | Serial line synchronizer                                                         | active       |               |
+| `sync_wedge`                 | Serial line synchronizer with edge detector                                      | active       |               |
 
 ### Counters and Shift Registers
 
-|         Name        |                   Description                                     |    Status    | Superseded By |
+| Name                | Description                                                       | Status       | Superseded By |
 |---------------------|-------------------------------------------------------------------|--------------|---------------|
 | `counter`           | Generic up/down counter with overflow detection                   | active       |               |
 | `delta_counter`     | Up/down counter with variable delta and overflow detection        | active       |               |
@@ -56,6 +57,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 ### Data Path Elements
 
 | Name                         | Description                                                                    | Status         | Superseded By |
+|------------------------------|--------------------------------------------------------------------------------|----------------|---------------|
 | :--------------------------- | :----------------------------------------------------------------------------- | :------------- | :------------ |
 | `addr_decode   `             | Address map decoder                                                            | active         |               |
 | `ecc_decode`                 | SECDED Decoder (Single Error Correction, Double Error Detection)               | active         |               |
@@ -88,6 +90,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 ### Data Structures
 
 | Name                 | Description                                     | Status         | Superseded By |
+|----------------------|-------------------------------------------------|----------------|---------------|
 | :------------------- | :---------------------------------------------- | :------------- | :------------ |
 | `cb_filter`          | Counting-Bloom-Filter with combinational lookup | active         |               |
 | `fifo`               | FIFO register with upper threshold              | *deprecated*   | `fifo_v3`     |
@@ -111,7 +114,7 @@ The header file `registers.svh` contains macros that expand to descriptions of r
 To avoid misuse of `always_ff` blocks, only the following macros shall be used to describe sequential behavior.
 The use of linter rules that flag explicit uses of `always_ff` in source code is encouraged.
 
-|         Macro         |                            Arguments                            |                               Description                               |
+| Macro                 | Arguments                                                       | Description                                                             |
 |-----------------------|-----------------------------------------------------------------|-------------------------------------------------------------------------|
 | <code>\`FF</code>     | `q_sig`, `d_sig`, `rst_val`                                     | Flip-flop with asynchronous active-low reset (implicit)                 |
 | <code>\`FFAR</code>   | `q_sig`, `d_sig`, `rst_val`, `clk_sig`, `arst_sig`              | Flip-flop with asynchronous active-high reset                           |

--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -1,0 +1,87 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+/// A register with handshakes that completely cuts any combinatorial paths
+/// between the input and output in isochronous clock domains.
+///
+/// > Definition of isochronous: In telecommunication, an isochronous signal is a signal
+/// > in which the time interval separating any two significant instants is equal to the
+/// > unit interval or a multiple of the unit interval.
+///
+/// The source and destination clock domains must be derived from the same clock
+/// but can vary in frequency by a constant factor (e.g., double the frequency).
+///
+/// The module is basically a two deep dual-clock fifo with read and write pointers
+/// in different clock domains. As we know the static timing relationship between the
+/// clock domains we can rely on static timing analysis (STA) to get the sampling windows
+/// right and therefore don't need any synchronization.
+module isochronous_spill_register #(
+  /// Data type of spill register.
+  parameter type T      = logic,
+  /// Make this spill register transparent.
+  parameter bit  Bypass = 1'b0
+) (
+  /// Clock of source clock domain.
+  input  logic src_clk_i,
+  /// Active low async reset in source domain.
+  input  logic src_rst_ni,
+  /// Source input data is valid.
+  input  logic src_valid_i,
+  /// Source is ready to accept.
+  output logic src_ready_o,
+  /// Source input data.
+  input  T     src_data_i,
+  /// Clock of destination clock domain.
+  input  logic dst_clk_i,
+  /// Active low async reset in destination domain.
+  input  logic dst_rst_ni,
+  /// Destination output data is valid.
+  output logic dst_valid_o,
+  /// Destination is ready to accept.
+  input  logic dst_ready_i,
+  /// Destination output data.
+  output T     dst_data_o
+);
+  // Don't generate the spill register.
+  if (Bypass) begin : gen_bypass
+    assign dst_valid_o = src_valid_i;
+    assign src_ready_o = dst_ready_i;
+    assign dst_data_o  = src_data_i;
+  // Generate the spill register
+  end else begin : gen_isochronous_spill_register
+    /// Read/write pointer are one bit wider than necessary.
+    /// We implicitly capture the full and empty state with the second bit:
+    /// If all but the topmost bit of `rd_pointer_q` and `wr_pointer_q` agree, the
+    /// FIFO is in a critical state. If the topmost bit is equal, the FIFO is
+    /// empty, otherwise it is full.
+    logic [1:0] rd_pointer_q, wr_pointer_q;
+    // Advance write pointer if we pushed a new item into the FIFO. (Source clock domain)
+    `FFLARN(wr_pointer_q, wr_pointer_q+1, (src_valid_i && src_ready_o), '0, src_clk_i, src_rst_ni)
+    // Advance read pointer if downstream consumed an item. (Destination clock domain)
+    `FFLARN(rd_pointer_q, rd_pointer_q+1, (dst_valid_o && dst_ready_i), '0, dst_clk_i, dst_rst_ni)
+
+    T [1:0] mem_d, mem_q;
+    `FFLNR(mem_q, mem_d, (src_valid_i && src_ready_o), src_clk_i)
+    always_comb begin
+      mem_d = mem_q;
+      mem_d[wr_pointer_q[0]] = src_data_i;
+    end
+
+    assign src_ready_o = (rd_pointer_q ^ wr_pointer_q) != 2'b10;
+
+    assign dst_valid_o = (rd_pointer_q ^ wr_pointer_q) != '0;
+    assign dst_data_o = mem_q[rd_pointer_q[0]];
+  end
+endmodule

--- a/src/stream_intf.sv
+++ b/src/stream_intf.sv
@@ -1,0 +1,49 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+/// A stream interface with custom payload of type `payload_t`.
+/// Handshaking rules as defined in the AXI standard.
+interface STREAM_DV #(
+  /// Custom payload type.
+  parameter type payload_t = logic
+)(
+  /// Interface clock.
+  input logic clk_i
+);
+  payload_t data;
+  logic valid;
+  logic ready;
+
+  modport In (
+    output ready,
+    input valid, data
+  );
+
+  modport Out (
+    output valid, data,
+    input ready
+  );
+
+  /// Passive modport for scoreboard and monitors.
+  modport Passive (
+    input valid, ready, data
+  );
+
+  // Make sure that the handshake and payload is stable
+  // pragma translate_off
+  `ifndef VERILATOR
+  assert property (@(posedge clk_i) (valid && !ready |=> $stable(data)));
+  assert property (@(posedge clk_i) (valid && !ready |=> valid));
+  `endif
+  // pragma translate_on
+endinterface

--- a/test/isochronous_spill_register_tb.sv
+++ b/test/isochronous_spill_register_tb.sv
@@ -1,0 +1,158 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+/// Testbench for the isochronous spill register.
+/// ## Compilation
+///
+/// This module needs to be compile with `-timescale "1 ns / 1 ps"` as
+/// it doesn't specify an internal timescale.
+module isochronous_spill_register_tb #(
+  parameter int unsigned NumReq   = 32'd10000,
+  parameter time SrcCyclTime      = 20ns,
+  /// Make sure that the clocks are an integer multiple of each other.
+  parameter time DstCyclTime      = SrcCyclTime*2
+);
+
+  logic src_clk, dst_clk;
+  logic src_rst_n, dst_rst_n;
+  logic sim_done;
+
+  typedef logic [15:0] payload_t;
+  // check FIFO
+  payload_t data_fifo[$];
+
+  STREAM_DV #(
+    .payload_t (payload_t)
+  ) dut_in (
+    .clk_i (src_clk)
+  );
+
+  STREAM_DV #(
+    .payload_t (payload_t)
+  ) dut_out (
+    .clk_i (dst_clk)
+  );
+
+  typedef stream_test::stream_driver #(
+    .payload_t (payload_t),
+    .TA (SrcCyclTime*0.2),
+    .TT (SrcCyclTime*0.8)
+  ) stream_driver_in_t;
+
+  typedef stream_test::stream_driver #(
+    .payload_t (payload_t),
+    .TA (DstCyclTime*0.2),
+    .TT (DstCyclTime*0.8)
+  ) stream_driver_out_t;
+
+  stream_driver_in_t in_driver = new(dut_in);
+  stream_driver_out_t out_driver = new(dut_out);
+
+  // Generate Stream data
+  initial begin : proc_stream_master
+    automatic payload_t    test_data;
+    automatic int unsigned stall_cycles;
+    in_driver.reset_in();
+    @(posedge src_rst_n);
+    repeat (5) @(posedge src_clk);
+    for (int unsigned i = 0; i < NumReq; i++) begin
+      test_data = payload_t'($urandom());
+      stall_cycles = $urandom_range(0, 5);
+      data_fifo.push_back(test_data);
+      repeat (stall_cycles) @(posedge src_clk);
+      in_driver.send(test_data);
+    end
+  end
+
+  // consume stream data and check that the result matches
+  initial begin : proc_stream_slave
+    automatic int unsigned stall_cycles;
+    automatic payload_t    expected, actual;
+    automatic int unsigned num_tested = 32'd0;
+    sim_done = 0;
+    out_driver.reset_out();
+    @(posedge dst_rst_n);
+    repeat (5) @(posedge dst_clk);
+    while (num_tested < NumReq) begin
+      stall_cycles = $urandom_range(0, 5);
+      repeat (stall_cycles) @(posedge dst_clk);
+      out_driver.recv(actual);
+      expected = data_fifo.pop_front();
+      assert(expected === actual) else $error("expected: %h, actual: %0h", expected, actual);
+      num_tested++;
+    end
+    repeat (50) @(posedge dst_clk);
+    sim_done = 1'b1;
+  end
+
+  // stop the simulation
+  initial begin : proc_sim_stop
+    @(posedge src_rst_n);
+    wait (sim_done);
+    $stop();
+  end
+
+  // Clock Generation
+  initial begin
+    src_clk = 1'b0;
+    forever begin
+      src_clk = ~src_clk;
+      #(SrcCyclTime / 2);
+    end
+  end
+
+  initial begin
+    dst_clk = 1'b0;
+    forever begin
+      dst_clk = ~dst_clk;
+      #(DstCyclTime / 2);
+    end
+  end
+
+  // Reset Generation
+  initial begin
+    static int unsigned rst_cnt = 0;
+    src_rst_n = 1'b0;
+    while (rst_cnt <= 10) begin
+      @(posedge src_clk);
+      rst_cnt++;
+    end
+    src_rst_n = 1'b1;
+  end
+
+  initial begin
+    static int unsigned rst_cnt = 0;
+    dst_rst_n = 1'b0;
+    while (rst_cnt <= 10) begin
+      @(posedge src_clk);
+      rst_cnt++;
+    end
+    dst_rst_n = 1'b1;
+  end
+
+  isochronous_spill_register #(
+    .T (payload_t)
+  ) i_isochronous_spill_register (
+    .src_clk_i (dut_in.clk_i),
+    .src_rst_ni (src_rst_n),
+    .src_valid_i (dut_in.valid),
+    .src_ready_o (dut_in.ready),
+    .src_data_i (dut_in.data),
+    .dst_clk_i (dut_out.clk_i),
+    .dst_rst_ni (dst_rst_n),
+    .dst_valid_o (dut_out.valid),
+    .dst_ready_i (dut_out.ready),
+    .dst_data_o (dut_out.data)
+  );
+
+endmodule

--- a/test/stream_test.sv
+++ b/test/stream_test.sv
@@ -1,0 +1,74 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+/// Stream test package containing drivers and common definitions for the
+/// stream interface.
+package stream_test;
+
+  class stream_driver #(
+    /// Payload data type.
+    parameter type payload_t = logic,
+    /// Stimuli application time.
+    parameter time TA = 2ns,
+    /// Stimuli test time.
+    parameter time TT = 8ns
+  );
+    virtual STREAM_DV #(
+      .payload_t (payload_t)
+    ) stream;
+
+    function new (
+      virtual STREAM_DV #(
+        .payload_t (payload_t)
+      ) stream
+    );
+      this.stream = stream;
+    endfunction
+
+    function void reset_in();
+      stream.valid = 1'b0;
+    endfunction
+
+    function void reset_out();
+      stream.ready = 1'b0;
+    endfunction
+
+    task cycle_start;
+      #TT;
+    endtask
+
+    task cycle_end;
+      @(posedge stream.clk_i);
+    endtask
+
+    /// Send a packet on the stream interface.
+    task send (input payload_t data);
+      stream.data  <= #TA data;
+      stream.valid <= #TA 1'b1;
+      cycle_start();
+      while (stream.ready != 1) begin cycle_end(); cycle_start(); end
+      cycle_end();
+      stream.valid <= #TA 1'b0;
+    endtask
+
+    /// Receive a packet on the stream interface.
+    task recv(output payload_t data);
+      stream.ready <= #TA 1'b1;
+      cycle_start();
+      while (stream.valid != 1) begin cycle_end(); cycle_start(); end
+      data = stream.data;
+      cycle_end();
+      stream.ready <= #TA 1'b0;
+    endtask
+  endclass
+endpackage


### PR DESCRIPTION
This module works similarly to the `spill_register` as it cuts any combinatorial paths but additionally allows to couple two clock domains with an isochronous clock (i.e., two clocks which do not vary in phase but vary in a constant integer factor in frequency).

The implementation concept is similar to the CDC FIFO but without any synchronization mechanisms as we do not need to deal with metastability (timing covered by STA).