### PR TITLE
stream_fifo_wrap: Add a wrapper that optimally selects either a spill register or a fifo

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -81,6 +81,7 @@ sources:
   - src/id_queue.sv
   - src/stream_to_mem.sv
   - src/stream_arbiter_flushable.sv
+  - src/stream_fifo_optimal_wrap.sv
   - src/stream_register.sv
   - src/stream_xbar.sv
   # Level 3

--- a/README.md
+++ b/README.md
@@ -98,18 +98,19 @@ Please note that cells with status *deprecated* are not to be used for new desig
 
 ### Data Structures
 
-| Name               | Description                                     | Status       | Superseded By |
-| ------------------ | ----------------------------------------------- | ------------ | ------------- |
-| `cb_filter`        | Counting-Bloom-Filter with combinational lookup | active       |               |
-| `fifo`             | FIFO register with upper threshold              | *deprecated* | `fifo_v3`     |
-| `fifo_v2`          | FIFO register with upper and lower threshold    | *deprecated* | `fifo_v3`     |
-| `fifo_v3`          | FIFO register with generic fill counts          | active       |               |
-| `stream_fifo`      | FIFO register with ready/valid interface        | active       |               |
-| `generic_fifo`     | FIFO register without thresholds                | *deprecated* | `fifo_v3`     |
-| `generic_fifo_adv` | FIFO register without thresholds                | *deprecated* | `fifo_v3`     |
-| `sram`             | SRAM behavioral model                           | active       |               |
-| `plru_tree`        | Pseudo least recently used tree                 | active       |               |
-| `unread`           | Empty module to sink unconnected outputs into   | active       |               |
+| Name                       | Description                                                      | Status       | Superseded By |
+| -------------------------- | ---------------------------------------------------------------- | ------------ | ------------- |
+| `cb_filter`                | Counting-Bloom-Filter with combinational lookup                  | active       |               |
+| `fifo`                     | FIFO register with upper threshold                               | *deprecated* | `fifo_v3`     |
+| `fifo_v2`                  | FIFO register with upper and lower threshold                     | *deprecated* | `fifo_v3`     |
+| `fifo_v3`                  | FIFO register with generic fill counts                           | active       |               |
+| `stream_fifo`              | FIFO register with ready/valid interface                         | active       |               |
+| `stream_fifo_optimal_wrap` | Wrapper that optimally selects either a spill register or a FIFO | active       |               |
+| `generic_fifo`             | FIFO register without thresholds                                 | *deprecated* | `fifo_v3`     |
+| `generic_fifo_adv`         | FIFO register without thresholds                                 | *deprecated* | `fifo_v3`     |
+| `sram`                     | SRAM behavioral model                                            | active       |               |
+| `plru_tree`                | Pseudo least recently used tree                                  | active       |               |
+| `unread`                   | Empty module to sink unconnected outputs into                    | active       |               |
 
 
 ## Header Contents

--- a/common_cells.core
+++ b/common_cells.core
@@ -69,6 +69,7 @@ filesets:
       - src/id_queue.sv
       - src/stream_to_mem.sv
       - src/stream_arbiter_flushable.sv
+      - src/stream_fifo_optimal_wrap.sv
       - src/stream_register.sv
       - src/stream_xbar.sv
       # Level 3

