### PR TITLE
Add stream_deposit module

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,7 @@ tests:
           - stream_to_mem_tb
           - stream_xbar_tb
           - sub_per_hash_tb
+          - stream_deposit_tb
       - TOPLEVEL: graycode_tb
         PARAM1: [-GN=1, -GN=2, -GN=3, -GN=4, -GN=8, -GN=16]
       - TOPLEVEL: fifo_tb

--- a/Bender.yml
+++ b/Bender.yml
@@ -56,6 +56,7 @@ sources:
   - src/stream_join.sv
   - src/stream_mux.sv
   - src/stream_throttle.sv
+  - src/stream_deposit.sv
   - src/sub_per_hash.sv
   - src/sync.sv
   - src/sync_wedge.sv
@@ -128,6 +129,7 @@ sources:
       - test/stream_xbar_tb.sv
       - test/clk_int_div_tb.sv
       - test/clk_mux_glitch_free_tb.sv
+      - test/stream_deposit_tb.sv
 
 
   - target: synth_test

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 ### Data Path Elements
 
 | Name                       | Description                                                                                               | Status       | Superseded By |
-| -------------------------- | --------------------------------------------------------------------------------------------------------- | ------------ | ------------- |
+|----------------------------|-----------------------------------------------------------------------------------------------------------|--------------|---------------|
 | `addr_decode`              | Address map decoder                                                                                       | active       |               |
 | `addr_decode_napot`        | Address map decoder using naturally-aligned power of two (NAPOT) regions                                  | active       |               |
 | `ecc_decode`               | SECDED Decoder (Single Error Correction, Double Error Detection)                                          | active       |               |
@@ -86,6 +86,7 @@ Please note that cells with status *deprecated* are not to be used for new desig
 | `stream_arbiter`           | Round-robin arbiter for ready/valid stream interface                                                      | active       |               |
 | `stream_arbiter_flushable` | Round-robin arbiter for ready/valid stream interface and flush functionality                              | active       |               |
 | `stream_demux`             | Ready/valid interface demultiplexer                                                                       | active       |               |
+| `stream_deposit`           | Convert Valid-only to ready/valid by updating in-flight transaction                                       | active       |               |
 | `stream_join`              | Ready/valid handshake join multiple to one common                                                         | active       |               |
 | `stream_mux`               | Ready/valid interface multiplexer                                                                         | active       |               |
 | `stream_register`          | Register with ready/valid interface                                                                       | active       |               |

--- a/src/stream_deposit.sv
+++ b/src/stream_deposit.sv
@@ -1,0 +1,81 @@
+//-----------------------------------------------------------------------------
+// Title : Stream Deposit
+// -----------------------------------------------------------------------------
+// File : stream_deposit.sv Author : Manuel Eggimann <meggimann@iis.ee.ethz.ch>
+// Created : 17.05.2023
+// -----------------------------------------------------------------------------
+// Description :
+//
+// This module helps to deal with stream-sources that do not support
+// backpressure i.e. cannot handle the case where the sink is not ready to
+// accept a value. In constrast to a FIFO that queues the transactions, this IP
+// just drops them. That is, the currently stalled in-flight transaction is just
+// updated with the new data sent by the input. Therefore the input of this
+// module is always ready but there is no guarantee that every transaction is
+// sent to the output. The module will just keep the valid_o signal asserted
+// until a transaction is acceted by the output side which at this point
+// receives whatever data the input last deposited.
+//
+// The stream_deposit module is helpful to connect configuration registers with
+// IPs that could cause back pressure. In this case we might not care how long
+// it takes for the config value to be sent to the IP but if we change the
+// config value we want the latest value to be used regardless wether the
+// previous transaction was still in-fligth or not.
+//
+// IMPORTANT: The described behavior of this moduel obviously implies, that the data_o is
+// not stable while valid_o is asserted. If you rely on this property, i.e. you
+// are using the data before you accept the transaction, then you must not use
+// this module!
+//
+//-----------------------------------------------------------------------------
+// Copyright (C) 2023 ETH Zurich, University of Bologna Copyright and related
+// rights are licensed under the Solderpad Hardware License, Version 0.51 (the
+// "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law or
+// agreed to in writing, software, hardware and materials distributed under this
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+// SPDX-License-Identifier: SHL-0.51
+// -----------------------------------------------------------------------------
+
+module stream_deposit #(
+    /// Default data width if the fifo is of type logic
+    parameter int unsigned DATA_WIDTH = 32,
+    parameter type T = logic [DATA_WIDTH-1:0]
+) (
+    input  logic clk_i,
+    input  logic rst_ni,
+    // Input Interface (the input is always ready so there is no ready_o signal)
+    input  logic valid_i,
+    input  T     data_i,
+    // Output Interface
+    output logic valid_o,
+    input  logic ready_i,
+    output T     data_o
+);
+
+  logic pending_d, pending_q;
+  T data_d, data_q;
+
+  assign data_d = valid_i ? data_i : data_q;
+  // The pending flag is set if the input is valid and ready_i is not asserted.
+  // It is cleared if it is currently set and the output side becomes ready.
+  assign pending_d = (valid_i | pending_q) ? ~ready_i : pending_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (~rst_ni) begin
+      pending_q <= 1'b0;
+      data_q    <= '0;
+    end else begin
+      pending_q <= pending_d;
+      data_q    <= data_d;
+    end
+  end
+
+  // If the input side is currently writing data, bypass the register.
+  assign valid_o = valid_i | pending_q;
+  assign data_o  = valid_i ? data_i : data_q;
+
+endmodule

