### PR TITLE
Use glitch-free `tc_clk_mux` muxes in `rstgen_bypass`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Changed
 - Avoid using `$bits()` call in `id_queue`'s parameters.
+- Use `tc_clk_mux` as glitch-free muxes in `rstgen_bypass` to avoid combinational glitches.
 
 ## 1.24.1 - 2022-04-13
 ### Fixed

--- a/src/rstgen_bypass.sv
+++ b/src/rstgen_bypass.sv
@@ -27,18 +27,28 @@ module rstgen_bypass #(
     logic rst_n;
 
     logic [NumRegs-1:0] synch_regs_q;
-    // bypass mode
-    always_comb begin
-        if (test_mode_i == 1'b0) begin
-            rst_n   = rst_ni;
-            rst_no  = synch_regs_q[NumRegs-1];
-            init_no = synch_regs_q[NumRegs-1];
-        end else begin
-            rst_n   = rst_test_mode_ni;
-            rst_no  = rst_test_mode_ni;
-            init_no = 1'b1;
-        end
-    end
+
+    // bypass mode: use glitch-free (clock) multiplexers
+    tc_clk_mux2 i_tc_clk_mux2_rst_n (
+        .clk0_i     ( rst_ni ),
+        .clk1_i     ( rst_test_mode_ni ),
+        .clk_sel_i  ( test_mode_i ),
+        .clk_o      ( rst_n )
+    );
+
+    tc_clk_mux2 i_tc_clk_mux2_rst_no (
+        .clk0_i     ( synch_regs_q[NumRegs-1] ),
+        .clk1_i     ( rst_test_mode_ni ),
+        .clk_sel_i  ( test_mode_i ),
+        .clk_o      ( rst_no )
+    );
+
+    tc_clk_mux2 i_tc_clk_mux2_init_no (
+        .clk0_i     ( synch_regs_q[NumRegs-1] ),
+        .clk1_i     ( 1'b1 ),
+        .clk_sel_i  ( test_mode_i ),
+        .clk_o      ( init_no )
+    );
 
     always @(posedge clk_i or negedge rst_n) begin
         if (~rst_n) begin


### PR DESCRIPTION
The current `rstgen_bypass` uses behaviorally-inferred multiplexing logic to switch between test mode and regular operation. Although `test_mode_i` is usually quasistatic, the generated reset may exhibit glitches if this does not hold for any reason or if the inferred multiplexing logic produces glitches when the reset itself toggles.