### PR TITLE
Simplify popcount and add proper support for all input widths

### DIFF
--- a/src/popcount.sv
+++ b/src/popcount.sv
@@ -11,50 +11,30 @@
 // Author: Manuel Eggimann <meggimann@iis.ee.ethz.ch>
 
 // Description: This module calculates the hamming weight (number of ones) in
-// its input vector using a balanced binary adder tree. Recursive instantiation
-// is used to build the tree.  Any unsigned INPUT_WIDTH larger or equal 2 is
-// legal.  The module pads the signal internally to the next power of two.  The
-// output result width is ceil(log2(INPUT_WIDTH))+1.
+// its input vector. Any unsigned INPUT_WIDTH larger or equal 1 is legal. The output result
+// width is ceil(log2(INPUT_WIDTH))+1.
+//
+// This module usded tobe implemented using a binary added tree. However,
+// the heuristics of modern logic Synthesizers work much better with a flat high
+// level description using a for loop and yield exactly the same or even better results.
+
 
 module popcount #(
-    parameter int unsigned INPUT_WIDTH = 256,
-    localparam int unsigned PopcountWidth = $clog2(INPUT_WIDTH)+1
+    parameter  int unsigned INPUT_WIDTH   = 256,
+    localparam int unsigned PopcountWidth = $clog2(INPUT_WIDTH) + 1
 ) (
-    input logic [INPUT_WIDTH-1:0]     data_i,
+    input  logic [  INPUT_WIDTH-1:0] data_i,
     output logic [PopcountWidth-1:0] popcount_o
 );
 
-   localparam int unsigned PaddedWidth = 1 << $clog2(INPUT_WIDTH);
+  if (INPUT_WIDTH < 1)
+    $error("INPUT_WIDTH must be larger or equal to 1.");
 
-   logic [PaddedWidth-1:0]           padded_input;
-   logic [PopcountWidth-2:0]         left_child_result, right_child_result;
-
-   //Zero pad the input to next power of two
-   always_comb begin
-     padded_input = '0;
-     padded_input[INPUT_WIDTH-1:0] = data_i;
-   end
-
-   //Recursive instantiation to build binary adder tree
-   if (INPUT_WIDTH == 1) begin : gen_single_node
-     assign left_child_result  = 1'b0;
-     assign right_child_result = padded_input[0];
-   end else if (INPUT_WIDTH == 2) begin : gen_leaf_node
-     assign left_child_result  = padded_input[1];
-     assign right_child_result = padded_input[0];
-   end else begin : gen_non_leaf_node
-     popcount #(.INPUT_WIDTH(PaddedWidth / 2))
-         left_child(
-                    .data_i(padded_input[PaddedWidth-1:PaddedWidth/2]),
-                    .popcount_o(left_child_result));
-
-     popcount #(.INPUT_WIDTH(PaddedWidth / 2))
-         right_child(
-                     .data_i(padded_input[PaddedWidth/2-1:0]),
-                     .popcount_o(right_child_result));
-   end
-
-   //Output assignment
-   assign popcount_o = left_child_result + right_child_result;
+  always_comb begin
+    popcount_o = 0;
+    for (int i = 0; i < INPUT_WIDTH; i++) begin
+      popcount_o += data_i[i];
+    end
+  end
 
 endmodule : popcount

--- a/src/popcount.sv
+++ b/src/popcount.sv
@@ -14,7 +14,7 @@
 // its input vector. Any unsigned INPUT_WIDTH larger or equal 1 is legal. The output result
 // width is ceil(log2(INPUT_WIDTH))+1.
 //
-// This module usded tobe implemented using a binary added tree. However,
+// This module used to be implemented using a binary added tree. However,
 // the heuristics of modern logic Synthesizers work much better with a flat high
 // level description using a for loop and yield exactly the same or even better results.
 

--- a/test/popcount_tb.sv
+++ b/test/popcount_tb.sv
@@ -31,6 +31,9 @@ end while (0)
 module popcount_tb;
 
    //---------------- Signals connecting to MUT ----------------
+   logic data_w1;
+   logic  popcount_w1;
+
    logic [4:0] data_w5;
    logic [3:0] popcount_w5;
 
@@ -47,6 +50,10 @@ module popcount_tb;
    logic [10:0]  popcount_w981;
 
    //--------------------- Instantiate MUT ---------------------
+  popcount #(.INPUT_WIDTH(1)) i_popcount_w1
+    (.data_i(data_w1),
+     .popcount_o(popcount_w1));
+
    popcount #(.INPUT_WIDTH(5)) i_popcount_w5
      (.data_i(data_w5),
       .popcount_o(popcount_w5));
@@ -71,7 +78,17 @@ module popcount_tb;
 
    initial begin
      //------------------------------------------------------------
-     //Test 12 bit popcount
+
+     // Test 1 bit popcount
+     data_w1 = 0;
+     for(int i = 0; i<100; i++)
+       begin
+         `SV_RAND_CHECK(randomize(data_w1));
+         #5ns;
+         assert(popcount_w1 == $countones(data_w1)) else $error("Popcount of %b was %d but should be %d.", data_w1, popcount_w1, $countones(data_w1));
+       end
+
+     //Test 5 bit popcount
      data_w5    = 0;
      #5ns;
      assert(popcount_w5 == $countones(data_w5)) else $error("Popcount of %b was %d but should be %d.", data_w5, popcount_w5, $countones(data_w5));

--- a/test/popcount_tb.sv
+++ b/test/popcount_tb.sv
@@ -32,7 +32,7 @@ module popcount_tb;
 
    //---------------- Signals connecting to MUT ----------------
    logic data_w1;
-   logic  popcount_w1;
+   logic popcount_w1;
 
    logic [4:0] data_w5;
    logic [3:0] popcount_w5;


### PR DESCRIPTION
The popcount implementation so far used a recursive implementation using a binary adder tree. However, experiments using reasonably modern synthesis tools show that the logic optimization heuristics achieve the same or better results in less compilation time when the popcount logic is described in a flat for loop instead of nested modules.
While simplifying the popcount implementation, this change also fixes #187 