### PR TITLE
rr_arb_tree: update assertion to allow flushing locked decision

### DIFF
--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -171,7 +171,8 @@ module rr_arb_tree #(
         // pragma translate_off
         `ifndef VERILATOR
           lock: assert property(
-            @(posedge clk_i) LockIn |-> req_o && !gnt_i |=> idx_o == $past(idx_o)) else
+            @(posedge clk_i) LockIn |-> req_o &&
+                             (!gnt_i && !flush_i) |=> idx_o == $past(idx_o)) else
                 $fatal (1, "Lock implies same arbiter decision in next cycle if output is not \
                             ready.");
 


### PR DESCRIPTION
When `rr_arb_tree` is locked, allow flushing the decision (i.e. do not throw an error). Otherwise, asserting `flush_i` with `LockIn` set will fail.