### PR TITLE
add more ifdef verilator

### DIFF
--- a/src/cb_filter.sv
+++ b/src/cb_filter.sv
@@ -235,6 +235,7 @@ module hash_block #(
     end
   end
 
+`ifndef VERILATOR
   // assertions
   // pragma translate_off
   initial begin
@@ -243,4 +244,5 @@ module hash_block #(
           InpWidth, HashWidth);
   end
   // pragma translate_on
+`endif
 endmodule

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -49,7 +49,7 @@ module id_queue #(
     parameter int ID_WIDTH  = 0,
     parameter int CAPACITY  = 0,
     parameter bit FULL_BW   = 0,
-    parameter type data_t   = logic,
+    parameter type data_t   = logic[31:0],
     // Dependent parameters, DO NOT OVERRIDE!
     localparam type id_t    = logic[ID_WIDTH-1:0]
 ) (

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -289,7 +289,7 @@ end
 ////////////////////////////////////////////////////////////////////////
 // assertions
 ////////////////////////////////////////////////////////////////////////
-
+`ifndef VERILATOR
 // pragma translate_off
 initial begin
   // these are the LUT limits
@@ -304,6 +304,7 @@ initial begin
   assert((CipherLayers > 0) && (LfsrWidth == 64) || (CipherLayers == 0)) else
     $fatal(1, "Use additional cipher layers only in conjunction with an LFSR width of 64 bit." );
 end
+`endif
 
 `ifndef VERILATOR
   all_zero: assert property (

--- a/src/lfsr_16bit.sv
+++ b/src/lfsr_16bit.sv
@@ -58,11 +58,13 @@ module lfsr_16bit #(
         end
     end
 
+  `ifndef VERILATOR
     //pragma translate_off
     initial begin
         assert (WIDTH <= 16)
             else $fatal(1, "WIDTH needs to be less than 16 because of the 16-bit LFSR");
     end
     //pragma translate_on
+  `endif
 
 endmodule

--- a/src/lfsr_8bit.sv
+++ b/src/lfsr_8bit.sv
@@ -52,10 +52,12 @@ module lfsr_8bit #(
     end
   end
 
+`ifndef VERILATOR
   //pragma translate_off
   initial begin
     assert (WIDTH <= 8) else $fatal(1, "WIDTH needs to be less than 8 because of the 8-bit LFSR");
   end
   //pragma translate_on
+`endif
 
 endmodule

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -39,11 +39,13 @@ module lzc #(
 
     localparam int unsigned NumLevels = $clog2(WIDTH);
 
+  `ifndef VERILATOR
     // pragma translate_off
     initial begin
       assert(WIDTH > 0) else $fatal(1, "input must be at least one bit wide");
     end
     // pragma translate_on
+  `endif
 
     logic [WIDTH-1:0][NumLevels-1:0] index_lut;
     logic [2**NumLevels-1:0] sel_nodes;


### PR DESCRIPTION
Dear @meggiman and @niwis , thanks for reviewing and suggesting changes wrt #164 - 

Ok, I think it is clean enough until sv2v or yosys get better at supporting **sv**,

meanwhile, I added a couple more ifdef for VERILATOR.

To be 100% fair, I do not know whether VERILATOR supports them or not, but I did not want to add ifdef YOSYS or SV2V, so I borrowed VERILATOR

Is that ok?

