### PR TITLE
Replace NDEBUG define with an XSIM guard

### DIFF
--- a/common_cells.core
+++ b/common_cells.core
@@ -97,10 +97,3 @@ filesets:
 targets:
   default:
     filesets : [rtl, deprecated]
-    parameters : [NDEBUG]
-
-parameters:
-  NDEBUG:
-    datatype  : bool
-    description : Disable axi formal checks
-    paramtype : vlogdefine

--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -27,7 +27,7 @@
 // local helper macro to reduce code clutter. undefined at the end of this file
 `ifndef VERILATOR
 `ifndef SYNTHESIS
-`ifndef NDEBUG
+`ifndef XSIM
 `define INC_ASSERT
 `endif   
 `endif

--- a/src/addr_decode.sv
+++ b/src/addr_decode.sv
@@ -27,9 +27,6 @@
 /// if the resulting map is valid. It fatals if `start_addr` is higher than `end_addr`
 /// or if a mapping targets an index that is outside the number of allowed indices.
 /// It issues warnings if the address regions of any two mappings overlap.
-`ifdef VERILATOR
- `define NDEBUG 1
-`endif
 module addr_decode #(
   /// Highest index which can happen in a rule.
   parameter int unsigned NoIndices = 32'd0,
@@ -102,7 +99,8 @@ module addr_decode #(
   end
 
   // Assumptions and assertions
-  `ifndef NDEBUG
+  `ifndef VERILATOR
+  `ifndef XSIM
   // pragma translate_off
   initial begin : proc_check_parameters
     assume ($bits(addr_i) == $bits(addr_map_i[0].start_addr)) else
@@ -158,5 +156,6 @@ module addr_decode #(
     end
   end
   // pragma translate_on
+  `endif
   `endif
 endmodule

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -44,9 +44,6 @@
 /// If it is `1'b1` two `lzc`, a masking logic stage and a two input multiplexer are instantiated.
 /// However these are small in respect of the data multiplexers needed, as the width of the `req_i`
 /// signal is usually less as than `DataWidth`.
-`ifdef VERILATOR
- `define NDEBUG 1
-`endif
 module rr_arb_tree #(
   /// Number of inputs to be arbitrated.
   parameter int unsigned NumIn      = 64,
@@ -113,9 +110,11 @@ module rr_arb_tree #(
 );
 
   // pragma translate_off
-  `ifndef NDEBUG
+  `ifndef VERILATOR
+  `ifndef XSIM
   // Default SVA reset
   default disable iff (!rst_ni || flush_i);
+  `endif
   `endif
   // pragma translate_on
 
@@ -308,7 +307,8 @@ module rr_arb_tree #(
     end
 
     // pragma translate_off
-    `ifndef NDEBUG
+    `ifndef VERILATOR
+    `ifndef XSIM
     initial begin : p_assert
       assert(NumIn)
         else $fatal(1, "Input must be at least one element wide.");
@@ -339,6 +339,7 @@ module rr_arb_tree #(
     req1 : assert property(
       @(posedge clk_i) req_o |-> |req_i)
         else $fatal (1, "Req out implies req in.");
+    `endif
     `endif
     // pragma translate_on
   end


### PR DESCRIPTION
Replaced the previously added NDEBUG define with a tool-specific XSIM define analogous to how the VERILATOR define is used