### PR TITLE
`stream_fifo_optimal_wrap`: Remove assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Allow out-of-bounds (i.e. `'0`) top end address in addr_map of `addr_decode` module for end of address space.
 - Update CI.
+- Remove asserts in `stream_fifo_optimal_wrap`
 
 ## 1.25.0 - 2022-08-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Remove asserts in `stream_fifo_optimal_wrap`
+
 ## 1.26.0 - 2022-08-26
 ### Added
 - Add `stream_throttle`: restricts the number of outstanding transfers in a stream.
@@ -11,7 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Allow out-of-bounds (i.e. `'0`) top end address in addr_map of `addr_decode` module for end of address space.
 - Update CI.
-- Remove asserts in `stream_fifo_optimal_wrap`
 
 ## 1.25.0 - 2022-08-10
 ### Added

--- a/src/stream_fifo_optimal_wrap.sv
+++ b/src/stream_fifo_optimal_wrap.sv
@@ -4,12 +4,9 @@
 //
 // Thomas Benz <tbenz@ethz.ch>
 
-`include "common_cells/assertions.svh"
-
 /// Optimal implementation of a stream FIFO based on the common cells modules.
 /// Selects the smaller and faster spill register if the depth is 2 and the FIFO if
 /// the depth is >2. Throws an error for the meaningless configurations depth 0 and 1.
-/// Includes assertion to check for full push and empty pop scenarios.
 module stream_fifo_optimal_wrap #(
     /// Depth can be arbitrary from 2 to 2**32
     parameter int unsigned Depth = 32'd8,
@@ -80,11 +77,6 @@ module stream_fifo_optimal_wrap #(
 
         // usage is not supported
         assign usage_o = 'x;
-
-        // no full push
-        `ASSERT_NEVER(CheckFullPush, (!ready_o & valid_i), clk_i, !rst_ni)
-        // empty pop
-        `ASSERT_NEVER(CheckEmptyPop, (!valid_o & ready_i), clk_i, !rst_ni)
     end
 
 
@@ -120,11 +112,6 @@ module stream_fifo_optimal_wrap #(
             .valid_o,
             .ready_i
         );
-
-        // no full push
-        `ASSERT_NEVER(CheckFullPush, (!ready_o & valid_i), clk_i, !rst_ni)
-        // empty pop
-        `ASSERT_NEVER(CheckEmptyPop, (!valid_o & ready_i), clk_i, !rst_ni)
     end
 
 endmodule : stream_fifo_optimal_wrap


### PR DESCRIPTION
In my opinion, the `Full push` and the `Empty pop` assertions are unnecessary in the `stream_fifo_optimal_wrap`. Empty pops and Full pushes are prevented inside the modules anyway.

Those asserts for example require that the `ready` can only be asserted when the `valid` is asserted, which is an unnecessary restriction in my opinion. The AXI ready signals e.g. are asserted independently of the valid signals.

What do you think @thommythomaso?