### PR TITLE
Trivial FIFO TB additions

### DIFF
--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -74,6 +74,7 @@ module fifo_v3 #(
             // un-gate the clock, we want to write something
             gate_clock = 1'b0;
             // increment the write counter
+            // this is dead code when DEPTH is a power of two
             if (write_pointer_q == FifoDepth[ADDR_DEPTH-1:0] - 1)
                 write_pointer_n = '0;
             else
@@ -85,6 +86,7 @@ module fifo_v3 #(
         if (pop_i && ~empty_o) begin
             // read from the queue is a default assignment
             // but increment the read pointer...
+            // this is dead code when DEPTH is a power of two
             if (read_pointer_n == FifoDepth[ADDR_DEPTH-1:0] - 1)
                 read_pointer_n = '0;
             else

--- a/test/fifo_tb.sv
+++ b/test/fifo_tb.sv
@@ -168,7 +168,7 @@ module fifo_tb #(
     logic       clk,
                 rst_n;
 
-    logic [3:0] done;
+    logic [5:0] done;
 
     clk_rst_gen #(.ClkPeriod(TCLK), .RstClkCycles(10)) i_clk_rst_gen (
         .clk_o    (clk),
@@ -221,6 +221,30 @@ module fifo_tb #(
         .clk_i  (clk),
         .rst_ni (rst_n),
         .done_o (done[3])
+    );
+
+    fifo_inst_tb #(
+        .FALL_THROUGH   (1'b0),
+        .DEPTH          (9),
+        .N_CHECKS       (N_CHECKS),
+        .TA             (TA),
+        .TT             (TT)
+    ) i_tb_9 (
+        .clk_i  (clk),
+        .rst_ni (rst_n),
+        .done_o (done[4])
+    );
+
+    fifo_inst_tb #(
+        .FALL_THROUGH   (1'b1),
+        .DEPTH          (9),
+        .N_CHECKS       (N_CHECKS),
+        .TA             (TA),
+        .TT             (TT)
+    ) i_tb_ft_9 (
+        .clk_i  (clk),
+        .rst_ni (rst_n),
+        .done_o (done[5])
     );
 
     initial begin


### PR DESCRIPTION
I was investigating `fifo_v3` with lint tools. There are no bugs just a few complaints about dead code.

When DEPTH is power of two then the  `if` branch for the write/read pointer updates are not needed (pointers just roll over). Can be e.g. seen by just deleting the branches and re-running the testbenches