### PR TITLE
sync: Extend with data type parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `sync`: Add data type parameter, so this module can be used on any signal instead of just
+  single-bit `logic`s.
 
 ## 1.23.0 - 2021-09-05
 ### Added

--- a/src/sync.sv
+++ b/src/sync.sv
@@ -11,16 +11,17 @@
 // Antonio Pullini <pullinia@iis.ee.ethz.ch>
 
 module sync #(
+    parameter type T = logic,
     parameter int unsigned STAGES = 2,
-    parameter bit ResetValue = 1'b0
+    parameter T ResetValue = '0
 ) (
     input  logic clk_i,
     input  logic rst_ni,
-    input  logic serial_i,
-    output logic serial_o
+    input  T     serial_i,
+    output T     serial_o
 );
 
-   logic [STAGES-1:0] reg_q;
+    T [STAGES-1:0] reg_q;
 
     always_ff @(posedge clk_i, negedge rst_ni) begin
         if (!rst_ni) begin


### PR DESCRIPTION
The `sync` module works for just one bit. `sync_t` can synchronize
more bits with one instance.