### PR TITLE
Fix port list copy paste bug

### DIFF
--- a/src/spill_register.sv
+++ b/src/spill_register.sv
@@ -21,7 +21,6 @@ module spill_register #(
   input  logic clk_i   ,
   input  logic rst_ni  ,
   input  logic valid_i ,
-  input  logic flush_i ,
   output logic ready_o ,
   input  T     data_i  ,
   output logic valid_o ,


### PR DESCRIPTION
The introduction of a new port to an existing module is not backward compatible and
thus breaks every other repository that uses the spill_registers from common
cells. I guess the intention was to not introduce this port and have the
spill_register module act as just a wrapper.

After merging this commit, we should immediately release a new minor version to restore compatibility. 