--- a/test/stream_deposit_tb.sv
+++ b/test/stream_deposit_tb.sv
@@ -1,0 +1,111 @@
+//-----------------------------------------------------------------------------
+// Copyright (C) 2023 ETH Zurich, University of Bologna
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+// SPDX-License-Identifier: SHL-0.51
+//-----------------------------------------------------------------------------
+
+// Author: Manuel Eggimann <meggimann@iis.ee.ethz.ch>
+
+module stream_deposit_tb #(
+    /// Theu number of requests to simulate
+    parameter int unsigned NumReq   = 32'd10000,
+    /// Clock cycle time.
+    parameter time         CyclTime = 20ns
+);
+
+  logic clk;
+  logic rst_n;
+
+  localparam type payload_t = logic [$clog2(NumReq)-1:0];
+
+
+
+  // clock generator
+  clk_rst_gen #(
+      .ClkPeriod   (CyclTime),
+      .RstClkCycles(5)
+  ) i_clk_rst_gen (
+      .clk_o (clk),
+      .rst_no(rst_n)
+  );
+
+  typedef stream_test::stream_driver#(
+      .payload_t(payload_t),
+      .TA(CyclTime * 0.2),
+      .TT(CyclTime * 0.8)
+  ) stream_driver_in_t;
+
+  STREAM_DV #(.payload_t(payload_t)) dut_in (.clk_i(clk));
+  stream_driver_in_t stream_source = new(dut_in);
+
+  typedef stream_test::stream_driver#(
+      .payload_t(payload_t),
+      .TA(CyclTime * 0.2),
+      .TT(CyclTime * 0.8)
+  ) stream_driver_out_t;
+  STREAM_DV #(.payload_t(payload_t)) dut_out (.clk_i(clk));
+  stream_driver_out_t stream_sink = new(dut_out);
+
+
+  payload_t current_payload;
+  bit data_in_flight = 0;
+
+  assign dut_in.ready = 1'b1;
+  stream_deposit #(
+      .T(payload_t)
+  ) i_stream_deposit (
+      .clk_i  (clk),
+      .rst_ni (rst_n),
+      .valid_i(dut_in.valid),
+      .data_i (dut_in.data),
+      .data_o (dut_out.data),
+      .valid_o(dut_out.valid),
+      .ready_i(dut_out.ready)
+  );
+
+  initial begin : apply_stimuli
+    automatic int unsigned wait_cycl;
+
+    // Disable data stable assertion for this module in the dv interface. The
+    // whole point of the stream_deposit is, that the data does not have to be
+    // stable.
+
+    $assertoff(0, dut_out);
+
+    @(posedge rst_n);
+    stream_source.reset_in();
+    for (int i = 0; i < NumReq; i++) begin
+      wait_cycl = $urandom_range(0, 5);
+      repeat (wait_cycl) @(posedge clk);
+      stream_source.send(i);
+      current_payload = i;
+      data_in_flight = 1;
+    end
+    $stop();
+  end
+
+  initial begin : receive_responses
+    automatic payload_t data;
+    automatic int unsigned wait_cycl;
+    @(posedge rst_n);
+    stream_sink.reset_out();
+    forever begin
+      wait_cycl = $urandom_range(0, 5);
+      repeat (wait_cycl) @(posedge clk);
+      stream_sink.recv(data);
+      assert (data_in_flight) else
+        $error("Receieved transaction at output even though the input side did not send any new data.");
+      assert (data == current_payload) else
+        $error("Received the wrong data. Was %d instead of %d", data, current_payload);
+      data_in_flight = 0;
+    end
+  end
+
+endmodule


### PR DESCRIPTION
This module helps to deal with stream-sources that do not support
 backpressure i.e. cannot handle the case where the sink is not ready to
 accept a value. In constrast to a FIFO that queues the transactions, this IP
 just drops them. That is, the currently stalled in-flight transaction is just
 updated with the new data sent by the input. Therefore the input of this
 module is always ready but there is no guarantee that every transaction is
 sent to the output. The module will just keep the valid_o signal asserted
 until a transaction is acceted by the output side which at this point
 receives whatever data the input last deposited.

 The stream_deposit module is helpful to connect configuration registers with
 IPs that could cause back pressure. In this case we might not care how long
 it takes for the config value to be sent to the IP but if we change the
 config value we want the latest value to be used regardless wether the
 previous transaction was still in-fligth or not.