### PR TITLE
stream_register: Fix DATA_WIDTH of instantiated FIFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 ### Fixed
+- `stream_register`: Fix `DATA_WIDTH` of instantiated FIFO.
 - `stream_xbar`: Add missing argument in assertion error string.
 
 ## 1.19.0 - 2020-05-25

--- a/src/stream_register.sv
+++ b/src/stream_register.sv
@@ -33,7 +33,7 @@ module stream_register #(
 
     fifo_v2 #(
         .FALL_THROUGH   (1'b0),
-        .DATA_WIDTH     ($size(T)),
+        .DATA_WIDTH     ($bits(T)),
         .DEPTH          (1),
         .dtype          (T)
     ) i_fifo (


### PR DESCRIPTION
Changed $size() to $bits() in stream_register.sv

Closes #92.