### PR TITLE
registers: Optionally disable Synopsys macros

### DIFF
--- a/include/common_cells/registers.svh
+++ b/include/common_cells/registers.svh
@@ -31,6 +31,10 @@
 // `FFLSRN:  load-enable and synchronous active-low reset
 // `FFLNR:   load-enable without reset
 
+`ifdef VERILATOR
+`define NO_SYNOPSYS_FF 1
+`endif
+
 `define REG_DFLT_CLK clk_i
 `define REG_DFLT_RST rst_ni
 
@@ -81,7 +85,7 @@
 // __clk: clock input
 // __reset_clk: reset input, active-high
 `define FFSR(__q, __d, __reset_value, __clk, __reset_clk) \
-  `ifndef VERILATOR                       \
+  `ifndef NO_SYNOPSYS_FF                       \
   /``* synopsys sync_set_reset `"__reset_clk`" *``/       \
     `endif                        \
   always_ff @(posedge (__clk)) begin                      \
@@ -95,7 +99,7 @@
 // __clk: clock input
 // __reset_n_clk: reset input, active-low
 `define FFSRN(__q, __d, __reset_value, __clk, __reset_n_clk) \
-    `ifndef VERILATOR                       \
+    `ifndef NO_SYNOPSYS_FF                       \
   /``* synopsys sync_set_reset `"__reset_n_clk`" *``/        \
     `endif                        \
   always_ff @(posedge (__clk)) begin                         \
@@ -162,9 +166,9 @@
 // __clk: clock input
 // __reset_clk: reset input, active-high
 `define FFLSR(__q, __d, __load, __reset_value, __clk, __reset_clk)       \
-    `ifndef VERILATOR                       \
+    `ifndef NO_SYNOPSYS_FF                                               \
   /``* synopsys sync_set_reset `"__reset_clk`" *``/                      \
-    `endif                        \
+    `endif                                                               \
   always_ff @(posedge (__clk)) begin                                     \
     __q <= (__reset_clk) ? (__reset_value) : ((__load) ? (__d) : (__q)); \
   end
@@ -177,9 +181,9 @@
 // __clk: clock input
 // __reset_n_clk: reset input, active-low
 `define FFLSRN(__q, __d, __load, __reset_value, __clk, __reset_n_clk)       \
-    `ifndef VERILATOR                       \
+    `ifndef NO_SYNOPSYS_FF                                                  \
   /``* synopsys sync_set_reset `"__reset_n_clk`" *``/                       \
-    `endif                        \
+    `endif                                                                  \
   always_ff @(posedge (__clk)) begin                                        \
     __q <= (!__reset_n_clk) ? (__reset_value) : ((__load) ? (__d) : (__q)); \
   end
@@ -193,9 +197,9 @@
 // __clk: clock input
 // __arst_n: asynchronous reset, active-low
 `define FFLARNC(__q, __d, __load, __clear, __reset_value, __clk, __arst_n) \
-    `ifndef VERILATOR                       \
-  /``* synopsys sync_set_reset `"__clear`" *``/                       \
-    `endif                        \
+    `ifndef NO_SYNOPSYS_FF                                                 \
+  /``* synopsys sync_set_reset `"__clear`" *``/                            \
+    `endif                                                                 \
   always_ff @(posedge (__clk) or negedge (__arst_n)) begin                 \
     if (!__arst_n) begin                                                   \
       __q <= (__reset_value);                                              \


### PR DESCRIPTION
As discussed in #115 here is a tidied-up version.