### PR TITLE
`stream_xbar`: Fix non-existing output assertion

### DIFF
--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -171,7 +171,7 @@ module stream_xbar #(
   `endif
   for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
     assert property (@(posedge clk_i) disable iff (~rst_ni)
-        (valid_i[i] |-> sel_i[i] < sel_oup_t'(NumOut))) else
+        (valid_i[i] |-> sel_i[i] < NumOut)) else
         $fatal(1, "Non-existing output is selected!");
   end
 


### PR DESCRIPTION
PR https://github.com/pulp-platform/common_cells/pull/200 fixed an issue in the `stream_xbar` assertions, effectively enabling them when reset is not asserted:
https://github.com/pulp-platform/common_cells/pull/200/files#diff-872c7e67b01645ac7cc6cecf1dbb01b73f1b1882d8bb77089dcb27570c35ac23L169

Thanks to this, a bug in one of the assertions was revealed:
https://github.com/pulp-platform/common_cells/blob/52f83eed3e92ed4ea5f79774854b0cb68618dcbb/src/stream_xbar.sv#L172-L176
`sel_oup_t` can represent values in the range [0, `NumOut`). Because of this, if for example `NumOut` is 32, the comparison will reduce to `sel_i[i] < 0` which will never be satisfied.

This PR fixes this issue.