### PR TITLE
update assertions for sv2v+yosys

### DIFF
--- a/src/cb_filter.sv
+++ b/src/cb_filter.sv
@@ -235,6 +235,7 @@ module hash_block #(
     end
   end
 
+`ifndef SYNTHESIS
   // assertions
   // pragma translate_off
   initial begin
@@ -243,4 +244,6 @@ module hash_block #(
           InpWidth, HashWidth);
   end
   // pragma translate_on
+`endif
+
 endmodule

--- a/src/cdc_2phase.sv
+++ b/src/cdc_2phase.sv
@@ -57,9 +57,9 @@ module cdc_2phase #(
 );
 
   // Asynchronous handshake signals.
-  `ifndef SV2V  `endif logic async_req;
-  `ifndef SV2V  `endif logic async_ack;
-  `ifndef SV2V  `endif T async_data;
+  `ifndef SV2V  (* dont_touch = "true" *) `endif logic async_req;
+  `ifndef SV2V  (* dont_touch = "true" *) `endif logic async_ack;
+  `ifndef SV2V  (* dont_touch = "true" *) `endif T async_data;
 
   // The sender in the source domain.
   cdc_2phase_src #(.T(T)) i_src (

--- a/src/cdc_2phase.sv
+++ b/src/cdc_2phase.sv
@@ -57,9 +57,9 @@ module cdc_2phase #(
 );
 
   // Asynchronous handshake signals.
-  (* dont_touch = "true" *) logic async_req;
-  (* dont_touch = "true" *) logic async_ack;
-  (* dont_touch = "true" *) T async_data;
+  `ifndef SV2V  `endif logic async_req;
+  `ifndef SV2V  `endif logic async_ack;
+  `ifndef SV2V  `endif T async_data;
 
   // The sender in the source domain.
   cdc_2phase_src #(.T(T)) i_src (
@@ -102,9 +102,9 @@ module cdc_2phase_src #(
   output T     async_data_o
 );
 
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   logic req_src_q, ack_src_q, ack_q;
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   T data_src_q;
 
   // The req_src and data_src registers change when a new data item is accepted.
@@ -152,10 +152,14 @@ module cdc_2phase_dst #(
   input  T     async_data_i
 );
 
+`ifndef SV2V
   (* dont_touch = "true" *)
   (* async_reg = "true" *)
+`endif
   logic req_dst_q, req_q0, req_q1, ack_dst_q;
+`ifndef SV2V
   (* dont_touch = "true" *)
+`endif
   T data_dst_q;
 
   // The ack_dst register changes when a new data item is accepted.

--- a/src/cdc_2phase_clearable.sv
+++ b/src/cdc_2phase_clearable.sv
@@ -83,9 +83,9 @@ module cdc_2phase_clearable #(
   logic        s_dst_isolate_ack_q;
 
   // Asynchronous handshake signals between the CDCs
-  (* dont_touch = "true" *) logic async_req;
-  (* dont_touch = "true" *) logic async_ack;
-  (* dont_touch = "true" *) T async_data;
+  `ifndef SV2V (* dont_touch = "true" *) `endif logic async_req;
+  `ifndef SV2V (* dont_touch = "true" *) `endif logic async_ack;
+  `ifndef SV2V (* dont_touch = "true" *) `endif T async_data;
 
   if (CLEAR_ON_ASYNC_RESET) begin : gen_elaboration_assertion
     if (SYNC_STAGES < 3)
@@ -212,9 +212,9 @@ module cdc_2phase_src_clearable #(
   output T     async_data_o
 );
 
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   logic  req_src_d, req_src_q, ack_synced;
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   T data_src_d, data_src_q;
 
   // Synchronize the async ACK
@@ -286,10 +286,10 @@ module cdc_2phase_dst_clearable #(
   input  T     async_data_i
 );
 
-  (* dont_touch = "true" *)
-  (* async_reg = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
+  `ifndef SV2V (* async_reg = "true" *) `endif
  logic ack_dst_d, ack_dst_q, req_synced, req_synced_q1;
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   T data_dst_d, data_dst_q;
 
 

--- a/src/cdc_4phase.sv
+++ b/src/cdc_4phase.sv
@@ -53,9 +53,9 @@ module cdc_4phase #(
 );
 
   // Asynchronous handshake signals.
