### PR TITLE
Verilator issue with sub_per_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Fixed
 - Correct reset polarity in assertions in `isochronous_4phase_handshake` and `isochronous_spill_register`
+- Fix compatibility of `sub_per_hash` constructs with Verilator
 
 ## 1.23.0 - 2021-09-05
 ### Added

--- a/src/sub_per_hash.sv
+++ b/src/sub_per_hash.sv
@@ -51,12 +51,14 @@ module sub_per_hash #(
 
   // typedefs and respective localparams
   typedef int unsigned perm_lists_t [NoRounds][InpWidth];
-  localparam perm_lists_t PERMUTATIONS = get_permutations(PermuteKey);
+  perm_lists_t Permutations;
+  assign Permutations = get_permutations(PermuteKey);
   // encoding for inner most array:
   // position 0 indicates the number of inputs, 2 or 3
   // the other positions 1 - 3 indicate the inputs
   typedef int unsigned xor_stages_t [NoRounds][InpWidth][3];
-  localparam xor_stages_t XorStages = get_xor_stages(XorKey);
+  xor_stages_t XorStages;
+  assign XorStages = get_xor_stages(XorKey);
 
   // stage signals
   logic [NoRounds-1:0][InpWidth-1:0] permuted, xored;
@@ -68,9 +70,9 @@ module sub_per_hash #(
 
       // assign the permutation
       if (r == 0) begin : gen_input
-        assign permuted[r][i] = data_i[PERMUTATIONS[r][i]];
+        assign permuted[r][i] = data_i[Permutations[r][i]];
       end else begin : gen_permutation
-        assign permuted[r][i] = permuted[r-1][PERMUTATIONS[r][i]];
+        assign permuted[r][i] = permuted[r-1][Permutations[r][i]];
       end
 
       // assign the xor substitution


### PR DESCRIPTION
The latest Verilator version has issues with some constructs used in the `sub_per_hash` module: 

``` 
%Error: common_cells/src/sub_per_hash.sv:54:42: Expecting expression to be constant, but can't determine constant for FUNCREF 'get_permutations'
                                                                                                      : ... In instance common_cells/src/sub_per_hash.sv:109:23: ... Location of non-constant ASSIGN: Array select LHS isn't simple variable
        common_cells/src/sub_per_hash.sv:54:42: ... Called from get_permutations() with parameters:
           seed = 32'h47df4
```

The issue is that `XorStages` and `PERMUTATIONS` are declared as `localparam`'s, whose value depends on the result of a function. The issue is solved by declaring those two variables as signals.

This fix is between `ifdef VERILATOR` guards, but there is no issue with using this construct with other EDA tools.