### PR TITLE
Renamed `translate_off` to `` `ifndef SYNTHESIS ``

### DIFF
--- a/src/addr_decode_dync.sv
+++ b/src/addr_decode_dync.sv
@@ -124,7 +124,7 @@ module addr_decode_dync #(
   // Assumptions and assertions
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef XSIM
-  // pragma translate_off
+  `ifndef SYNTHESIS
   initial begin : proc_check_parameters
     assume ($bits(addr_i) == $bits(addr_map_i[0].start_addr)) else
       $warning($sformatf("Input address has %d bits and address map has %d bits.",
@@ -184,7 +184,7 @@ module addr_decode_dync #(
       end
     end
   end
-  // pragma translate_on
+  `endif
   `endif
   `endif
 

--- a/src/cb_filter.sv
+++ b/src/cb_filter.sv
@@ -237,12 +237,12 @@ module hash_block #(
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
   // assertions
-  // pragma translate_off
+  `ifndef SYNTHESIS
   initial begin
     hash_conf: assume (InpWidth > HashWidth) else
       $fatal(1, "%m:\nA Hash Function reduces the width of the input>\nInpWidth: %s\nOUT_WIDTH: %s",
           InpWidth, HashWidth);
   end
-  // pragma translate_on
+  `endif
 `endif
 endmodule

--- a/src/cdc_2phase_clearable.sv
+++ b/src/cdc_2phase_clearable.sv
@@ -258,12 +258,12 @@ module cdc_2phase_src_clearable #(
 
 // Assertions
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  // pragma translate_off
+  `ifndef SYNTHESIS
   no_clear_and_request: assume property (
      @(posedge clk_i) disable iff(~rst_ni) (clear_i |-> ~valid_i))
     else $fatal(1, "No request allowed while clear_i is asserted.");
 
-  // pragma translate_on
+  `endif
 `endif
 
 endmodule

--- a/src/cdc_fifo_2phase.sv
+++ b/src/cdc_fifo_2phase.sv
@@ -62,11 +62,11 @@ module cdc_fifo_2phase #(
 );
 
   // Check the invariants.
-  //pragma translate_off
+  `ifndef SYNTHESIS
   initial begin
     assert(LOG_DEPTH > 0);
   end
-  //pragma translate_on
+  `endif
 
   localparam int PtrWidth = LOG_DEPTH+1;
   typedef logic [PtrWidth-1:0] pointer_t;

--- a/src/cdc_fifo_gray.sv
+++ b/src/cdc_fifo_gray.sv
@@ -157,12 +157,12 @@ module cdc_fifo_gray #(
   );
 
   // Check the invariants.
-  // pragma translate_off
+  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   initial assert(LOG_DEPTH > 0);
   initial assert(SYNC_STAGES >= 2);
   `endif
-  // pragma translate_on
+  `endif
 
 endmodule
 

--- a/src/cdc_fifo_gray_clearable.sv
+++ b/src/cdc_fifo_gray_clearable.sv
@@ -254,12 +254,12 @@ module cdc_fifo_gray_clearable #(
   assign dst_clear_pending_o = s_dst_isolate_req;
 
   // Check the invariants.
-  // pragma translate_off
+  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   initial assert(LOG_DEPTH > 0);
   initial assert(SYNC_STAGES >= 2);
   `endif
-  // pragma translate_on
+  `endif
 
 endmodule
 

--- a/src/cf_math_pkg.sv
+++ b/src/cf_math_pkg.sv
@@ -23,7 +23,7 @@ package cf_math_pkg;
     function automatic integer ceil_div (input longint dividend, input longint divisor);
         automatic longint remainder;
 
-        // pragma translate_off
+        `ifndef SYNTHESIS
         `ifndef COMMON_CELLS_ASSERTS_OFF
         if (dividend < 0) begin
             $fatal(1, "Dividend %0d is not a natural number!", dividend);
@@ -37,7 +37,7 @@ package cf_math_pkg;
             $fatal(1, "Division by zero!");
         end
         `endif
-        // pragma translate_on
+        `endif
 
         remainder = dividend;
         for (ceil_div = 0; remainder > 0; ceil_div++) begin

--- a/src/exp_backoff.sv
+++ b/src/exp_backoff.sv
@@ -81,7 +81,7 @@ module exp_backoff #(
 // assertions
 ///////////////////////////////////////////////////////
 
-//pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin
     // assert wrong parameterizations
@@ -93,6 +93,6 @@ module exp_backoff #(
       else $fatal(1,"Zero seed is not allowed for LFSR");
   end
 `endif
-//pragma translate_on
+`endif
 
 endmodule // exp_backoff

--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -137,7 +137,7 @@ module fifo_v3 #(
         end
     end
 
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin
         assert (DEPTH > 0)             else $error("DEPTH must be greater than 0.");
@@ -151,6 +151,6 @@ module fifo_v3 #(
         @(posedge clk_i) disable iff (~rst_ni) (empty_o |-> ~pop_i))
         else $fatal (1, "Trying to pop data although the FIFO is empty.");
 `endif
-// pragma translate_on
+`endif
 
 endmodule // fifo_v3

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -404,7 +404,7 @@ module id_queue #(
     end
 
     // Validate parameters.
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin: validate_params
         assert (ID_WIDTH >= 1)
@@ -413,6 +413,6 @@ module id_queue #(
             else $fatal(1, "The queue must have capacity of at least one entry!");
     end
 `endif
-// pragma translate_on
+`endif
 
 endmodule

--- a/src/isochronous_4phase_handshake.sv
+++ b/src/isochronous_4phase_handshake.sv
@@ -68,7 +68,7 @@ module isochronous_4phase_handshake (
   // destination is valid if we didn't yet get acknowledge
   assign dst_valid_o = (dst_req_q != dst_ack_q);
 
- // pragma translate_off
+ `ifndef SYNTHESIS
  // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
   assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)
@@ -76,6 +76,6 @@ module isochronous_4phase_handshake (
   assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
     (dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o))) else $error("dst_valid_o is unstable");
   `endif
-  // pragma translate_on
+  `endif
 
 endmodule

