### PR TITLE
Upstream fixes

### DIFF
--- a/src/addr_decode_dync.sv
+++ b/src/addr_decode_dync.sv
@@ -184,7 +184,7 @@ module addr_decode_dync #(
       end
     end
   end
-  // pragma translate_on
+  // synopsys translate_on
   `endif
   `endif
 

--- a/src/addr_decode_dync.sv
+++ b/src/addr_decode_dync.sv
@@ -124,7 +124,7 @@ module addr_decode_dync #(
   // Assumptions and assertions
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef XSIM
-  // pragma translate_off
+  // synopsys translate_off
   initial begin : proc_check_parameters
     assume ($bits(addr_i) == $bits(addr_map_i[0].start_addr)) else
       $warning($sformatf("Input address has %d bits and address map has %d bits.",

--- a/src/cb_filter.sv
+++ b/src/cb_filter.sv
@@ -243,6 +243,6 @@ module hash_block #(
       $fatal(1, "%m:\nA Hash Function reduces the width of the input>\nInpWidth: %s\nOUT_WIDTH: %s",
           InpWidth, HashWidth);
   end
-  // pragma translate_on
+  // synopsys translate_on
 `endif
 endmodule

--- a/src/cb_filter.sv
+++ b/src/cb_filter.sv
@@ -237,7 +237,7 @@ module hash_block #(
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
   // assertions
-  // pragma translate_off
+  // synopsys translate_off
   initial begin
     hash_conf: assume (InpWidth > HashWidth) else
       $fatal(1, "%m:\nA Hash Function reduces the width of the input>\nInpWidth: %s\nOUT_WIDTH: %s",

--- a/src/cdc_2phase_clearable.sv
+++ b/src/cdc_2phase_clearable.sv
@@ -263,7 +263,7 @@ module cdc_2phase_src_clearable #(
      @(posedge clk_i) disable iff(~rst_ni) (clear_i |-> ~valid_i))
     else $fatal(1, "No request allowed while clear_i is asserted.");
 
-  // pragma translate_on
+  // synopsys translate_on
 `endif
 
 endmodule

--- a/src/cdc_2phase_clearable.sv
+++ b/src/cdc_2phase_clearable.sv
@@ -258,7 +258,7 @@ module cdc_2phase_src_clearable #(
 
 // Assertions
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  // pragma translate_off
+  // synopsys translate_off
   no_clear_and_request: assume property (
      @(posedge clk_i) disable iff(~rst_ni) (clear_i |-> ~valid_i))
     else $fatal(1, "No request allowed while clear_i is asserted.");

--- a/src/cdc_fifo_2phase.sv
+++ b/src/cdc_fifo_2phase.sv
@@ -66,7 +66,7 @@ module cdc_fifo_2phase #(
   initial begin
     assert(LOG_DEPTH > 0);
   end
-  //pragma translate_on
+  // synopsys translate_on
 
   localparam int PtrWidth = LOG_DEPTH+1;
   typedef logic [PtrWidth-1:0] pointer_t;

--- a/src/cdc_fifo_2phase.sv
+++ b/src/cdc_fifo_2phase.sv
@@ -62,7 +62,7 @@ module cdc_fifo_2phase #(
 );
 
   // Check the invariants.
-  //pragma translate_off
+  // synopsys translate_off
   initial begin
     assert(LOG_DEPTH > 0);
   end

--- a/src/cdc_fifo_gray.sv
+++ b/src/cdc_fifo_gray.sv
@@ -157,7 +157,7 @@ module cdc_fifo_gray #(
   );
 
   // Check the invariants.
-  // pragma translate_off
+  // synopsys translate_off
   `ifndef COMMON_CELLS_ASSERTS_OFF
   initial assert(LOG_DEPTH > 0);
   initial assert(SYNC_STAGES >= 2);

--- a/src/cdc_fifo_gray.sv
+++ b/src/cdc_fifo_gray.sv
@@ -162,7 +162,7 @@ module cdc_fifo_gray #(
   initial assert(LOG_DEPTH > 0);
   initial assert(SYNC_STAGES >= 2);
   `endif
-  // pragma translate_on
+  // synopsys translate_on
 
 endmodule
 

