### PR TITLE
Fix toolproblems in `id_queue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## Unreleased
+### Changed
+- Avoid using `$bits()` call in `id_queue`'s parameters.
 
 ## 1.24.1 - 2022-04-13
 ### Fixed

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -52,7 +52,7 @@ module id_queue #(
     parameter type data_t   = logic,
     // Dependent parameters, DO NOT OVERRIDE!
     localparam type id_t    = logic[ID_WIDTH-1:0],
-    localparam type mask_t  = logic[$bits(data_t)-1:0]
+    localparam type mask_t  = data_t
 ) (
     input  logic    clk_i,
     input  logic    rst_ni,

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -51,8 +51,7 @@ module id_queue #(
     parameter bit FULL_BW   = 0,
     parameter type data_t   = logic,
     // Dependent parameters, DO NOT OVERRIDE!
-    localparam type id_t    = logic[ID_WIDTH-1:0],
-    localparam type mask_t  = data_t
+    localparam type id_t    = logic[ID_WIDTH-1:0]
 ) (
     input  logic    clk_i,
     input  logic    rst_ni,
@@ -63,7 +62,7 @@ module id_queue #(
     output logic    inp_gnt_o,
 
     input  data_t   exists_data_i,
-    input  mask_t   exists_mask_i,
+    input  data_t   exists_mask_i,
     input  logic    exists_req_i,
     output logic    exists_o,
     output logic    exists_gnt_o,
@@ -357,7 +356,7 @@ module id_queue #(
 
     // Exists Lookup
     for (genvar i = 0; i < CAPACITY; i++) begin: gen_lookup
-        mask_t exists_match_bits;
+        data_t exists_match_bits;
         for (genvar j = 0; j < $bits(data_t); j++) begin: gen_mask
             always_comb begin
                 if (linked_data_q[i].free) begin


### PR DESCRIPTION
VCS can not handle the way the `mask_t` is defined for specific instances. Since the `mask_t` and the `data_t` need the same width anyway, and the tools have problems with this call, I propose we just reuse the `data_t` directly.

Furthermore, I would argue that we should use a width parameter instead of a type parameter for `data_t` in the future. This requires an interface change, but the current implementation could run into problems if the `data_t` is defined as a multidimensional array. On [line 369](https://github.com/pulp-platform/common_cells/blob/master/src/id_queue.sv#L369), we loop over all bits in `data_t`, which only works for 1D vectors or packed structs, afaik. We could also just flatten the `data_t` inside the module to avoid changing the interface. @andreaskurth What do you think?

An example where the tool encounters problems is the [`axi_riscv_atomics/axi_riscv_lrsc/i_write_in_flight_queue`](https://github.com/pulp-platform/axi_riscv_atomics/blob/master/src/axi_riscv_lrsc.sv#L534) module. The `mask_t` inferred by VCS is only 5 bits if the `data_t` is 49 bits.

- [ ] Squash commits
- [ ] Potentially directly flatten the data types