### PR TITLE
Edge propagator ack

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -136,5 +136,6 @@ sources:
   - src/deprecated/fifo_v1.sv
 
   # Depend on deprecated modules
+  - src/edge_propagator_ack.sv
   - src/edge_propagator.sv
   - src/edge_propagator_rx.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add `edge_propagator_ack`: Edge/pulse propagator with sender-synchronous receive-acknowledge
+  output.  `edge_propagator` is now implemented by instantiating `edge_propagator_ack`.
+
 ### Fixed
 - Correct reset polarity in assertions in `isochronous_4phase_handshake` and `isochronous_spill_register`
 - Fix compatibility of `sub_per_hash` constructs with Verilator

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `cdc_fifo_2phase`              | Clock domain crossing FIFO using two-phase handshake, with ready/valid interface | active       |               |
 | `cdc_fifo_gray`                | Clock domain crossing FIFO using a gray-counter, with ready/valid interface      | active       |               |
 | `edge_detect`                  | Rising/falling edge detector                                                     | active       |               |
-| `edge_propagator`              | **ANTONIO ADD DESCRIPTION**                                                      | active       |               |
-| `edge_propagator_rx`           | **ANTONIO ADD DESCRIPTION**                                                      | active       |               |
-| `edge_propagator_tx`           | **ANTONIO ADD DESCRIPTION**                                                      | active       |               |
+| `edge_propagator`              | Propagates a single-cycle pulse across an asynchronous clock domain crossing     | active       |               |
+| `edge_propagator_tx`           | Transmit slice of `edge_propagator`, requires only the sender clock              | active       |               |
+| `edge_propagator_rx`           | Receive slice of `edge_propagator`, requires only the receiver clock             | active       |               |
 | `isochronous_spill_register`   | Isochronous clock domain crossing and full handshake (like `spill_register`)     | active       |               |
 | `isochronous_4phase_handshake` | Isochronous four-phase handshake.                                                | active       |               |
 | `pulp_sync`                    | Serial line synchronizer                                                         | *deprecated* | `sync`        |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `cdc_fifo_gray`                | Clock domain crossing FIFO using a gray-counter, with ready/valid interface      | active       |               |
 | `edge_detect`                  | Rising/falling edge detector                                                     | active       |               |
 | `edge_propagator`              | Propagates a single-cycle pulse across an asynchronous clock domain crossing     | active       |               |
+| `edge_propagator_ack`          | `edge_propagator` with sender-synchronous acknowledge pin (flags received pulse) | active       |               |
 | `edge_propagator_tx`           | Transmit slice of `edge_propagator`, requires only the sender clock              | active       |               |
 | `edge_propagator_rx`           | Receive slice of `edge_propagator`, requires only the receiver clock             | active       |               |
 | `isochronous_spill_register`   | Isochronous clock domain crossing and full handshake (like `spill_register`)     | active       |               |

--- a/src/edge_propagator_ack.sv
+++ b/src/edge_propagator_ack.sv
@@ -10,23 +10,44 @@
 
 // Antonio Pullini <pullinia@iis.ee.ethz.ch>
 
-module edge_propagator (
+module edge_propagator_ack (
   input  logic clk_tx_i,
   input  logic rstn_tx_i,
   input  logic edge_i,
+  output logic ack_tx_o,
   input  logic clk_rx_i,
   input  logic rstn_rx_i,
   output logic edge_o
 );
 
-  edge_propagator_ack i_edge_propagator_ack (
-    .clk_tx_i,
-    .rstn_tx_i,
-    .edge_i,
-    .ack_tx_o (/* unused */),
-    .clk_rx_i,
-    .rstn_rx_i,
-    .edge_o
+  logic [1:0] sync_a;
+  logic       sync_b;
+
+  logic r_input_reg;
+  logic s_input_reg_next;
+
+  assign ack_tx_o = sync_a[0];
+
+  assign s_input_reg_next = edge_i | (r_input_reg & ~sync_a[0]);
+
+  always @(negedge rstn_tx_i or posedge clk_tx_i) begin
+    if (~rstn_tx_i) begin
+      r_input_reg <= 1'b0;
+      sync_a      <= 2'b00;
+    end else begin
+      r_input_reg <= s_input_reg_next;
+      sync_a      <= {sync_b,sync_a[1]};
+    end
+  end
+
+  pulp_sync_wedge u_sync_clkb (
+    .clk_i    ( clk_rx_i    ),
+    .rstn_i   ( rstn_rx_i   ),
+    .en_i     ( 1'b1        ),
+    .serial_i ( r_input_reg ),
+    .r_edge_o ( edge_o      ),
+    .f_edge_o (             ),
+    .serial_o ( sync_b      )
   );
 
 endmodule

--- a/src_files.yml
+++ b/src_files.yml
@@ -86,5 +86,6 @@ common_cells_all:
     # Level 3
 
     # Depend on deprecated modules
+    - src/edge_propagator_ack.sv
     - src/edge_propagator.sv
     - src/edge_propagator_rx.sv


### PR DESCRIPTION
Added a version of the edge propagator that has an acknowledge port which flags if the edge has actually propagated to the receiving side. Useful if the initiating circuit can only safely continue if the described condition is met.