### PR TITLE
plru_tree: Assert output is onehot

### DIFF
--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -123,6 +123,10 @@ module plru_tree #(
     initial begin
         assert (ENTRIES == 2**LogEntries) else $error("Entries must be a power of two");
     end
+
+    output_onehot : assert property(
+        @(posedge clk_i) disable iff (~rst_ni) ((plru_o & (plru_o - 1)) == '0))
+        else $fatal (1, "More than one bit set in PLRU output.");
 `endif
 // pragma translate_on
 

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -125,7 +125,7 @@ module plru_tree #(
     end
 
     output_onehot : assert property(
-        @(posedge clk_i) disable iff (~rst_ni) ((plru_o & (plru_o - 1)) == '0))
+        @(posedge clk_i) disable iff (~rst_ni) ($onehot0(plru_o))
         else $fatal (1, "More than one bit set in PLRU output.");
 `endif
 // pragma translate_on

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -125,7 +125,7 @@ module plru_tree #(
     end
 
     output_onehot : assert property(
-        @(posedge clk_i) disable iff (~rst_ni) ($onehot0(plru_o))
+        @(posedge clk_i) disable iff (~rst_ni) ($onehot0(plru_o)))
         else $fatal (1, "More than one bit set in PLRU output.");
 `endif
 // pragma translate_on


### PR DESCRIPTION
@niwis Another thing that just came to my mind: it might make sense to add an assertion to verify that the output is always onehot.