### PR TITLE
Allow clock divider configuration while clock is disabled

### DIFF
--- a/src/clk_int_div.sv
+++ b/src/clk_int_div.sv
@@ -139,7 +139,7 @@ module clk_int_div #(
       IDLE: begin
         gate_en_d     = 1'b1;
         toggle_ffs_en = 1'b1;
-        if (en_i && div_valid_i) begin
+        if (div_valid_i) begin
           if (div_i == div_q) begin
             div_ready_o      = 1'b1;
           end else begin

--- a/test/clk_int_div_tb.sv
+++ b/test/clk_int_div_tb.sv
@@ -100,11 +100,27 @@ module clk_int_div_tb;
     @(posedge rstn);
     in_driver.reset_in();
 
+
     // Verify test bypass mode
     test_mode_en = 1'b1;
     semphr_is_transitioning.put();
     repeat (100) @(clk);
     test_mode_en = 1'b0;
+
+    $info("Testing programming divider while clock disabled...");
+    enable = 1'b0;
+    next_div_value = 3;
+    semphr_is_transitioning.put(1);
+    wait_cycl = $urandom_range(5*current_div_value, MaxWaitCycles*current_div_value);
+    repeat(wait_cycl) @(posedge clk);
+    in_driver.send(next_div_value);
+    current_div_value = next_div_value;
+    semphr_is_transitioning.put(1);
+    @(posedge clk);
+    enable = 1'b1;
+    repeat(20) @(posedge clk);
+
+    $info("Starting randomized reconfiguration while clock is enabled...");
 
     for (int i = 0; i < NumTests; i++) begin
       do begin


### PR DESCRIPTION
The FSM of the configurable clock divider contains an unnecessary gating condition to only allow divider configuration while the output clock is enabled. Although configuration during enabled output clock is perfectly safe since the module temporarily gates itself to avoid any output glitches, it might still be desirable from an application point of view to disable the output clock for a longer time period and re-enable it with a different clock divider value. With the current implementation this is not possible since at least one or two clock edges of the old clock period might still escape the module before the reconfiguration with enabled output clock takes effect.

This PR fixes this and adds a new test to the TB to check if the divider can be configured correctly while `en_i` is de-asserted. Thanks to @fimtrey for pointing out this issue.