### PR TITLE
Allow out-of-bounds top end address in addr_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Allow out-of-bounds (i.e. `'0`) top end address in addr_map of `addr_decode` module for end of address space
+
 ## 1.25.0 - 2022-08-10
 ### Added
 - Add `addr_decode_napot`: variant of `addr_decode` which uses a base address and mask instead of a start and end address.


### PR DESCRIPTION
This allows for use of an address map where the top end address is zero, indicating the end of the address space (or wrap around as there are no longer any bits available).