--- a/src/cdc_fifo_gray_clearable.sv
+++ b/src/cdc_fifo_gray_clearable.sv
@@ -254,7 +254,7 @@ module cdc_fifo_gray_clearable #(
   assign dst_clear_pending_o = s_dst_isolate_req;
 
   // Check the invariants.
-  // pragma translate_off
+  // synopsys translate_off
   `ifndef COMMON_CELLS_ASSERTS_OFF
   initial assert(LOG_DEPTH > 0);
   initial assert(SYNC_STAGES >= 2);

--- a/src/cdc_fifo_gray_clearable.sv
+++ b/src/cdc_fifo_gray_clearable.sv
@@ -259,7 +259,7 @@ module cdc_fifo_gray_clearable #(
   initial assert(LOG_DEPTH > 0);
   initial assert(SYNC_STAGES >= 2);
   `endif
-  // pragma translate_on
+  // synopsys translate_on
 
 endmodule
 

--- a/src/cf_math_pkg.sv
+++ b/src/cf_math_pkg.sv
@@ -23,7 +23,7 @@ package cf_math_pkg;
     function automatic integer ceil_div (input longint dividend, input longint divisor);
         automatic longint remainder;
 
-        // pragma translate_off
+        // synopsys translate_off
         `ifndef COMMON_CELLS_ASSERTS_OFF
         if (dividend < 0) begin
             $fatal(1, "Dividend %0d is not a natural number!", dividend);

--- a/src/cf_math_pkg.sv
+++ b/src/cf_math_pkg.sv
@@ -37,7 +37,7 @@ package cf_math_pkg;
             $fatal(1, "Division by zero!");
         end
         `endif
-        // pragma translate_on
+        // synopsys translate_on
 
         remainder = dividend;
         for (ceil_div = 0; remainder > 0; ceil_div++) begin

--- a/src/deprecated/fifo_v2.sv
+++ b/src/deprecated/fifo_v2.sv
@@ -67,7 +67,7 @@ module fifo_v2 #(
         .pop_i
     );
 
-    // pragma translate_off
+    // synopsys translate_off
     `ifndef COMMON_CELLS_ASSERTS_OFF
         initial begin
             assert (ALM_FULL_TH <= DEPTH)  else $error("ALM_FULL_TH can't be larger than the DEPTH.");

--- a/src/deprecated/fifo_v2.sv
+++ b/src/deprecated/fifo_v2.sv
@@ -74,6 +74,6 @@ module fifo_v2 #(
             assert (ALM_EMPTY_TH <= DEPTH) else $error("ALM_EMPTY_TH can't be larger than the DEPTH.");
         end
     `endif
-    // pragma translate_on
+    // synopsys translate_on
 
 endmodule // fifo_v2

--- a/src/deprecated/find_first_one.sv
+++ b/src/deprecated/find_first_one.sv
@@ -26,7 +26,7 @@ module find_first_one #(
 
     localparam int NUM_LEVELS = $clog2(WIDTH);
 
-    // pragma translate_off
+    // synopsys translate_off
     initial begin
         assert(WIDTH >= 0);
     end

--- a/src/deprecated/find_first_one.sv
+++ b/src/deprecated/find_first_one.sv
@@ -30,7 +30,7 @@ module find_first_one #(
     initial begin
         assert(WIDTH >= 0);
     end
-    // pragma translate_on
+    // synopsys translate_on
 
     logic [WIDTH-1:0][NUM_LEVELS-1:0]          index_lut;
     logic [2**NUM_LEVELS-1:0]                  sel_nodes;

--- a/src/exp_backoff.sv
+++ b/src/exp_backoff.sv
@@ -93,6 +93,6 @@ module exp_backoff #(
       else $fatal(1,"Zero seed is not allowed for LFSR");
   end
 `endif
-//pragma translate_on
+// synopsys translate_on
 
 endmodule // exp_backoff

--- a/src/exp_backoff.sv
+++ b/src/exp_backoff.sv
@@ -81,7 +81,7 @@ module exp_backoff #(
 // assertions
 ///////////////////////////////////////////////////////
 
-//pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin
     // assert wrong parameterizations

--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -137,7 +137,7 @@ module fifo_v3 #(
         end
     end
 
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin
         assert (DEPTH > 0)             else $error("DEPTH must be greater than 0.");

--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -151,6 +151,6 @@ module fifo_v3 #(
         @(posedge clk_i) disable iff (~rst_ni) (empty_o |-> ~pop_i))
         else $fatal (1, "Trying to pop data although the FIFO is empty.");
 `endif
