### PR TITLE
Fix deadlock on div_i == 0 and avoid hold issues on ungated_output_clock

### DIFF
--- a/lint/common_cells.style.waiver
+++ b/lint/common_cells.style.waiver
@@ -4,9 +4,9 @@ waive --rule=typedef-structs-unions --line=29 --location="src/ecc_encode.sv"
 # That is a known issue with string parameter in Synopsys DC
 waive --rule=explicit-parameter-storage-type --line=19 --location="src/stream_arbiter.sv"
 waive --rule=explicit-parameter-storage-type --line=19 --location="src/stream_arbiter_flushable.sv"
-waive --rule=always-ff-non-blocking --line=262 --location="src/clk_int_div.sv"
-waive --rule=always-ff-non-blocking --line=265 --location="src/clk_int_div.sv"
-waive --rule=always-ff-non-blocking --line=274 --location="src/clk_int_div.sv"
-waive --rule=always-ff-non-blocking --line=277 --location="src/clk_int_div.sv"
+waive --rule=always-ff-non-blocking --line=276 --location="src/clk_int_div.sv"
+waive --rule=always-ff-non-blocking --line=279 --location="src/clk_int_div.sv"
+waive --rule=always-ff-non-blocking --line=288 --location="src/clk_int_div.sv"
+waive --rule=always-ff-non-blocking --line=291 --location="src/clk_int_div.sv"
 # Allow strings to continue across lines
 waive --rule=forbid-line-continuations

--- a/test/clk_int_div_tb.sv
+++ b/test/clk_int_div_tb.sv
@@ -123,12 +123,12 @@ module clk_int_div_tb;
     $info("Starting randomized reconfiguration while clock is enabled...");
 
     for (int i = 0; i < NumTests; i++) begin
-      do begin
-        assert(std::randomize(next_div_value)) else
-          $error("Randomization failure");
-      end while (next_div_value == 0);
+      logic [DivWidth-1:0] div_value_temp;
+      assert(std::randomize(div_value_temp)) else
+        $error("Randomization failure");
       $info("Setting clock divider value to %0d", next_div_value);
-      in_driver.send(next_div_value);
+      next_div_value = (div_value_temp == 0)? 1: div_value_temp;
+      in_driver.send(div_value_temp);
       semphr_is_transitioning.put(1);
       current_div_value = next_div_value;
       wait_cycl = $urandom_range(0, MaxWaitCycles);


### PR DESCRIPTION
Instead of storing div_i directly in the internal register div_q we normalize the value to be strictly larger than 0. This avoids the deadlock issue when preloading with 0. Furthermore this commit removes all combinational checks on the phase of `ungated_output_clock` to avoid hold issues in synthesis. This checks were required to wait until the clock enable signal has been latched by the ICG. Now, we instead use a dedicated flip-flop that tracks the current status of the output clock gate.

This fixes #172.
