### PR TITLE
Fix a syntax error with  that broke verific

### DIFF
--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -268,9 +268,9 @@ module id_queue #(
 `ifndef VERILATOR
     initial begin: validate_params
         assert (ID_WIDTH >= 1)
-            else $fatal("The ID must at least be one bit wide!");
+            else $fatal(1,"The ID must at least be one bit wide!");
         assert (CAPACITY >= 1)
-            else $fatal("The queue must have capacity of at least one entry!");
+            else $fatal(1,"The queue must have capacity of at least one entry!");
     end
 `endif
 // pragma translate_on

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -268,7 +268,7 @@ module id_queue #(
 `ifndef VERILATOR
     initial begin: validate_params
         assert (ID_WIDTH >= 1)
-            else $fatal(1,"The ID must at least be one bit wide!");
+            else $fatal(1, "The ID must at least be one bit wide!");
         assert (CAPACITY >= 1)
             else $fatal(1,"The queue must have capacity of at least one entry!");
     end

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -270,7 +270,7 @@ module id_queue #(
         assert (ID_WIDTH >= 1)
             else $fatal(1, "The ID must at least be one bit wide!");
         assert (CAPACITY >= 1)
-            else $fatal(1,"The queue must have capacity of at least one entry!");
+            else $fatal(1, "The queue must have capacity of at least one entry!");
     end
 `endif
 // pragma translate_on

--- a/src/stream_fork.sv
+++ b/src/stream_fork.sv
@@ -125,7 +125,7 @@ module stream_fork #(
 // pragma translate_off
 `ifndef VERILATOR
     initial begin: p_assertions
-        assert (N_OUP >= 1) else $fatal(1,"Number of outputs must be at least 1!");
+        assert (N_OUP >= 1) else $fatal(1, "Number of outputs must be at least 1!");
     end
 `endif
 // pragma translate_on

--- a/src/stream_fork.sv
+++ b/src/stream_fork.sv
@@ -125,7 +125,7 @@ module stream_fork #(
 // pragma translate_off
 `ifndef VERILATOR
     initial begin: p_assertions
-        assert (N_OUP >= 1) else $fatal("Number of outputs must be at least 1!");
+        assert (N_OUP >= 1) else $fatal(1,"Number of outputs must be at least 1!");
     end
 `endif
 // pragma translate_on

--- a/src/stream_mux.sv
+++ b/src/stream_mux.sv
@@ -38,7 +38,7 @@ module stream_mux #(
 // pragma translate_off
 `ifndef VERILATOR
   initial begin: p_assertions
-    assert (N_INP >= 1) else $fatal (1,"The number of inputs must be at least 1!");
+    assert (N_INP >= 1) else $fatal (1, "The number of inputs must be at least 1!");
   end
 `endif
 // pragma translate_on

--- a/src/stream_mux.sv
+++ b/src/stream_mux.sv
@@ -38,7 +38,7 @@ module stream_mux #(
 // pragma translate_off
 `ifndef VERILATOR
   initial begin: p_assertions
-    assert (N_INP >= 1) else $fatal ("The number of inputs must be at least 1!");
+    assert (N_INP >= 1) else $fatal (1,"The number of inputs must be at least 1!");
   end
 `endif
 // pragma translate_on


### PR DESCRIPTION
Verific is a stickler for syntax, and the usage of $fatal in places seemed to disregard the first argument.