--- a/src/stream_fifo_optimal_wrap.sv
+++ b/src/stream_fifo_optimal_wrap.sv
@@ -1,0 +1,130 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Thomas Benz <tbenz@ethz.ch>
+
+`include "common_cells/assertions.svh"
+
+/// Optimal implementation of a stream FIFO based on the common cells modules.
+/// Selects the smaller and faster spill register if the depth is 2 and the FIFO if
+/// the depth is >2. Throws an error for the meaningless configurations depth 0 and 1.
+/// Includes assertion to check for full push and empty pop scenarios.
+module stream_fifo_optimal_wrap #(
+    /// Depth can be arbitrary from 2 to 2**32
+    parameter int unsigned Depth = 32'd8,
+    /// Type of the FIFO
+    parameter type type_t = logic,
+    /// Print information when the simulation launches
+    parameter bit PrintInfo = 1'b0,
+    // DO NOT OVERWRITE THIS PARAMETER
+    parameter int unsigned AddrDepth  = (Depth > 32'd1) ? $clog2(Depth) : 32'd1
+) (
+    input  logic                 clk_i,      // Clock
+    input  logic                 rst_ni,     // Asynchronous reset active low
+    input  logic                 flush_i,    // flush the fifo
+    input  logic                 testmode_i, // test_mode to bypass clock gating
+    output logic [AddrDepth-1:0] usage_o,    // fill pointer
+    // input interface
+    input  type_t                data_i,     // data to push into the fifo
+    input  logic                 valid_i,    // input data valid
+    output logic                 ready_o,    // fifo is not full
+    // output interface
+    output type_t                data_o,     // output data
+    output logic                 valid_o,    // fifo is not empty
+    input  logic                 ready_i     // pop head from fifo
+);
+
+    //--------------------------------------
+    // Prevent Depth 0 and 1
+    //--------------------------------------
+    // Throw an error if depth is 0 or 1
+    // pragma translate off
+    if (Depth < 32'd2) begin : gen_fatal
+        initial begin
+            $fatal(1, "FIFO of depth %d does not make any sense!", Depth);
+        end
+    end
+    // pragma translate on
+
+    //--------------------------------------
+    // Spill register (depth 2)
+    //--------------------------------------
+    // Instantiate a spill register for depth 2
+    if (Depth == 32'd2) begin : gen_spill
+
+        // print info
+        // pragma translate off
+        if (PrintInfo) begin : gen_info
+            initial begin
+                $display("[%m] Instantiate spill register (of depth %d)", Depth);
+            end
+        end
+        // pragma translate on
+
+        // spill register
+        spill_register_flushable #(
+            .T       ( type_t ),
+            .Bypass  ( 1'b0   )
+        ) i_spill_register_flushable (
+            .clk_i,
+            .rst_ni,
+            .flush_i,
+            .valid_i,
+            .ready_o,
+            .data_i,
+            .valid_o,
+            .ready_i,
+            .data_o
+        );
+
+        // usage is not supported
+        assign usage_o = 'x;
+
+        // no full push
+        `ASSERT_NEVER(CheckFullPush, (!ready_o & valid_i), clk_i, !rst_ni)
+        // empty pop
+        `ASSERT_NEVER(CheckEmptyPop, (!valid_o & ready_i), clk_i, !rst_ni)
+    end
+
+
+    //--------------------------------------
+    // FIFO register (depth 3+)
+    //--------------------------------------
+    // default to stream fifo
+    if (Depth > 32'd2) begin : gen_fifo
+
+        // print info
+        // pragma translate off
+        if (PrintInfo) begin : gen_info
+            initial begin
+                $info("[%m] Instantiate stream FIFO of depth %d", Depth);
+            end
+        end
+        // pragma translate on
+
+        // stream fifo
+        stream_fifo #(
+            .DEPTH        ( Depth  ),
+            .T            ( type_t )
+        ) i_stream_fifo (
+            .clk_i,
+            .rst_ni,
+            .flush_i,
+            .testmode_i,
+            .usage_o,
+            .data_i,
+            .valid_i,
+            .ready_o,
+            .data_o,
+            .valid_o,
+            .ready_i
+        );
+
+        // no full push
+        `ASSERT_NEVER(CheckFullPush, (!ready_o & valid_i), clk_i, !rst_ni)
+        // empty pop
+        `ASSERT_NEVER(CheckEmptyPop, (!valid_o & ready_i), clk_i, !rst_ni)
+    end
+
+endmodule : stream_fifo_optimal_wrap

--- a/src_files.yml
+++ b/src_files.yml
@@ -66,6 +66,7 @@ common_cells_all:
     - src/id_queue.sv
     - src/stream_to_mem.sv
     - src/stream_arbiter_flushable.sv
+    - src/stream_fifo_optimal_wrap.sv
     - src/stream_register.sv
     - src/stream_xbar.sv
     # Level 3


### PR DESCRIPTION
Based on synthesis numbers spill registers are superior in terms of area and timing to FIFOs of depth 2 whilst having the same semantics. A wrapper was created to select the optimal configuration.