### PR TITLE
Add priority encoder

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -43,6 +43,7 @@ sources:
   - src/onehot_to_bin.sv
   - src/plru_tree.sv
   - src/popcount.sv
+  - src/priority_encoder.sv
   - src/rr_arb_tree.sv
   - src/rstgen_bypass.sv
   - src/serial_deglitch.sv
@@ -116,6 +117,7 @@ sources:
       - test/graycode_tb.sv
       - test/id_queue_tb.sv
       - test/popcount_tb.sv
+      - test/priority_encoder_tb.sv
       - test/rr_arb_tree_tb.sv
       - test/stream_test.sv
       - test/stream_register_tb.sv

--- a/common_cells.core
+++ b/common_cells.core
@@ -30,6 +30,7 @@ filesets:
       - src/onehot_to_bin.sv
       - src/plru_tree.sv
       - src/popcount.sv
+      - src/priority_encoder.sv
       - src/rr_arb_tree.sv
       - src/rstgen_bypass.sv
       - src/serial_deglitch.sv

--- a/src/priority_encoder.sv
+++ b/src/priority_encoder.sv
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright 2023 ETH Zurich and University of Bologna.
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+/*
+ * Module `priority_encoder`
+ *
+ * This module implements a fully-combinational priority encoder. 
+ *
+ * It takes as input a signal of `N_BITS` bits and returns the index of the 
+ * first LSB set to 1. Any `N_BITS` value bigger than 1 is legal. The module 
+ * pads the input signal internally to the next power of two, because of how
+ * the recursive module instantiation work. The output signal width is 
+ * $clog2(N_BITS) bits wide.
+ *
+ * Author: Emanuele Parisi <emanuele.parisi@unibo.it>
+ */
+
+module priority_encoder #(
+    parameter int unsigned N_BITS = 8
+) (
+    input  logic [N_BITS-1:0]         data_i,
+    output logic [$clog2(N_BITS)-1:0] data_o,
+    output logic                      valid_o
+);
+
+    localparam int unsigned PADDED_N_BITS = 1 << $clog2(N_BITS);
+
+    if (PADDED_N_BITS == 2) begin
+        always_comb begin
+            unique case (data_i) 
+                2'b01, 2'b11: begin
+                    data_o  = 'b0;
+                    valid_o = 'b1;
+                end
+                2'b10: begin
+                    data_o  = 'b1;
+                    valid_o = 'b1;
+                end
+                default: begin
+                    data_o  = 'b0;
+                    valid_o = 'b0;
+                end
+            endcase
+        end
+    end else begin
+        logic [PADDED_N_BITS-1:0]         padded_data;
+        logic [$clog2(PADDED_N_BITS)-2:0] lsb_data;
+        logic                             lsb_valid;
+        logic [$clog2(PADDED_N_BITS)-2:0] msb_data;
+        logic                             msb_valid;
+
+        assign padded_data = data_i;
+
+        priority_encoder #(.N_BITS(PADDED_N_BITS/2)) priority_encoder_lsb (
+            .data_i  (padded_data[PADDED_N_BITS/2-1:0]),
+            .data_o  (lsb_data),
+            .valid_o (lsb_valid)
+        );
+        priority_encoder #(.N_BITS(PADDED_N_BITS/2)) priority_encoder_msb (
+            .data_i  (padded_data[PADDED_N_BITS-1:PADDED_N_BITS/2]),
+            .data_o  (msb_data),
+            .valid_o (msb_valid)
+        );
+
+        always_comb begin
+            unique case ({msb_valid, lsb_valid})
+                2'b01, 2'b11: begin
+                    data_o  = {1'b0, lsb_data};
+                    valid_o = 'b1;
+                end
+                2'b10: begin
+                    data_o  = {1'b1, msb_data};
+                    valid_o = 'b1;
+                end
+                default: begin
+                    data_o  = 'b0;
+                    valid_o = 'b0;
+                end
+            endcase
+        end
+    end
+
+endmodule

--- a/src_files.yml
+++ b/src_files.yml
@@ -26,6 +26,7 @@ common_cells_all:
     - src/onehot_to_bin.sv
     - src/plru_tree.sv
     - src/popcount.sv
+    - src/priority_encoder.sv
     - src/rr_arb_tree.sv
     - src/rstgen_bypass.sv
     - src/serial_deglitch.sv

--- a/test/priority_encoder_tb.sv
+++ b/test/priority_encoder_tb.sv
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2023 ETH Zurich and University of Bologna.
+ * Copyright and related rights are licensed under the Solderpad Hardware
+ * License, Version 0.51 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+ * or agreed to in writing, software, hardware and materials distributed under
+ * this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ ******************************************************************************/
+/*
+ * Module `priority_encoder_tb`
+ *
+ * A testbench for the priority encoder module.
+ *
+ * It tests the priority encoder module in two configurations, with input
+ * signal width of 5 and 8.
+ *
+ * Author: Emanuele Parisi <emanuele.parisi@unibo.it>
+ */
+
+module priority_encoder_tb ();
+
+    localparam int unsigned DUT0_N_BITS = 8;
+    localparam int unsigned DUT1_N_BITS = 5;
+
+    logic [DUT0_N_BITS-1:0]         dut0_data_i;
+    logic [$clog2(DUT0_N_BITS)-1:0] dut0_data_o;
+    logic                           dut0_valid_o;
+
+    logic [DUT1_N_BITS-1:0]         dut1_data_i;
+    logic [$clog2(DUT1_N_BITS)-1:0] dut1_data_o;
+    logic                           dut1_valid_o;
+
+    priority_encoder #(.N_BITS(DUT0_N_BITS)) dut0 (
+        .data_i (dut0_data_i),
+        .data_o (dut0_data_o),
+        .valid_o(dut0_valid_o)
+    );
+
+    priority_encoder #(.N_BITS(DUT1_N_BITS)) dut1 (
+        .data_i (dut1_data_i),
+        .data_o (dut1_data_o),
+        .valid_o(dut1_valid_o)
+    );
+
+    initial begin
+        // Apply test stimuli to DUT 0.
+        dut1_data_i = 'b0;
+        for (int i=0; i<2**DUT0_N_BITS; i++) begin
+            dut0_data_i = i;
+            #1;
+        end
+
+        // Apply test stimuli to DUT 1.
+        dut0_data_i = 'b0;
+        for (int i=0; i<2**DUT1_N_BITS; i++) begin
+            dut1_data_i = i;
+            #1;
+        end
+
+        $finish;
+    end
+
+endmodule


### PR DESCRIPTION
Hi! I designed this priority encoder in the context of a project we are carrying on at University of Bologna, about enhancing the CVA6 core with security features. 

This is a fully-combinational, generic, priority encoder that takes as input a `N_BITS` signal and returns the index of the first bit set, giving higher priority to the LSB bit, in case multiple bits are set. If the input is zero, a output flag is cleared. Any input signal whose width is bigger than 1 is legal.