### PR TITLE
Bump common_verification and tech_cells_generic dependency

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -10,8 +10,8 @@ package:
     - "Wolfgang Roenninger <wroennin@student.ethz.ch>"
 
 dependencies:
-  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.1.1 }
-  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.1.1 }
+  common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.0 }
+  tech_cells_generic: { git: "https://github.com/pulp-platform/tech_cells_generic.git", version: 0.2.3 }
 
 export_include_dirs:
   - include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- updated `common_verification` and `tech_cells_generic` dependency versions
 
 ## 1.20.1 - 2021-01-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Changed
-- updated `common_verification` and `tech_cells_generic` dependency versions
+- Remove `timeprecision/timeunit` arguments
+- Update `common_verification` to `0.2.0`
+- Update `tech_cells_generic` to `0.2.3`
 
 ## 1.20.1 - 2021-01-21
 ### Changed

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -1,2 +1,2 @@
 common_verification:
-    commit: v0.1.1    
+    commit: v0.2.0

--- a/test/addr_decode_tb.sv
+++ b/test/addr_decode_tb.sv
@@ -12,8 +12,6 @@
 
 // test bench for addr_decode module
 
-timeunit 1ns/1ns;
-
 module addr_decode_tb;
   localparam int unsigned NoIndices =  2;
   localparam int unsigned NoRules   =  3;

--- a/test/cb_filter_tb.sv
+++ b/test/cb_filter_tb.sv
@@ -83,8 +83,8 @@ module cb_filter_tb;
   // Clock generator
   // -------------
   clk_rst_gen #(
-    .CLK_PERIOD     ( TCycle ),
-    .RST_CLK_CYCLES (       5 )
+    .ClkPeriod     ( TCycle ),
+    .RstClkCycles  (      5 )
   ) i_clk_gen (
     .clk_o  (   clk ),
     .rst_no ( rst_n )

--- a/test/cdc_2phase_tb.sv
+++ b/test/cdc_2phase_tb.sv
@@ -11,8 +11,6 @@
 //
 // Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 
-timeunit 0.1ns/1ps;
-
 module cdc_2phase_tb;
 
   parameter int UNTIL = 100000;

--- a/test/cdc_fifo_tb.sv
+++ b/test/cdc_fifo_tb.sv
@@ -11,8 +11,6 @@
 //
 // Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 
-timeunit 0.1ns/1ps;
-
 module cdc_fifo_tb;
 
   parameter bit INJECT_SRC_STALLS = 0;

--- a/test/fifo_tb.sv
+++ b/test/fifo_tb.sv
@@ -24,9 +24,6 @@ module fifo_inst_tb #(
     output logic    done_o
 );
 
-    timeunit 1ns;
-    timeprecision 10ps;
-
     import rand_verif_pkg::rand_wait;
 
     typedef logic [DATA_WIDTH-1:0] data_t;
@@ -167,9 +164,6 @@ module fifo_tb #(
     parameter time          TA              = TCLK * 1/4,
     parameter time          TT              = TCLK * 3/4
 );
-
-    timeunit 1ns;
-    timeprecision 10ps;
 
     logic       clk,
                 rst_n;

--- a/test/fifo_tb.sv
+++ b/test/fifo_tb.sv
@@ -176,7 +176,7 @@ module fifo_tb #(
 
     logic [3:0] done;
 
-    clk_rst_gen #(.CLK_PERIOD(TCLK), .RST_CLK_CYCLES(10)) i_clk_rst_gen (
+    clk_rst_gen #(.ClkPeriod(TCLK), .RstClkCycles(10)) i_clk_rst_gen (
         .clk_o    (clk),
         .rst_no   (rst_n)
     );

--- a/test/graycode_tb.sv
+++ b/test/graycode_tb.sv
@@ -11,8 +11,6 @@
 //
 // Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 
-timeunit 1ns/1ns;
-
 module graycode_tb #(
     parameter int N = 9
 );

--- a/test/id_queue_tb.sv
+++ b/test/id_queue_tb.sv
@@ -61,8 +61,8 @@ module id_queue_tb #(
                 oup_data_valid;
 
     clk_rst_gen #(