-// pragma translate_on
+// synopsys translate_on
 
 endmodule // fifo_v3

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -404,7 +404,7 @@ module id_queue #(
     end
 
     // Validate parameters.
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin: validate_params
         assert (ID_WIDTH >= 1)

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -413,6 +413,6 @@ module id_queue #(
             else $fatal(1, "The queue must have capacity of at least one entry!");
     end
 `endif
-// pragma translate_on
+// synopsys translate_on
 
 endmodule

--- a/src/isochronous_4phase_handshake.sv
+++ b/src/isochronous_4phase_handshake.sv
@@ -76,6 +76,6 @@ module isochronous_4phase_handshake (
   assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
     (dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o))) else $error("dst_valid_o is unstable");
   `endif
-  // pragma translate_on
+  // synopsys translate_on
 
 endmodule

--- a/src/isochronous_4phase_handshake.sv
+++ b/src/isochronous_4phase_handshake.sv
@@ -68,7 +68,7 @@ module isochronous_4phase_handshake (
   // destination is valid if we didn't yet get acknowledge
   assign dst_valid_o = (dst_req_q != dst_ack_q);
 
- // pragma translate_off
+ // synopsys translate_off
  // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
   assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)

--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -95,7 +95,7 @@ module isochronous_spill_register #(
     assign dst_data_o = mem_q[rd_pointer_q[0]];
   end
 
-  // pragma translate_off
+  // synopsys translate_off
   // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
   assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)

--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -107,5 +107,5 @@ module isochronous_spill_register #(
   assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
     (dst_valid_o && !dst_ready_i |=> $stable(dst_data_o))) else $error("dst_data_o is unstable");
   `endif
-  // pragma translate_on
+  // synopsys translate_on
 endmodule

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -308,7 +308,7 @@ end
   all_zero: assert property (
     @(posedge clk_i) disable iff (!rst_ni) en_i |-> lfsr_d)
       else $fatal(1,"Lfsr must not be all-zero.");
-// pragma translate_on
+// synopsys translate_on
 `endif
 
 endmodule // lfsr

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -290,7 +290,7 @@ end
 // assertions
 ////////////////////////////////////////////////////////////////////////
 `ifndef COMMON_CELLS_ASSERTS_OFF
-// pragma translate_off
+// synopsys translate_off
 initial begin
   // these are the LUT limits
   assert(OutWidth <= LfsrWidth) else

--- a/src/lfsr_16bit.sv
+++ b/src/lfsr_16bit.sv
@@ -64,7 +64,7 @@ module lfsr_16bit #(
         assert (WIDTH <= 16)
             else $fatal(1, "WIDTH needs to be less than 16 because of the 16-bit LFSR");
     end
-    //pragma translate_on
+    // synopsys translate_on
   `endif
 
 endmodule

--- a/src/lfsr_16bit.sv
+++ b/src/lfsr_16bit.sv
@@ -59,7 +59,7 @@ module lfsr_16bit #(
     end
 
   `ifndef COMMON_CELLS_ASSERTS_OFF
-    //pragma translate_off
+    // synopsys translate_off
     initial begin
         assert (WIDTH <= 16)
             else $fatal(1, "WIDTH needs to be less than 16 because of the 16-bit LFSR");

--- a/src/lfsr_8bit.sv
+++ b/src/lfsr_8bit.sv
@@ -57,7 +57,7 @@ module lfsr_8bit #(
   initial begin
     assert (WIDTH <= 8) else $fatal(1, "WIDTH needs to be less than 8 because of the 8-bit LFSR");
   end
-  //pragma translate_on
+  // synopsys translate_on
 `endif
 
 endmodule