-  (* dont_touch = "true" *) logic async_req;
-  (* dont_touch = "true" *) logic async_ack;
-  (* dont_touch = "true" *) T async_data;
+  `ifndef SV2V (* dont_touch = "true" *) `endif logic async_req;
+  `ifndef SV2V (* dont_touch = "true" *) `endif logic async_ack;
+  `ifndef SV2V (* dont_touch = "true" *) `endif T async_data;
 
   // The sender in the source domain.
   cdc_4phase_src #(
@@ -106,11 +106,11 @@ module cdc_4phase_src #(
   output T     async_data_o
 );
 
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   logic  req_src_d, req_src_q;
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   T data_src_d, data_src_q;
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   logic  ack_synced;
 
   typedef enum logic[1:0] {IDLE, WAIT_ACK_ASSERT, WAIT_ACK_DEASSERT} state_e;
@@ -217,9 +217,9 @@ module cdc_4phase_dst #(
   input  T     async_data_i
 );
 
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   logic  ack_dst_d, ack_dst_q;
-  (* dont_touch = "true" *)
+  `ifndef SV2V (* dont_touch = "true" *) `endif
   logic  req_synced;
 
   logic  data_valid;

--- a/src/cdc_fifo_gray.sv
+++ b/src/cdc_fifo_gray.sv
@@ -97,8 +97,10 @@
 
 `include "common_cells/registers.svh"
 
+`ifndef SV2V
 (* no_ungroup *)
 (* no_boundary_optimization *)
+`endif
 module cdc_fifo_gray #(
   /// The width of the default logic type.
   parameter int unsigned WIDTH = 1,
@@ -135,10 +137,15 @@ module cdc_fifo_gray #(
     .src_data_i,
     .src_valid_i,
     .src_ready_o,
-
+`ifndef SV2V
     (* async *) .async_data_o ( async_data ),
     (* async *) .async_wptr_o ( async_wptr ),
     (* async *) .async_rptr_i ( async_rptr )
+`else
+    .async_data_o ( async_data ),
+    .async_wptr_o ( async_wptr ),
+    .async_rptr_i ( async_rptr )
+`endif
   );
 
   cdc_fifo_gray_dst #(
@@ -150,10 +157,15 @@ module cdc_fifo_gray #(
     .dst_data_o,
     .dst_valid_o,
     .dst_ready_i,
-
+`ifndef SV2V
     (* async *) .async_data_i ( async_data ),
     (* async *) .async_wptr_i ( async_wptr ),
     (* async *) .async_rptr_o ( async_rptr )
+`else
+    .async_data_i ( async_data ),
+    .async_wptr_i ( async_wptr ),
+    .async_rptr_o ( async_rptr )
+`endif
   );
 
   // Check the invariants.
@@ -166,9 +178,10 @@ module cdc_fifo_gray #(
 
 endmodule
 
-
+`ifndef SV2V
 (* no_ungroup *)
 (* no_boundary_optimization *)
+`endif
 module cdc_fifo_gray_src #(
   parameter type T = logic,
   parameter int LOG_DEPTH = 3,
@@ -224,9 +237,10 @@ module cdc_fifo_gray_src #(
 
 endmodule
 
-
+`ifndef SV2V
 (* no_ungroup *)
 (* no_boundary_optimization *)
+`endif
 module cdc_fifo_gray_dst #(
   parameter type T = logic,
   parameter int LOG_DEPTH = 3,

--- a/src/cdc_fifo_gray_clearable.sv
+++ b/src/cdc_fifo_gray_clearable.sv
@@ -97,8 +97,12 @@
 
 `include "common_cells/registers.svh"
 
+
+`ifndef SV2V
 (* no_ungroup *)
 (* no_boundary_optimization *)
+`endif
+
 module cdc_fifo_gray_clearable #(
   /// The width of the default logic type.
   parameter int unsigned WIDTH = 1,
