### PR TITLE
Index width constant function.

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -21,7 +21,6 @@ sources:
   # Files in level 1 only depend on files in level 0, files in level 2 on files in levels 1 and 0,
   # etc. Files within a level are ordered alphabetically.
   # Level 0
-  - src/addr_decode.sv
   - src/cdc_2phase.sv
   - src/cf_math_pkg.sv
   - src/clk_div.sv
@@ -35,7 +34,6 @@ sources:
   - src/lfsr.sv
   - src/lfsr_16bit.sv
   - src/lfsr_8bit.sv
-  - src/lzc.sv
   - src/mv_filter.sv
   - src/onehot_to_bin.sv
   - src/plru_tree.sv
@@ -56,6 +54,7 @@ sources:
   - src/sync_wedge.sv
   - src/unread.sv
   # Level 1
+  - src/addr_decode.sv
   - src/cb_filter.sv
   - src/cdc_fifo_2phase.sv
   - src/cdc_fifo_gray.sv
@@ -63,7 +62,7 @@ sources:
   - src/ecc_decode.sv
   - src/ecc_encode.sv
   - src/edge_detect.sv
-  - src/id_queue.sv
+  - src/lzc.sv
   - src/max_counter.sv
   - src/rstgen.sv
   - src/stream_delay.sv
@@ -71,6 +70,7 @@ sources:
   - src/stream_fork_dynamic.sv
   # Level 2
   - src/fall_through_register.sv
+  - src/id_queue.sv
   - src/stream_to_mem.sv
   - src/stream_arbiter_flushable.sv
   - src/stream_register.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   without flow control for output data to be used in streams.
 - isochronous_spill_register: Isochronous clock domain crossing cutting all paths.
 - `rr_arb_tree_tb`: Systemverilog testbench for `rr_arb_tree`, which checks for fair throughput.
+- `cf_math_pkg::idx_width`: Constant function for defining the binary representation width
+  of an index signal.
+
+### Changed
+- `addr_decode`: Use `cf_math_pkg::idx_width` for computing the index width, inline documentation.
+- `lzc`: Use `cf_math_pkg::idx_width` for computing the index width, inline documentation.
+- `Bender`: Change levels of modules affected by depending on `cf_math_pkg::idx_width()`.
 
 ### Fixed
 - Improve tool compatibility.

--- a/src/addr_decode.sv
+++ b/src/addr_decode.sv
@@ -15,18 +15,6 @@
 /// The ranges of any two rules may overlap. If so, the rule at the higher (more significant)
 /// position in `addr_map_i` prevails.
 ///
-/// The address decoder expects three fields in `rule_t`:
-///
-/// typedef struct packed {
-///   int unsigned idx;
-///   addr_t       start_addr;
-///   addr_t       end_addr;
-/// } rule_t;
-///
-///  - `idx`:        index of the rule, has to be < `NoIndices`
-///  - `start_addr`: start address of the range the rule describes, value is included in range
-///  - `end_addr`:   end address of the range the rule describes, value is NOT included in range
-///
 /// There can be an arbitrary number of address rules. There can be multiple
 /// ranges defined for the same index. The start address has to be less than the end address.
 ///
@@ -46,7 +34,18 @@ module addr_decode #(
   parameter int unsigned NoRules   = 32'd0,
   /// Address type inside the rules and to decode.
   parameter type         addr_t    = logic,
-  /// Rule packed struct type, see above!
+  /// Rule packed struct type.
+  /// The address decoder expects three fields in `rule_t`:
+  ///
+  /// typedef struct packed {
+  ///   int unsigned idx;
+  ///   addr_t       start_addr;
+  ///   addr_t       end_addr;
+  /// } rule_t;
+  ///
+  ///  - `idx`:        index of the rule, has to be < `NoIndices`
+  ///  - `start_addr`: start address of the range the rule describes, value is included in range
+  ///  - `end_addr`:   end address of the range the rule describes, value is NOT included in range
   parameter type         rule_t    = logic,
   /// Dependent parameter, do **not** overwite!
   ///