-        .CLK_PERIOD     (TCLK),
-        .RST_CLK_CYCLES (5)
+        .ClkPeriod    (TCLK),
+        .RstClkCycles (5)
     ) i_clk_rst_gen (
         .clk_o  (clk),
         .rst_no (rst_n)
@@ -98,10 +98,10 @@ module id_queue_tb #(
     // Random Input Driver
     rand_stream_mst #(
         .data_t             (queue_t),
-        .MIN_WAIT_CYCLES    (INP_MIN_WAIT_CYCLES),
-        .MAX_WAIT_CYCLES    (INP_MAX_WAIT_CYCLES),
-        .APPL_DELAY         (TA),
-        .ACQ_DELAY          (TT)
+        .MinWaitCycles      (INP_MIN_WAIT_CYCLES),
+        .MaxWaitCycles      (INP_MAX_WAIT_CYCLES),
+        .ApplDelay          (TA),
+        .AcqDelay           (TT)
     ) i_inp_mst (
         .clk_i      (clk),
         .rst_ni     (rst_n),
@@ -116,10 +116,10 @@ module id_queue_tb #(
     // Random Output Driver
     rand_stream_mst #(
         .data_t             (logic),
-        .MIN_WAIT_CYCLES    (OUP_MIN_WAIT_CYCLES),
-        .MAX_WAIT_CYCLES    (OUP_MAX_WAIT_CYCLES),
-        .APPL_DELAY         (TA),
-        .ACQ_DELAY          (TT)
+        .MinWaitCycles      (OUP_MIN_WAIT_CYCLES),
+        .MaxWaitCycles      (OUP_MAX_WAIT_CYCLES),
+        .ApplDelay          (TA),
+        .AcqDelay           (TT)
     ) i_oup_mst (
         .clk_i      (clk),
         .rst_ni     (rst_n),
@@ -132,10 +132,10 @@ module id_queue_tb #(
     // Random Exists Driver
     rand_stream_mst #(
         .data_t             (exists_t),
-        .MIN_WAIT_CYCLES    (OUP_MIN_WAIT_CYCLES),
-        .MAX_WAIT_CYCLES    (OUP_MAX_WAIT_CYCLES),
-        .APPL_DELAY         (TA),
-        .ACQ_DELAY          (TT)
+        .MinWaitCycles      (OUP_MIN_WAIT_CYCLES),
+        .MaxWaitCycles      (OUP_MAX_WAIT_CYCLES),
+        .ApplDelay          (TA),
+        .AcqDelay           (TT)
     ) i_exists_mst (
         .clk_i      (clk),
         .rst_ni     (rst_n),

--- a/test/id_queue_tb.sv
+++ b/test/id_queue_tb.sv
@@ -20,9 +20,6 @@ module id_queue_tb #(
     parameter type data_t = logic[3:0]
 );
 
-    timeunit 1ns;
-    timeprecision 10ps;
-
     localparam time TCLK = 10ns;
     localparam time TA = TCLK * 1/4;
     localparam time TT = TCLK * 3/4;

--- a/test/popcount_tb.sv
+++ b/test/popcount_tb.sv
@@ -29,8 +29,6 @@ do begin \
 end while (0)
 
 module popcount_tb;
-   timeunit 1ns;
-   timeprecision 1ps;
 
    //---------------- Signals connecting to MUT ----------------
    logic [4:0] data_w5;

--- a/test/rr_arb_tree_tb.sv
+++ b/test/rr_arb_tree_tb.sv
@@ -49,8 +49,8 @@ module rr_arb_tree_tb #(
 
   // clock and rst gen
   clk_rst_gen #(
-    .CLK_PERIOD     ( CyclTime ),
-    .RST_CLK_CYCLES ( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_rst_gen (
     .clk_o  ( clk   ),
     .rst_no ( rst_n )

--- a/test/stream_omega_net_tb.sv
+++ b/test/stream_omega_net_tb.sv
@@ -43,8 +43,8 @@ module stream_omega_net_tb #(
 
   // clock generator
   clk_rst_gen #(
-    .CLK_PERIOD     ( CyclTime ),
-    .RST_CLK_CYCLES ( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_rst_gen (
     .clk_o  ( clk   ),
     .rst_no ( rst_n )

--- a/test/stream_to_mem_tb.sv
+++ b/test/stream_to_mem_tb.sv
@@ -16,8 +16,6 @@ module stream_to_mem_tb #(
   parameter int unsigned NumReq   = 32'd10000,
   parameter int unsigned BufDepth = 32'd1
 );
-  timeunit 1ns;
-  timeprecision 10ps;
 
   localparam time CyclTime = 10ns;
   localparam time ApplTime = 2ns;

--- a/test/stream_to_mem_tb.sv
+++ b/test/stream_to_mem_tb.sv
@@ -124,8 +124,8 @@ module stream_to_mem_tb #(
 
   // CLK generator
   clk_rst_gen #(
-    .CLK_PERIOD     ( CyclTime ),
-    .RST_CLK_CYCLES ( 10       )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 10       )
   ) i_clk_rst_gen (
     .clk_o  ( clk   ),
     .rst_no ( rst_n )

--- a/test/stream_xbar_tb.sv
+++ b/test/stream_xbar_tb.sv
@@ -41,8 +41,8 @@ module stream_xbar_tb #(
 
   // clock generator
   clk_rst_gen #(
-    .CLK_PERIOD     ( CyclTime ),
-    .RST_CLK_CYCLES ( 5        )
+    .ClkPeriod    ( CyclTime ),
+    .RstClkCycles ( 5        )
   ) i_clk_rst_gen (
     .clk_o  ( clk   ),
     .rst_no ( rst_n )

--- a/test/sub_per_hash_tb.sv
+++ b/test/sub_per_hash_tb.sv
@@ -49,8 +49,8 @@ module sub_per_hash_tb;
   // Clock generator
   // -------------
   clk_rst_gen #(
-    .CLK_PERIOD     ( TCycle ),
-    .RST_CLK_CYCLES (      1 )
+    .ClkPeriod    ( TCycle ),
+    .RstClkCycles (      1 )
   ) i_clk_gen (
     .clk_o  (   clk ),
     .rst_no ( rst_n )


### PR DESCRIPTION
Updates the following dependencies:
- `tech_cells_generic` (v0.1.1 -> v0.2.3)
- `common_verification` (v0.1.1 -> v0.2.0)
    - requires renaming of some parameters