@@ -177,10 +181,15 @@ module cdc_fifo_gray_clearable #(
     .src_data_i,
     .src_valid_i ( src_valid_i & !s_src_isolate_req ),
     .src_ready_o ( s_src_ready                      ),
-
+`ifndef SV2V
     (* async *) .async_data_o ( async_data ),
     (* async *) .async_wptr_o ( async_wptr ),
     (* async *) .async_rptr_i ( async_rptr )
+`else
+    .async_data_o ( async_data ),
+    .async_wptr_o ( async_wptr ),
+    .async_rptr_i ( async_rptr )
+`endif
   );
 
   assign src_ready_o = s_src_ready & !s_src_isolate_req;
@@ -196,10 +205,15 @@ module cdc_fifo_gray_clearable #(
     .dst_data_o,
     .dst_valid_o ( s_dst_valid                      ),
     .dst_ready_i ( dst_ready_i & !s_dst_isolate_req ),
-
+`ifndef SV2V
     (* async *) .async_data_i ( async_data ),
     (* async *) .async_wptr_i ( async_wptr ),
     (* async *) .async_rptr_o ( async_rptr )
+`else
+    .async_data_i ( async_data ),
+    .async_wptr_i ( async_wptr ),
+    .async_rptr_o ( async_rptr )
+`endif
   );
 
   assign dst_valid_o = s_dst_valid & !s_dst_isolate_req;
@@ -263,9 +277,10 @@ module cdc_fifo_gray_clearable #(
 
 endmodule
 
-
+`ifndef SV2V
 (* no_ungroup *)
 (* no_boundary_optimization *)
+`endif
 module cdc_fifo_gray_src_clearable #(
   parameter type T = logic,
   parameter int LOG_DEPTH = 3,
@@ -323,8 +338,10 @@ module cdc_fifo_gray_src_clearable #(
 endmodule
 
 
+`ifndef SV2V
 (* no_ungroup *)
 (* no_boundary_optimization *)
+`endif
 module cdc_fifo_gray_dst_clearable #(
   parameter type T = logic,
   parameter int LOG_DEPTH = 3,

--- a/src/cdc_reset_ctrlr.sv
+++ b/src/cdc_reset_ctrlr.sv
@@ -137,16 +137,19 @@ module cdc_reset_ctrlr
 
 `ifndef SV2V
   (* dont_touch = "true" *)
-  logic        async_a2b_req, async_b2a_ack;
 `endif
+  logic        async_a2b_req, async_b2a_ack;
+
 `ifndef SV2V
   (* dont_touch = "true" *)
 `endif
   clear_seq_phase_e async_a2b_next_phase;
+
 `ifndef SV2V
   (* dont_touch = "true" *)
 `endif
   logic        async_b2a_req, async_a2b_ack;
+
 `ifndef SV2V
   (* dont_touch = "true" *)
 `endif

--- a/src/cdc_reset_ctrlr.sv
+++ b/src/cdc_reset_ctrlr.sv
@@ -135,13 +135,21 @@ module cdc_reset_ctrlr
   input logic  b_isolate_ack_i
 );
 
+`ifndef SV2V
   (* dont_touch = "true" *)
   logic        async_a2b_req, async_b2a_ack;
+`endif
+`ifndef SV2V
   (* dont_touch = "true" *)
+`endif
   clear_seq_phase_e async_a2b_next_phase;
+`ifndef SV2V
   (* dont_touch = "true" *)
+`endif
   logic        async_b2a_req, async_a2b_ack;
+`ifndef SV2V
   (* dont_touch = "true" *)
+`endif
   clear_seq_phase_e async_b2a_next_phase;
 
   cdc_reset_ctrlr_half #(
@@ -155,12 +163,21 @@ module cdc_reset_ctrlr
     .clear_ack_i        ( a_clear_ack_i        ),
     .isolate_o          ( a_isolate_o          ),
     .isolate_ack_i      ( a_isolate_ack_i      ),
