### PR TITLE
unread: Assign do dummy net when synthesizing with vivado

### DIFF
--- a/src/unread.sv
+++ b/src/unread.sv
@@ -16,6 +16,10 @@
 module unread (
     input logic d_i
 );
-
+    // Vivado treats this module as black box otherwise
+`ifdef TARGET_VIVADO
+    logic x;
+    assign d_i = x;
+`endif
 endmodule
 /* verilator lint_on UNUSED */


### PR DESCRIPTION
Synthesizing with Vivado results in the module `unread` being a black box and subsequent implementation fails.

This patch proposes to assign the input to a fake net to mitigate this error.