### PR TITLE
Add `addr_decode_napot`

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -60,6 +60,7 @@ sources:
   - src/unread.sv
   - src/cdc_reset_ctrlr_pkg.sv
   # Level 1
+  - src/addr_decode_napot.sv
   - src/cdc_2phase.sv
   - src/cdc_4phase.sv
   - src/addr_decode.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use `tc_clk_mux` as glitch-free muxes in `rstgen_bypass` to avoid combinational glitches.
 - Avoid program blocks in testbenches for simulator compatibility.
 
+## Unreleased
+### Added
+- Add `addr_decode_napot`: variant of `addr_decode` which uses a base address and mask instead of a start and end address.
+
+### Fixed
+- Remove program blocks in testbenches for VCS compatibility.
+- Remove derived parameter mask type in id_queue for VCS compatibility.
+- Remove `cb_filter` and `cb_filter_pkg` from from Vivado IP packager project sources due to compatibility issues.
+
+### Changed
+- Use `tc_clk_mux` as glitch-free muxes in `rstgen_bypass` to avoid combinational glitches.
+
 ## 1.24.1 - 2022-04-13
 ### Fixed
 - Fix typos in `Bender.yml` and `src_files.yml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## Unreleased
+### Added
+- Add `addr_decode_napot`: variant of `addr_decode` which uses a base address and mask instead of a start and end address.
+
 ### Changed
 - Avoid using `$bits()` call in `id_queue`'s parameters.
 - Remove `cb_filter` and `cb_filter_pkg` from from Vivado IP packager project sources due to compatibility issues.
 - Use `tc_clk_mux` as glitch-free muxes in `rstgen_bypass` to avoid combinational glitches.
 - Avoid program blocks in testbenches for simulator compatibility.
-
-## Unreleased
-### Added
-- Add `addr_decode_napot`: variant of `addr_decode` which uses a base address and mask instead of a start and end address.
-
-### Fixed
-- Remove program blocks in testbenches for VCS compatibility.
-- Remove derived parameter mask type in id_queue for VCS compatibility.
-- Remove `cb_filter` and `cb_filter_pkg` from from Vivado IP packager project sources due to compatibility issues.
-
-### Changed
-- Use `tc_clk_mux` as glitch-free muxes in `rstgen_bypass` to avoid combinational glitches.
 
 ## 1.24.1 - 2022-04-13
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Please note that cells with status *deprecated* are not to be used for new desig
 
 | Name                       | Description                                                                                               | Status       | Superseded By |
 | -------------------------- | --------------------------------------------------------------------------------------------------------- | ------------ | ------------- |
-| `addr_decode   `           | Address map decoder                                                                                       | active       |               |
+| `addr_decode`              | Address map decoder                                                                                       | active       |               |
+| `addr_decode_napot`        | Address map decoder using naturally-aligned power of two (NAPOT) regions                                  | active       |               |
 | `ecc_decode`               | SECDED Decoder (Single Error Correction, Double Error Detection)                                          | active       |               |
 | `ecc_encode`               | SECDED Encoder (Single Error Correction, Double Error Detection)                                          | active       |               |
 | `binary_to_gray`           | Binary to gray code converter                                                                             | active       |               |

--- a/common_cells.core
+++ b/common_cells.core
@@ -49,6 +49,7 @@ filesets:
       - src/cdc_2phase.sv
       - src/cdc_4phase.sv
       - src/addr_decode.sv
+      - src/addr_decode_napot.sv
       - src/cb_filter.sv
       - src/cdc_fifo_2phase.sv
       - src/counter.sv

--- a/src/addr_decode_napot.sv
+++ b/src/addr_decode_napot.sv
@@ -1,0 +1,119 @@
+// Copyright 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+/// Address Decoder: Maps the input address combinatorially to an index.
+/// The address map `addr_map_i` is a packed array of rule_t structs.
+/// The ranges of any two rules may overlap. If so, the rule at the higher (more significant)
+/// position in `addr_map_i` prevails.
+///
+/// There can be an arbitrary number of address rules. There can be multiple
+/// ranges defined for the same index. The start address has to be less than the end address.
+///
+/// There is the possibility to add a default mapping:
+/// `en_default_idx_i`: Driving this port to `1'b1` maps all input addresses
+/// for which no rule in `addr_map_i` exists to the default index specified by
+/// `default_idx_i`. In this case, `dec_error_o` is always `1'b0`.
+///
+/// Assertions: The module checks every time there is a change in the address mapping
+/// if the resulting map is valid. It fatals if `start_addr` is higher than `end_addr`
+/// or if a mapping targets an index that is outside the number of allowed indices.
+/// It issues warnings if the address regions of any two mappings overlap.
+module addr_decode_napot #(
+  /// Highest index which can happen in a rule.
+  parameter int unsigned NoIndices = 32'd0,
+  /// Total number of rules.
+  parameter int unsigned NoRules   = 32'd0,
+  /// Address type inside the rules and to decode.
+  parameter type         addr_t    = logic,
+  /// Rule packed struct type.
+  /// The address decoder expects three fields in `rule_t`:
+  ///
+  /// typedef struct packed {
+  ///   int unsigned idx;
+  ///   addr_t       base;
+  ///   addr_t       mask;
+  /// } rule_t;
+  ///
+  ///  - `idx`:        index of the rule, has to be < `NoIndices`
+  ///  - `start_addr`: start address of the range the rule describes, value is included in range
+  ///  - `end_addr`:   end address of the range the rule describes, value is NOT included in range
+  parameter type         rule_t    = logic,
+  /// Dependent parameter, do **not** overwite!
+  ///
+  /// Width of the `idx_o` output port.
+  parameter int unsigned IdxWidth  = cf_math_pkg::idx_width(NoIndices),
+  /// Dependent parameter, do **not** overwite!
+  ///
+  /// Type of the `idx_o` output port.
+  parameter type         idx_t     = logic [IdxWidth-1:0]
+) (
+  /// Address to decode.
+  input  addr_t               addr_i,
+  /// Address map: rule with the highest array position wins on collision
+  input  rule_t [NoRules-1:0] addr_map_i,
+  /// Decoded index.
+  output idx_t                idx_o,
+  /// Decode is valid.
+  output logic                dec_valid_o,
+  /// Decode is not valid, no matching rule found.
+  output logic                dec_error_o,
+  /// Enable default port mapping.
+  ///
+  /// When not used, tie to `0`.
+  input  logic                en_default_idx_i,
+  /// Default port index.
+  ///
+  /// When `en_default_idx_i` is `1`, this will be the index when no rule matches.
+  ///
+  /// When not used, tie to `0`.
+  input  idx_t                default_idx_i
+);
+
+  logic [NoRules-1:0] matched_rules; // purely for address map debugging
+
+  always_comb begin
+    // default assignments
+    matched_rules = '0;
+    dec_valid_o   = 1'b0;
+    dec_error_o   = (en_default_idx_i) ? 1'b0 : 1'b1;
+    idx_o         = (en_default_idx_i) ? default_idx_i : '0;
+
+    // match the rules
+    for (int unsigned i = 0; i < NoRules; i++) begin
+      if ((addr_map_i[i].base & addr_map_i[i].mask) == (addr_i & addr_map_i[i].mask)) begin
+        matched_rules[i] = 1'b1;
+        dec_valid_o      = 1'b1;
+        dec_error_o      = 1'b0;
+        idx_o            = idx_t'(addr_map_i[i].idx);
+      end
+    end
+  end
+
+  // Assumptions and assertions
+  `ifndef VERILATOR
+  // pragma translate_off
+  initial begin : proc_check_parameters
+    assume ($bits(addr_i) == $bits(addr_map_i[0].base)) else
+      $warning($sformatf("Input address has %d bits and address map has %d bits.",
+        $bits(addr_i), $bits(addr_map_i[0].base)));
+    assume (NoRules > 0) else
+      $fatal(1, $sformatf("At least one rule needed"));
+    assume (NoIndices > 0) else
+      $fatal(1, $sformatf("At least one index needed"));
+  end
+
+  assert final ($onehot0(matched_rules)) else
+    $warning("More than one bit set in the one-hot signal, matched_rules");
+
+  // pragma translate_on
+  `endif
+endmodule

--- a/src/addr_decode_napot.sv
+++ b/src/addr_decode_napot.sv
@@ -77,9 +77,7 @@ module addr_decode_napot #(
     .NoRules   ( NoRules      ),
     .addr_t    ( addr_t       ),
     .rule_t    ( rule_range_t ),
-    .Napot     ( 1            ),
-    .IdxWidth  ( IdxWidth     ),
-    .idx_t     ( idx_t        )
+    .Napot     ( 1            )
   ) i_addr_decode (
     .addr_i,
     .addr_map_i,

--- a/src_files.yml
+++ b/src_files.yml
@@ -46,6 +46,7 @@ common_cells_all:
     - src/cdc_2phase.sv
     - src/cdc_4phase.sv
     - src/addr_decode.sv
+    - src/addr_decode_napot.sv
     - src/cb_filter.sv
     - src/cdc_fifo_2phase.sv
     - src/counter.sv


### PR DESCRIPTION
Add `addr_decode_napot`, which uses a base address and mask instead of a start and end address.

TODO:

* [x] Avoid `addr_decode_napot` copypasta by properly extending and wrapping `addr_decode`
* [ ] Check refactor in simulation