### PR TITLE
src/id_queue.sv: Specify dont-cares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Changed
-- `id_queue`: Specify default/reset values as `0`.
+- `id_queue`: Replace default or reset value of signals that were assigned `'x` with `'0`.
 - `id_queue`: Use `cf_math_pkg::idx_width()` for computation of localparams.
 
 ## 1.20.0 - 2020-11-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- `id_queue`: Specify default/reset values as `0`.
+- `id_queue`: Use `cf_math_pkg::idx_width()` for computation of localparams.
 
 ## 1.20.0 - 2020-11-04
 ### Added


### PR DESCRIPTION
The [styleguide](https://github.com/lowRISC/style-guides/blob/master/VerilogCodingStyle.md#dont-cares-xs) strongly discourages the use of don't cares. 
Eg. When using the output of `id_queue` to index into arrays the simulation output gets spamed with [warnings](https://github.com/pulp-platform/axi/issues/150).

Changes:
* `'x` in `id_queue` are replaced by `'0`.
* The localparams `HtIdxWidth` and `LdIdxWidth` in `id_queue` are now calculated with `cf_math_pkg::idx_width()`.

#106 should also be adapted, as there are also `'x` in default assignments/resets.
