### PR TITLE
Exclude `cb_filter` from Vivado IP packager projects

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -22,7 +22,9 @@ sources:
   # etc. Files within a level are ordered alphabetically.
   # Level 0
   - src/binary_to_gray.sv
-  - src/cb_filter_pkg.sv
+  - target: not(all(xilinx,vivado_ipx))
+    files:
+    - src/cb_filter_pkg.sv
   - src/cc_onehot.sv
   - src/cf_math_pkg.sv
   - src/clk_int_div.sv
@@ -61,7 +63,9 @@ sources:
   - src/cdc_2phase.sv
   - src/cdc_4phase.sv
   - src/addr_decode.sv
-  - src/cb_filter.sv
+  - target: not(all(xilinx,vivado_ipx))
+    files:
+    - src/cb_filter.sv
   - src/cdc_fifo_2phase.sv
   - src/counter.sv
   - src/ecc_decode.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Changed
 - Avoid using `$bits()` call in `id_queue`'s parameters.
+- Remove `cb_filter` and `cb_filter_pkg` from from Vivado IP packager project sources due to compatibility issues.
 
 ## 1.24.1 - 2022-04-13
 ### Fixed


### PR DESCRIPTION
Remove `cb_filter` and `cb_filter_pkg` from from Vivado IP packager project sources due to compatibility issues. Note that this does *not* remove it from sources when using Vivado by itself.