### PR TITLE
Fix FuseSoc core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.24.1 - 2022-04-13
 ### Fixed
+- Fix FuseSoc core version in `common_cells.core`
 - Fix typos in `Bender.yml` and `src_files.yml`
 
 ## 1.24.0 - 2022-03-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 1.24.1 - 2022-04-13
 ### Fixed
-- Fix FuseSoc core version in `common_cells.core`
 - Fix typos in `Bender.yml` and `src_files.yml`
 
 ## 1.24.0 - 2022-03-31

--- a/common_cells.core
+++ b/common_cells.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : pulp-platform.org::common_cells:1.20.0
+name : pulp-platform.org::common_cells:1.24.1
 
 filesets:
   rtl:


### PR DESCRIPTION
It seems `common_cells.core` is out of date for some time now. However there is at least[ one other IP](https://github.com/pulp-platform/axi/blob/db457aa8d8996d87ca72486a9b15873042e04d38/axi.core#L54) in PULP that expects newer version of `common_cells` through FuseSoc. This PR should fix that.