### PR TITLE
Fix HideStrb feature of mem_to_banks

### DIFF
--- a/src/mem_to_banks.sv
+++ b/src/mem_to_banks.sv
@@ -154,7 +154,7 @@ module mem_to_banks #(
 
   if (HideStrb) begin : gen_dead_write_fifo
     fifo_v3 #(
-      .FALL_THROUGH ( 1'b1     ),
+      .FALL_THROUGH ( 1'b0     ),
       .DEPTH        ( MaxTrans+1 ),
       .DATA_WIDTH   ( NumBanks )
     ) i_dead_write_fifo (


### PR DESCRIPTION
With this change, mem_to_banks assumes at least 1 cycle latency to the memory bank, but cuts a possible timing loop (e.g., when in axi_to_mem).