--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -95,7 +95,7 @@ module isochronous_spill_register #(
     assign dst_data_o = mem_q[rd_pointer_q[0]];
   end
 
-  // pragma translate_off
+  `ifndef SYNTHESIS
   // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
   assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)
@@ -107,5 +107,5 @@ module isochronous_spill_register #(
   assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
     (dst_valid_o && !dst_ready_i |=> $stable(dst_data_o))) else $error("dst_data_o is unstable");
   `endif
-  // pragma translate_on
+  `endif
 endmodule

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -290,7 +290,7 @@ end
 // assertions
 ////////////////////////////////////////////////////////////////////////
 `ifndef COMMON_CELLS_ASSERTS_OFF
-// pragma translate_off
+`ifndef SYNTHESIS
 initial begin
   // these are the LUT limits
   assert(OutWidth <= LfsrWidth) else
@@ -308,7 +308,7 @@ end
   all_zero: assert property (
     @(posedge clk_i) disable iff (!rst_ni) en_i |-> lfsr_d)
       else $fatal(1,"Lfsr must not be all-zero.");
-// pragma translate_on
+`endif
 `endif
 
 endmodule // lfsr

--- a/src/lfsr_16bit.sv
+++ b/src/lfsr_16bit.sv
@@ -59,12 +59,12 @@ module lfsr_16bit #(
     end
 
   `ifndef COMMON_CELLS_ASSERTS_OFF
-    //pragma translate_off
+    `ifndef SYNTHESIS
     initial begin
         assert (WIDTH <= 16)
             else $fatal(1, "WIDTH needs to be less than 16 because of the 16-bit LFSR");
     end
-    //pragma translate_on
+    `endif
   `endif
 
 endmodule

--- a/src/lfsr_8bit.sv
+++ b/src/lfsr_8bit.sv
@@ -53,11 +53,11 @@ module lfsr_8bit #(
   end
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  //pragma translate_off
+  `ifndef SYNTHESIS
   initial begin
     assert (WIDTH <= 8) else $fatal(1, "WIDTH needs to be less than 8 because of the 8-bit LFSR");
   end
-  //pragma translate_on
+  `endif
 `endif
 
 endmodule

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -40,11 +40,11 @@ module lzc #(
     localparam int unsigned NumLevels = $clog2(WIDTH);
 
   `ifndef COMMON_CELLS_ASSERTS_OFF
-    // pragma translate_off
+    `ifndef SYNTHESIS
     initial begin
       assert(WIDTH > 0) else $fatal(1, "input must be at least one bit wide");
     end
-    // pragma translate_on
+    `endif
   `endif
 
     logic [WIDTH-1:0][NumLevels-1:0] index_lut;
@@ -101,13 +101,13 @@ module lzc #(
 
   end : gen_lzc
 
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin: validate_params
     assert (WIDTH >= 1)
       else $fatal(1, "The WIDTH must at least be one bit wide!");
   end
 `endif
-// pragma translate_on
+`endif
 
 endmodule : lzc

--- a/src/mem_to_banks_detailed.sv
+++ b/src/mem_to_banks_detailed.sv
@@ -208,7 +208,7 @@ module mem_to_banks_detailed #(
   assign rvalid_o = &(resp_valid | dead_response);
 
   // Assertions