--- a/src/lfsr_8bit.sv
+++ b/src/lfsr_8bit.sv
@@ -53,7 +53,7 @@ module lfsr_8bit #(
   end
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  //pragma translate_off
+  // synopsys translate_off
   initial begin
     assert (WIDTH <= 8) else $fatal(1, "WIDTH needs to be less than 8 because of the 8-bit LFSR");
   end

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -40,7 +40,7 @@ module lzc #(
     localparam int unsigned NumLevels = $clog2(WIDTH);
 
   `ifndef COMMON_CELLS_ASSERTS_OFF
-    // pragma translate_off
+    // synopsys translate_off
     initial begin
       assert(WIDTH > 0) else $fatal(1, "input must be at least one bit wide");
     end
@@ -101,7 +101,7 @@ module lzc #(
 
   end : gen_lzc
 
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin: validate_params
     assert (WIDTH >= 1)

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -44,7 +44,7 @@ module lzc #(
     initial begin
       assert(WIDTH > 0) else $fatal(1, "input must be at least one bit wide");
     end
-    // pragma translate_on
+    // synopsys translate_on
   `endif
 
     logic [WIDTH-1:0][NumLevels-1:0] index_lut;
@@ -108,6 +108,6 @@ module lzc #(
       else $fatal(1, "The WIDTH must at least be one bit wide!");
   end
 `endif
-// pragma translate_on
+// synopsys translate_on
 
 endmodule : lzc

--- a/src/mem_to_banks_detailed.sv
+++ b/src/mem_to_banks_detailed.sv
@@ -221,5 +221,5 @@ module mem_to_banks_detailed #(
     end
   `endif
   `endif
-  // pragma translate_on
+  // synopsys translate_on
 endmodule

--- a/src/mem_to_banks_detailed.sv
+++ b/src/mem_to_banks_detailed.sv
@@ -208,7 +208,7 @@ module mem_to_banks_detailed #(
   assign rvalid_o = &(resp_valid | dead_response);
 
   // Assertions
-  // pragma translate_off
+  // synopsys translate_off
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef SYNTHESIS
     initial begin

--- a/src/multiaddr_decode.sv
+++ b/src/multiaddr_decode.sv
@@ -122,7 +122,7 @@ module multiaddr_decode #(
   // Assumptions and assertions
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef XSIM
-  // pragma translate_off
+  // synopsys translate_off
   initial begin : proc_check_parameters
     assume (NoRules > 0) else
       $fatal(1, $sformatf("At least one rule needed"));

--- a/src/multiaddr_decode.sv
+++ b/src/multiaddr_decode.sv
@@ -148,7 +148,7 @@ module multiaddr_decode #(
     end
   end
 
-  // pragma translate_on
+  // synopsys translate_on
   `endif
   `endif
 endmodule

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -34,5 +34,5 @@ module onehot_to_bin #(
     assert final ($onehot0(onehot)) else
         $fatal(1, "[onehot_to_bin] More than two bit set in the one-hot signal");
 `endif
-// pragma translate_on
+// synopsys translate_on
 endmodule

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -29,7 +29,7 @@ module onehot_to_bin #(
         assign bin[j] = |(tmp_mask & onehot);
     end
 
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
     assert final ($onehot0(onehot)) else
         $fatal(1, "[onehot_to_bin] More than two bit set in the one-hot signal");

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -109,7 +109,7 @@ module plru_tree #(
         end
     end
 
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin
         assert (ENTRIES == 2**LogEntries) else $error("Entries must be a power of two");

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -115,6 +115,6 @@ module plru_tree #(
         assert (ENTRIES == 2**LogEntries) else $error("Entries must be a power of two");
     end
 `endif
-// pragma translate_on
+// synopsys translate_on
 
 endmodule

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -109,7 +109,7 @@ module rr_arb_tree #(
   output idx_t                idx_o
 );
 
-  // pragma translate_off
+  // synopsys translate_off
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef VERILATOR
   `ifndef XSIM
@@ -170,7 +170,7 @@ module rr_arb_tree #(
           end
         end
 
-        // pragma translate_off
+        // synopsys translate_off
         `ifndef COMMON_CELLS_ASSERTS_OFF
           lock: assert property(
             @(posedge clk_i) disable iff (!rst_ni || flush_i)
@@ -310,7 +310,7 @@ module rr_arb_tree #(
       end
     end
 
-    // pragma translate_off
+    // synopsys translate_off
     `ifndef COMMON_CELLS_ASSERTS_OFF
     `ifndef XSIM
     initial begin : p_assert

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -118,7 +118,7 @@ module rr_arb_tree #(
   `endif
   `endif
   `endif