@@ -57,15 +56,15 @@ module addr_decode #(
   /// Type of the `idx_o` output port.
   parameter type         idx_t     = logic [IdxWidth-1:0]
 ) (
-  /// Address to decode
+  /// Address to decode.
   input  addr_t               addr_i,
   /// Address map: rule with the highest array position wins on collision
   input  rule_t [NoRules-1:0] addr_map_i,
-  /// Decoded index
+  /// Decoded index.
   output idx_t                idx_o,
-  /// Decode is valid
+  /// Decode is valid.
   output logic                dec_valid_o,
-  /// Decode is not valid, no matching rule found
+  /// Decode is not valid, no matching rule found.
   output logic                dec_error_o,
   /// Enable default port mapping.
   ///

--- a/src/cf_math_pkg.sv
+++ b/src/cf_math_pkg.sv
@@ -8,19 +8,18 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
-// cf_math_pkg: Constant Function Implementations of Mathematical Functions for HDL Elaboration
-//
-// This package contains a collection of mathematical functions that are commonly used when defining
-// the value of constants in HDL code.  These functions are implemented as Verilog constants
-// functions.  Introduced in Verilog 2001 (IEEE Std 1364-2001), a constant function (§ 10.3.5) is a
-// function whose value can be evaluated at compile time or during elaboration.  A constant function
-// must be called with arguments that are constants.
-
+/// cf_math_pkg: Constant Function Implementations of Mathematical Functions for HDL Elaboration
+///
+/// This package contains a collection of mathematical functions that are commonly used when defining
+/// the value of constants in HDL code.  These functions are implemented as Verilog constants
+/// functions.  Introduced in Verilog 2001 (IEEE Std 1364-2001), a constant function (§ 10.3.5) is a
+/// function whose value can be evaluated at compile time or during elaboration.  A constant function
+/// must be called with arguments that are constants.
 package cf_math_pkg;
 
-    // Ceiled Division of Two Natural Numbers
-    //
-    // Returns the quotient of two natural numbers, rounded towards plus infinity.
+    /// Ceiled Division of Two Natural Numbers
+    ///
+    /// Returns the quotient of two natural numbers, rounded towards plus infinity.
     function automatic integer ceil_div (input longint dividend, input longint divisor);
         automatic longint remainder;
 
@@ -44,6 +43,19 @@ package cf_math_pkg;
         for (ceil_div = 0; remainder > 0; ceil_div++) begin
             remainder = remainder - divisor;
         end
+    endfunction
+
+    /// Index width required to be able to represent up to `num_idx` indices as a binary
+    /// encoded signal.
+    /// Ensures that the minimum width if an index signal is `1`, regardless of parametrization.
+    ///
+    /// Sample usage in type definition:
+    /// As parameter:
+    ///   `parameter type idx_t = logic[cf_math_pkg::idx_width(NumIdx)-1:0]`
+    /// As typedef:
+    ///   `typedef logic [cf_math_pkg::idx_width(NumIdx)-1:0] idx_t`
+    function automatic integer unsigned idx_width (input integer unsigned num_idx);
+        return (num_idx > 32'd1) ? unsigned'($clog2(num_idx)) : 32'd1;
     endfunction
 
 endpackage

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -22,17 +22,22 @@
 ///   in_i = 000_1000, empty_o = 0, cnt_o = 3 (mode = 0)
 /// Furthermore, this unit contains a more efficient implementation for Verilator (simulation only).
 /// This speeds up simulation significantly.
-
 module lzc #(
   /// The width of the input vector.
   parameter int unsigned WIDTH = 2,
-  parameter bit          MODE  = 1'b0, // 0 -> trailing zero, 1 -> leading zero
-  // Dependent parameters. Do not change!
-  parameter int unsigned CNT_WIDTH = WIDTH == 1 ? 1 : $clog2(WIDTH)
+  /// Mode selection: 0 -> trailing zero, 1 -> leading zero
+  parameter bit          MODE  = 1'b0,
+  /// Dependent parameter. Do **not** change!
+  ///
+  /// Width of the output signal with the zero count.
+  parameter int unsigned CNT_WIDTH = cf_math_pkg::idx_width(WIDTH)
 ) (
+  /// Input vector to be counted.
   input  logic [WIDTH-1:0]     in_i,
+  /// Count of the leading / trailing zeros.
   output logic [CNT_WIDTH-1:0] cnt_o,
-  output logic                 empty_o // asserted if all bits in in_i are zero
+  /// Counter is empty: Asserted if all bits in in_i are zero.
+  output logic                 empty_o
 );
 
   if (WIDTH == 1) begin: gen_degenerate_lzc

--- a/test/simulate.sh
+++ b/test/simulate.sh
@@ -24,7 +24,7 @@ call_vsim() {
 }
 
 #call_vsim cdc_fifo_tb # currently broken
-for tb in cdc_2phase_tb fifo_tb graycode_tb id_queue_tb popcount_tb stream_register_tb; do
+for tb in cdc_2phase_tb fifo_tb graycode_tb id_queue_tb popcount_tb stream_register_tb addr_decode_tb; do
     call_vsim $tb
 done
 


### PR DESCRIPTION
This adds a the function `cf_math_pkg::idx_width()`.

* Many modules have special degeneration code for `$clog2(x)` where `x==1`.   
* Adds a constant function which ensures that defined index signals always have a width of 1.
* Added the function to `addr_decode` and `lzc` as example how to use.
* Changed `addr_decode` and `lzc` to inline documentation.