-  // pragma translate_off
+  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef SYNTHESIS
     initial begin
@@ -221,5 +221,5 @@ module mem_to_banks_detailed #(
     end
   `endif
   `endif
-  // pragma translate_on
+  `endif
 endmodule

--- a/src/multiaddr_decode.sv
+++ b/src/multiaddr_decode.sv
@@ -122,7 +122,7 @@ module multiaddr_decode #(
   // Assumptions and assertions
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef XSIM
-  // pragma translate_off
+  `ifndef SYNTHESIS
   initial begin : proc_check_parameters
     assume (NoRules > 0) else
       $fatal(1, $sformatf("At least one rule needed"));
@@ -148,7 +148,7 @@ module multiaddr_decode #(
     end
   end
 
-  // pragma translate_on
+  `endif
   `endif
   `endif
 endmodule

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -29,10 +29,10 @@ module onehot_to_bin #(
         assign bin[j] = |(tmp_mask & onehot);
     end
 
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     assert final ($onehot0(onehot)) else
         $fatal(1, "[onehot_to_bin] More than two bit set in the one-hot signal");
 `endif
-// pragma translate_on
+`endif
 endmodule

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -118,7 +118,7 @@ module plru_tree #(
         end
     end
 
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin
         assert (ENTRIES == 2**LogEntries) else $error("Entries must be a power of two");
@@ -128,6 +128,6 @@ module plru_tree #(
         @(posedge clk_i) disable iff (~rst_ni) ($onehot0(plru_o)))
         else $fatal (1, "More than one bit set in PLRU output.");
 `endif
-// pragma translate_on
+`endif
 
 endmodule

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -109,7 +109,7 @@ module rr_arb_tree #(
   output idx_t                idx_o
 );
 
-  // pragma translate_off
+  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef VERILATOR
   `ifndef XSIM
@@ -118,7 +118,7 @@ module rr_arb_tree #(
   `endif
   `endif
   `endif
-  // pragma translate_on
+  `endif
 
   // just pass through in this corner case
   if (NumIn == unsigned'(1)) begin : gen_pass_through
@@ -170,7 +170,7 @@ module rr_arb_tree #(
           end
         end
 
-        // pragma translate_off
+        `ifndef SYNTHESIS
         `ifndef COMMON_CELLS_ASSERTS_OFF
           lock: assert property(
             @(posedge clk_i) disable iff (!rst_ni || flush_i)
@@ -186,7 +186,7 @@ module rr_arb_tree #(
                 $fatal (1, "It is disallowed to deassert unserved request signals when LockIn is \
                             enabled.");
         `endif
-        // pragma translate_on
+        `endif
 
         always_ff @(posedge clk_i or negedge rst_ni) begin : p_req_regs
           if (!rst_ni) begin
@@ -310,7 +310,7 @@ module rr_arb_tree #(
       end
     end
 
-    // pragma translate_off
+    `ifndef SYNTHESIS
     `ifndef COMMON_CELLS_ASSERTS_OFF
     `ifndef XSIM
     initial begin : p_assert
@@ -345,7 +345,7 @@ module rr_arb_tree #(
         else $fatal (1, "Req out implies req in.");
     `endif
     `endif
-    // pragma translate_on
+    `endif
   end
 
 endmodule : rr_arb_tree

--- a/src/rstgen_bypass.sv
+++ b/src/rstgen_bypass.sv
@@ -57,11 +57,11 @@ module rstgen_bypass #(
             synch_regs_q <= {synch_regs_q[NumRegs-2:0], 1'b1};
         end
     end
-    // pragma translate_off
+    `ifndef SYNTHESIS
     `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin : p_assertions
         if (NumRegs < 1) $fatal(1, "At least one register is required.");
     end
     `endif
-    // pragma translate_on
+    `endif
 endmodule

--- a/src/spill_register_flushable.sv
+++ b/src/spill_register_flushable.sv
@@ -94,12 +94,12 @@ module spill_register_flushable #(
     // We empty the spill register before the slice register.
     assign data_o = b_full_q ? b_data_q : a_data_q;
 
-    // pragma translate_off
+    `ifndef SYNTHESIS
     `ifndef COMMON_CELLS_ASSERTS_OFF
     flush_valid : assert property (
       @(posedge clk_i) disable iff (~rst_ni) (flush_i |-> ~valid_i)) else
       $warning("Trying to flush and feed the spill register simultaneously. You will lose data!");
    `endif
-     // pragma translate_on
+     `endif
   end
 endmodule

--- a/src/stream_arbiter_flushable.sv
+++ b/src/stream_arbiter_flushable.sv
@@ -74,9 +74,9 @@ module stream_arbiter_flushable #(
     );
 
   end else begin : gen_arb_error
-    // pragma translate_off
+    `ifndef SYNTHESIS
     $fatal(1, "Invalid value for parameter 'ARBITER'!");
-    // pragma translate_on
+    `endif
   end
 
 endmodule

--- a/src/stream_fork.sv
+++ b/src/stream_fork.sv
@@ -122,12 +122,12 @@ module stream_fork #(
     assign all_ones = '1;   // Synthesis fix for Vivado, which does not correctly compute the width
                             // of the '1 literal when assigned to a port of parametrized width.
 
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin: p_assertions
         assert (N_OUP >= 1) else $fatal(1, "Number of outputs must be at least 1!");
     end
 `endif
-// pragma translate_on
+`endif
 
 endmodule

--- a/src/stream_fork_dynamic.sv
+++ b/src/stream_fork_dynamic.sv
@@ -85,11 +85,11 @@ module stream_fork_dynamic #(
     .ready_i ( int_oup_ready )
   );
 
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin: p_assertions
     assert (N_OUP >= 1) else $fatal(1, "N_OUP must be at least 1!");
   end
 `endif
-// pragma translate_on
+`endif
 endmodule

--- a/src/stream_intf.sv
+++ b/src/stream_intf.sv
@@ -40,10 +40,10 @@ interface STREAM_DV #(
   );
 
   // Make sure that the handshake and payload is stable
