### PR TITLE
`stream_omega_net`: Fix non-existing output assertion

### DIFF
--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -267,7 +267,7 @@ module stream_omega_net #(
     `endif
     for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
       assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_i[i] |-> sel_i[i] < sel_oup_t'(NumOut))) else
+          (valid_i[i] |-> sel_i[i] < NumOut)) else
           $fatal(1, "Non-existing output is selected!");
     end
 


### PR DESCRIPTION
Fixes the same problem described in https://github.com/pulp-platform/common_cells/pull/204, but for the `stream_omega_net` IP.

This urges a new release, as v1.33.0 broke certain IPs (RTL simulation of the Snitch cluster) which previously worked with v1.32.0.