### PR TITLE
Set bank count to nonzero in default parameter to avoid div by 0

### DIFF
--- a/src/mem_to_banks.sv
+++ b/src/mem_to_banks.sv
@@ -20,7 +20,7 @@ module mem_to_banks #(
   /// Atop width.
   parameter int unsigned AtopWidth = 32'd0,
   /// Number of banks at output, must evenly divide `DataWidth`.
-  parameter int unsigned NumBanks  = 32'd0,
+  parameter int unsigned NumBanks  = 32'd1,
   /// Remove transactions that have zero strobe
   parameter bit          HideStrb  = 1'b0,
   /// Number of outstanding transactions

--- a/src/mem_to_banks_detailed.sv
+++ b/src/mem_to_banks_detailed.sv
@@ -22,7 +22,7 @@ module mem_to_banks_detailed #(
   /// Response sideband width.
   parameter int unsigned RUserWidth = 32'd0,
   /// Number of banks at output, must evenly divide `DataWidth`.
-  parameter int unsigned NumBanks  = 32'd0,
+  parameter int unsigned NumBanks  = 32'd1,
   /// Remove transactions that have zero strobe
   parameter bit          HideStrb  = 1'b0,
   /// Number of outstanding transactions


### PR DESCRIPTION
Verilator crashes parsing mem_to_banks.sv because of a divide by zero if NumBanks is 0 