+`ifndef SV2V
     (* async *) .async_next_phase_o ( async_a2b_next_phase ),
     (* async *) .async_req_o        ( async_a2b_req        ),
     (* async *) .async_ack_i        ( async_b2a_ack        ),
     (* async *) .async_next_phase_i ( async_b2a_next_phase ),
     (* async *) .async_req_i        ( async_b2a_req        ),
     (* async *) .async_ack_o        ( async_a2b_ack        )
+`else
+    .async_next_phase_o ( async_a2b_next_phase ),
+    .async_req_o        ( async_a2b_req        ),
+    .async_ack_i        ( async_b2a_ack        ),
+    .async_next_phase_i ( async_b2a_next_phase ),
+    .async_req_i        ( async_b2a_req        ),
+    .async_ack_o        ( async_a2b_ack        )
+`endif
   );
 
     cdc_reset_ctrlr_half #(
@@ -174,12 +191,21 @@ module cdc_reset_ctrlr
     .clear_ack_i        ( b_clear_ack_i        ),
     .isolate_o          ( b_isolate_o          ),
     .isolate_ack_i      ( b_isolate_ack_i      ),
+`ifndef SV2V
     (* async *) .async_next_phase_o ( async_b2a_next_phase ),
     (* async *) .async_req_o        ( async_b2a_req        ),
     (* async *) .async_ack_i        ( async_a2b_ack        ),
     (* async *) .async_next_phase_i ( async_a2b_next_phase ),
     (* async *) .async_req_i        ( async_a2b_req        ),
     (* async *) .async_ack_o        ( async_b2a_ack        )
+`else
+    .async_next_phase_o ( async_b2a_next_phase ),
+    .async_req_o        ( async_b2a_req        ),
+    .async_ack_i        ( async_a2b_ack        ),
+    .async_next_phase_i ( async_a2b_next_phase ),
+    .async_req_i        ( async_a2b_req        ),
+    .async_ack_o        ( async_b2a_ack        )
+`endif
   );
 endmodule
 

--- a/src/exp_backoff.sv
+++ b/src/exp_backoff.sv
@@ -82,6 +82,7 @@ module exp_backoff #(
 ///////////////////////////////////////////////////////
 
 //pragma translate_off
+`ifndef SYNTHESIS
 `ifndef VERILATOR
   initial begin
     // assert wrong parameterizations
@@ -94,5 +95,6 @@ module exp_backoff #(
   end
 `endif
 //pragma translate_on
+`endif
 
 endmodule // exp_backoff

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -49,7 +49,7 @@ module id_queue #(
     parameter int ID_WIDTH  = 0,
     parameter int CAPACITY  = 0,
     parameter bit FULL_BW   = 0,
