### PR TITLE
add dummy assign

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -59,6 +59,7 @@ sources:
   - src/sync.sv
   - src/sync_wedge.sv
   - src/unread.sv
+  - src/read.sv
   - src/cdc_reset_ctrlr_pkg.sv
   # Level 1
   - src/addr_decode_napot.sv

--- a/common_cells.core
+++ b/common_cells.core
@@ -45,6 +45,7 @@ filesets:
       - src/sync.sv
       - src/sync_wedge.sv
       - src/unread.sv
+      - src/read.sv
       - src/cdc_reset_ctrlr_pkg.sv
       # Level 1
       - src/cdc_2phase.sv

--- a/src/read.sv
+++ b/src/read.sv
@@ -6,6 +6,7 @@
 // Date: 07.11.2022
 // Description: Dummy circuit to assign a signal, prevent signal being removed after non-ungroupped synthesis compilation
 
+(* no_ungroup *)
 module read #(
     parameter int unsigned Width = 1,
     parameter type T = logic [Width-1:0]

--- a/src/read.sv
+++ b/src/read.sv
@@ -6,9 +6,12 @@
 // Date: 07.11.2022
 // Description: Dummy circuit to assign a signal, prevent signal being removed after non-ungroupped synthesis compilation
 
-module read (
-    input  logic d_i,
-    output logic d_o
+module read #(
+    parameter int unsigned Width = 1,
+    parameter type T = logic [Width-1:0]
+) (
+    input  T d_i,
+    output T d_o
 );
 
   assign d_o = d_i;

--- a/src/read.sv
+++ b/src/read.sv
@@ -1,0 +1,16 @@
+// Copyright 2022 EPFL
+// Solderpad Hardware License, Version 2.1, see LICENSE.md for details.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+// Author: Davide Schiavone, EPFL, OpenHW Group
+// Date: 07.11.2022
+// Description: Dummy circuit to assign a signal, prevent signal being removed after non-ungroupped synthesis compilation
+
+module read (
+    input  logic d_i,
+    output logic d_o
+);
+
+  assign d_o = d_i;
+
+endmodule

--- a/src_files.yml
+++ b/src_files.yml
@@ -42,6 +42,7 @@ common_cells_all:
     - src/sync.sv
     - src/sync_wedge.sv
     - src/unread.sv
+    - src/read.sv
     - src/cdc_reset_ctrlr_pkg.sv
     # Level 1
     - src/cdc_2phase.sv


### PR DESCRIPTION
This module is used when you want to keep an internal signal after synthesis elaboration.

For example to refer to it in the UPFs, or any other reason.