-  // pragma translate_on
+  // synopsys translate_on
 
   // just pass through in this corner case
   if (NumIn == unsigned'(1)) begin : gen_pass_through
@@ -186,7 +186,7 @@ module rr_arb_tree #(
                 $fatal (1, "It is disallowed to deassert unserved request signals when LockIn is \
                             enabled.");
         `endif
-        // pragma translate_on
+        // synopsys translate_on
 
         always_ff @(posedge clk_i or negedge rst_ni) begin : p_req_regs
           if (!rst_ni) begin
@@ -345,7 +345,7 @@ module rr_arb_tree #(
         else $fatal (1, "Req out implies req in.");
     `endif
     `endif
-    // pragma translate_on
+    // synopsys translate_on
   end
 
 endmodule : rr_arb_tree

--- a/src/rstgen_bypass.sv
+++ b/src/rstgen_bypass.sv
@@ -57,7 +57,7 @@ module rstgen_bypass #(
             synch_regs_q <= {synch_regs_q[NumRegs-2:0], 1'b1};
         end
     end
-    // pragma translate_off
+    // synopsys translate_off
     `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin : p_assertions
         if (NumRegs < 1) $fatal(1, "At least one register is required.");

--- a/src/rstgen_bypass.sv
+++ b/src/rstgen_bypass.sv
@@ -63,5 +63,5 @@ module rstgen_bypass #(
         if (NumRegs < 1) $fatal(1, "At least one register is required.");
     end
     `endif
-    // pragma translate_on
+    // synopsys translate_on
 endmodule

--- a/src/spill_register_flushable.sv
+++ b/src/spill_register_flushable.sv
@@ -94,12 +94,12 @@ module spill_register_flushable #(
     // We empty the spill register before the slice register.
     assign data_o = b_full_q ? b_data_q : a_data_q;
 
-    // pragma translate_off
+    // synopsys translate_off
     `ifndef COMMON_CELLS_ASSERTS_OFF
     flush_valid : assert property (
       @(posedge clk_i) disable iff (~rst_ni) (flush_i |-> ~valid_i)) else
       $warning("Trying to flush and feed the spill register simultaneously. You will lose data!");
    `endif
-     // pragma translate_on
+     // synopsys translate_on
   end
 endmodule

--- a/src/stream_arbiter_flushable.sv
+++ b/src/stream_arbiter_flushable.sv
@@ -76,7 +76,7 @@ module stream_arbiter_flushable #(
   end else begin : gen_arb_error
     // synopsys translate_off
     $fatal(1, "Invalid value for parameter 'ARBITER'!");
-    // pragma translate_on
+    // synopsys translate_on
   end
 
 endmodule

--- a/src/stream_arbiter_flushable.sv
+++ b/src/stream_arbiter_flushable.sv
@@ -74,7 +74,7 @@ module stream_arbiter_flushable #(
     );
 
   end else begin : gen_arb_error
-    // pragma translate_off
+    // synopsys translate_off
     $fatal(1, "Invalid value for parameter 'ARBITER'!");
     // pragma translate_on
   end

--- a/src/stream_fork.sv
+++ b/src/stream_fork.sv
@@ -122,7 +122,7 @@ module stream_fork #(
     assign all_ones = '1;   // Synthesis fix for Vivado, which does not correctly compute the width
                             // of the '1 literal when assigned to a port of parametrized width.
 
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin: p_assertions
         assert (N_OUP >= 1) else $fatal(1, "Number of outputs must be at least 1!");

--- a/src/stream_fork.sv
+++ b/src/stream_fork.sv
@@ -128,6 +128,6 @@ module stream_fork #(
         assert (N_OUP >= 1) else $fatal(1, "Number of outputs must be at least 1!");
     end
 `endif
-// pragma translate_on
+// synopsys translate_on
 
 endmodule

--- a/src/stream_fork_dynamic.sv
+++ b/src/stream_fork_dynamic.sv
@@ -91,5 +91,5 @@ module stream_fork_dynamic #(
     assert (N_OUP >= 1) else $fatal(1, "N_OUP must be at least 1!");
   end
 `endif
-// pragma translate_on
+// synopsys translate_on
 endmodule

--- a/src/stream_fork_dynamic.sv
+++ b/src/stream_fork_dynamic.sv
@@ -85,7 +85,7 @@ module stream_fork_dynamic #(
     .ready_i ( int_oup_ready )
   );
 
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin: p_assertions
     assert (N_OUP >= 1) else $fatal(1, "N_OUP must be at least 1!");

--- a/src/stream_intf.sv
+++ b/src/stream_intf.sv
@@ -40,7 +40,7 @@ interface STREAM_DV #(
   );
 
   // Make sure that the handshake and payload is stable
-  // pragma translate_off
+  // synopsys translate_off
   `ifndef COMMON_CELLS_ASSERTS_OFF
   assert property (@(posedge clk_i) (valid && !ready |=> $stable(data)));
   assert property (@(posedge clk_i) (valid && !ready |=> valid));

--- a/src/stream_intf.sv
+++ b/src/stream_intf.sv
@@ -45,5 +45,5 @@ interface STREAM_DV #(
   assert property (@(posedge clk_i) (valid && !ready |=> $stable(data)));
   assert property (@(posedge clk_i) (valid && !ready |=> valid));
   `endif
-  // pragma translate_on
+  // synopsys translate_on
 endinterface

--- a/src/stream_join_dynamic.sv
+++ b/src/stream_join_dynamic.sv
@@ -37,7 +37,7 @@ module stream_join_dynamic #(
     assign inp_ready_o[i] = oup_valid_o & oup_ready_i;
   end
 
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin: p_assertions
     assert (N_INP >= 1) else $fatal(1, "N_INP must be at least 1!");

--- a/src/stream_join_dynamic.sv
+++ b/src/stream_join_dynamic.sv
@@ -43,5 +43,5 @@ module stream_join_dynamic #(
     assert (N_INP >= 1) else $fatal(1, "N_INP must be at least 1!");
   end
 `endif
-// pragma translate_on
+// synopsys translate_on
 endmodule

--- a/src/stream_mux.sv
+++ b/src/stream_mux.sv
@@ -35,7 +35,7 @@ module stream_mux #(
   assign oup_data_o   = inp_data_i[inp_sel_i];
   assign oup_valid_o  = inp_valid_i[inp_sel_i];
 
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin: p_assertions
     assert (N_INP >= 1) else $fatal (1, "The number of inputs must be at least 1!");

--- a/src/stream_mux.sv
+++ b/src/stream_mux.sv
@@ -41,6 +41,6 @@ module stream_mux #(
     assert (N_INP >= 1) else $fatal (1, "The number of inputs must be at least 1!");
   end
 `endif
-// pragma translate_on
+// synopsys translate_on
 
 endmodule

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -260,7 +260,7 @@ module stream_omega_net #(
 
     // Assertions
     // Make sure that the handshake and payload is stable
-    // pragma translate_off
+    // synopsys translate_off
     `ifndef COMMON_CELLS_ASSERTS_OFF
     `ifndef VERILATOR
     default disable iff (~rst_ni);

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -305,6 +305,6 @@ module stream_omega_net #(
           $fatal(1, "Bit slicing of the internal selection signal is broken.");
     end
     `endif
-    // pragma translate_on
+    // synopsys translate_on
   end
 endmodule

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -130,5 +130,5 @@ module stream_to_mem #(
       else $error("Without BufDepth = 0, the memory must respond in the same cycle!");
   end
 `endif
-// pragma translate_on
+// synopsys translate_on
 endmodule

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -116,7 +116,7 @@ module stream_to_mem #(
   assign mem_req_o = req_i;
 
 // Assertions
-// pragma translate_off
+// synopsys translate_off
 `ifndef COMMON_CELLS_ASSERTS_OFF
   if (BufDepth > 0) begin : gen_buf_asserts
     assert property (@(posedge clk_i) mem_resp_valid_i |-> buf_ready)

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -205,5 +205,5 @@ module stream_xbar #(
     assert (NumOut > 32'd0) else $fatal(1, "NumOut has to be > 0!");
   end
   `endif
-  // pragma translate_on
+  // synopsys translate_on
 endmodule

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -164,7 +164,7 @@ module stream_xbar #(
 
   // Assertions
   // Make sure that the handshake and payload is stable
-  // pragma translate_off
+  // synopsys translate_off
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef VERILATOR
   default disable iff (~rst_ni);


### PR DESCRIPTION
"pragma" prefix for translate_on/off might be considered as invalid by many tools w/o additional settings

by default valid prefix for translate_on/off is "synopsys", and both "pragma" and "synopsys" are valid for synthesis_on/off