### PR TITLE
iso-crossings: Fix reset polarity in assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Correct reset polarity in assertions in `isochronous_4phase_handshake` and `isochronous_spill_register`
 
 ## 1.23.0 - 2021-09-05
 ### Added

--- a/src/isochronous_4phase_handshake.sv
+++ b/src/isochronous_4phase_handshake.sv
@@ -71,9 +71,9 @@ module isochronous_4phase_handshake (
  // pragma translate_off
  // stability guarantees
   `ifndef VERILATOR
-  assert property (@(posedge src_clk_i) disable iff (src_rst_ni)
+  assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)
     (src_valid_i && !src_ready_o |=> $stable(src_valid_i))) else $error("src_valid_i is unstable");
-  assert property (@(posedge dst_clk_i) disable iff (dst_rst_ni)
+  assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
     (dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o))) else $error("dst_valid_o is unstable");
   `endif
   // pragma translate_on

--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -98,13 +98,13 @@ module isochronous_spill_register #(
   // pragma translate_off
   // stability guarantees
   `ifndef VERILATOR
-  assert property (@(posedge src_clk_i) disable iff (src_rst_ni)
+  assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)
     (src_valid_i && !src_ready_o |=> $stable(src_valid_i))) else $error("src_valid_i is unstable");
-  assert property (@(posedge src_clk_i) disable iff (src_rst_ni)
+  assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)
     (src_valid_i && !src_ready_o |=> $stable(src_data_i))) else $error("src_data_i is unstable");
-  assert property (@(posedge dst_clk_i) disable iff (dst_rst_ni)
+  assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
     (dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o))) else $error("dst_valid_o is unstable");
-  assert property (@(posedge dst_clk_i) disable iff (dst_rst_ni)
+  assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
     (dst_valid_o && !dst_ready_i |=> $stable(dst_data_o))) else $error("dst_data_o is unstable");
   `endif
   // pragma translate_on


### PR DESCRIPTION
The `disable iff` conditions in these assertions did not account for the active-low reset polarity.