-    parameter type data_t   = logic,
+    parameter type data_t   = logic[31:0],
     // Dependent parameters, DO NOT OVERRIDE!
     localparam type id_t    = logic[ID_WIDTH-1:0]
 ) (

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -289,7 +289,7 @@ end
 ////////////////////////////////////////////////////////////////////////
 // assertions
 ////////////////////////////////////////////////////////////////////////
-
+`ifndef SYNTHESIS
 // pragma translate_off
 initial begin
   // these are the LUT limits
@@ -311,5 +311,6 @@ end
       else $fatal(1,"Lfsr must not be all-zero.");
 `endif
 // pragma translate_on
+`endif
 
 endmodule // lfsr

--- a/src/lfsr_16bit.sv
+++ b/src/lfsr_16bit.sv
@@ -58,11 +58,13 @@ module lfsr_16bit #(
         end
     end
 
+`ifndef SYNTHESIS
     //pragma translate_off
     initial begin
         assert (WIDTH <= 16)
             else $fatal(1, "WIDTH needs to be less than 16 because of the 16-bit LFSR");
     end
     //pragma translate_on
+`endif
 
 endmodule

--- a/src/lfsr_8bit.sv
+++ b/src/lfsr_8bit.sv
@@ -52,10 +52,12 @@ module lfsr_8bit #(
     end
   end
 
+`ifndef SYNTHESIS
   //pragma translate_off
   initial begin
     assert (WIDTH <= 8) else $fatal(1, "WIDTH needs to be less than 8 because of the 8-bit LFSR");
   end
   //pragma translate_on
+`endif
 
 endmodule

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -39,11 +39,13 @@ module lzc #(
 
     localparam int unsigned NumLevels = $clog2(WIDTH);
 
+`ifndef SYNTHESIS
     // pragma translate_off
     initial begin
       assert(WIDTH > 0) else $fatal(1, "input must be at least one bit wide");
     end
     // pragma translate_on
+`endif
 
     logic [WIDTH-1:0][NumLevels-1:0] index_lut;
     logic [2**NumLevels-1:0] sel_nodes;
@@ -99,6 +101,7 @@ module lzc #(
 
   end : gen_lzc
 
+`ifndef SYNTHESIS
 // pragma translate_off
 `ifndef VERILATOR
   initial begin: validate_params
@@ -107,5 +110,6 @@ module lzc #(
   end
 `endif
 // pragma translate_on
+`endif
 
 endmodule : lzc

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -112,8 +112,10 @@ module rr_arb_tree #(
   // pragma translate_off
   `ifndef VERILATOR
   `ifndef XSIM
+  `ifndef SYNTHESIS
   // Default SVA reset
   default disable iff (!rst_ni || flush_i);
+  `endif
   `endif
   `endif
   // pragma translate_on
@@ -310,6 +312,7 @@ module rr_arb_tree #(
     // pragma translate_off
     `ifndef VERILATOR
     `ifndef XSIM
+    `ifndef SYNTHESIS
     initial begin : p_assert
       assert(NumIn)
         else $fatal(1, "Input must be at least one element wide.");
@@ -340,6 +343,7 @@ module rr_arb_tree #(
     req1 : assert property(
       @(posedge clk_i) req_o |-> |req_i)
         else $fatal (1, "Req out implies req in.");
+    `endif
     `endif
     `endif
     // pragma translate_on

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -262,6 +262,7 @@ module stream_omega_net #(
     // Make sure that the handshake and payload is stable
     // pragma translate_off
     `ifndef VERILATOR
+    `ifndef SYNTHESIS
     default disable iff rst_ni;
     for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
       assert property (@(posedge clk_i) (valid_i[i] |-> sel_i[i] < sel_oup_t'(NumOut))) else
@@ -295,6 +296,7 @@ module stream_omega_net #(
       assert ($clog2(NumLanes) % SelW == 0) else
           $fatal(1, "Bit slicing of the internal selection signal is broken.");
     end
+    `endif
     `endif
     // pragma translate_on
   end

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -164,6 +164,7 @@ module stream_xbar #(
   // Make sure that the handshake and payload is stable
   // pragma translate_off
   `ifndef VERILATOR
+  `ifndef SYNTHESIS
   default disable iff rst_ni;
   for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
     assert property (@(posedge clk_i) (valid_i[i] |-> sel_i[i] < sel_oup_t'(NumOut))) else
@@ -193,6 +194,7 @@ module stream_xbar #(
     assert (NumInp > 32'd0) else $fatal(1, "NumInp has to be > 0!");
     assert (NumOut > 32'd0) else $fatal(1, "NumOut has to be > 0!");
   end
+  `endif
   `endif
   // pragma translate_on
 endmodule

--- a/src/sync.sv
+++ b/src/sync.sv
@@ -19,9 +19,10 @@ module sync #(
     input  logic serial_i,
     output logic serial_o
 );
-
+`ifndef SV2V
    (* dont_touch = "true" *)
    (* async_reg = "true" *)
+`endif
    logic [STAGES-1:0] reg_q;
 
     always_ff @(posedge clk_i, negedge rst_ni) begin


### PR DESCRIPTION
hey guys (@meggiman , @micprog , @SamuelRiedel ), I added a few ifdef SV2V to get rid of attributes, and ifdef SYNTHESIS around assertions.

Not sure whether SV2V is appropriate, I did not want to add ifdef ATTRIBUTES as it is really tool specific to SV2V, also I assume soon or later yosys will support systemverilog, thus sv2v won't be used again