-  // pragma translate_off
+  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   assert property (@(posedge clk_i) (valid && !ready |=> $stable(data)));
   assert property (@(posedge clk_i) (valid && !ready |=> valid));
   `endif
-  // pragma translate_on
+  `endif
 endinterface

--- a/src/stream_join_dynamic.sv
+++ b/src/stream_join_dynamic.sv
@@ -37,11 +37,11 @@ module stream_join_dynamic #(
     assign inp_ready_o[i] = oup_valid_o & oup_ready_i;
   end
 
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin: p_assertions
     assert (N_INP >= 1) else $fatal(1, "N_INP must be at least 1!");
   end
 `endif
-// pragma translate_on
+`endif
 endmodule

--- a/src/stream_mux.sv
+++ b/src/stream_mux.sv
@@ -35,12 +35,12 @@ module stream_mux #(
   assign oup_data_o   = inp_data_i[inp_sel_i];
   assign oup_valid_o  = inp_valid_i[inp_sel_i];
 
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   initial begin: p_assertions
     assert (N_INP >= 1) else $fatal (1, "The number of inputs must be at least 1!");
   end
 `endif
-// pragma translate_on
+`endif
 
 endmodule

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -260,7 +260,7 @@ module stream_omega_net #(
 
     // Assertions
     // Make sure that the handshake and payload is stable
-    // pragma translate_off
+    `ifndef SYNTHESIS
     `ifndef COMMON_CELLS_ASSERTS_OFF
     `ifndef VERILATOR
     default disable iff (~rst_ni);
@@ -305,6 +305,6 @@ module stream_omega_net #(
           $fatal(1, "Bit slicing of the internal selection signal is broken.");
     end
     `endif
-    // pragma translate_on
+    `endif
   end
 endmodule

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -116,7 +116,7 @@ module stream_to_mem #(
   assign mem_req_o = req_i;
 
 // Assertions
-// pragma translate_off
+`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   if (BufDepth > 0) begin : gen_buf_asserts
     assert property (@(posedge clk_i) mem_resp_valid_i |-> buf_ready)
@@ -130,5 +130,5 @@ module stream_to_mem #(
       else $error("Without BufDepth = 0, the memory must respond in the same cycle!");
   end
 `endif
-// pragma translate_on
+`endif
 endmodule

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -164,7 +164,7 @@ module stream_xbar #(
 
   // Assertions
   // Make sure that the handshake and payload is stable
-  // pragma translate_off
+  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef VERILATOR
   default disable iff (~rst_ni);
@@ -205,5 +205,5 @@ module stream_xbar #(
     assert (NumOut > 32'd0) else $fatal(1, "NumOut has to be > 0!");
   end
   `endif
-  // pragma translate_on
+  `endif
 endmodule


### PR DESCRIPTION
Hello!

According to the IEEE 1364.1-2005 spec 6.3.2, the use of `translate_off`/`translate_on` is discouraged as opposed to `` `ifndef SYNTHESIS ``. This change gives support to newer SystemVerilog frontends such as sv2v, Verible, and PySlint.

Thanks!