### PR TITLE
stream-xbar: Add payload stability assertion mask

### DIFF
--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -33,6 +33,10 @@ module stream_xbar #(
   /// When this is set, valids have to be asserted until the corresponding transaction is indicated
   /// by ready.
   parameter int unsigned LockIn      = 1'b1,
+  /// If `AxiVldReady` is 1, which bits of the payload to check for stability on valid inputs.
+  /// In some cases, we may want to allow parts of the payload to change depending on the value of
+  /// other parts (e.g. write data in read requests), requiring more nuanced external assertions.
+  parameter payload_t    AxiVldMask  = '1,
   /// Derived parameter, do **not** overwrite!
   ///
   /// Width of the output selection signal.
@@ -178,7 +182,7 @@ module stream_xbar #(
   if (AxiVldRdy) begin : gen_handshake_assertions
     for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_inp_assertions
       assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_i[i] && !ready_o[i] |=> $stable(data_i[i]))) else
+          (valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask))) else
           $error("data_i is unstable at input: %0d", i);
       assert property (@(posedge clk_i) disable iff (~rst_ni)
           (valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]))) else
@@ -189,7 +193,7 @@ module stream_xbar #(
     end
     for (genvar i = 0; unsigned'(i) < NumOut; i++) begin : gen_out_assertions
       assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_o[i] && !ready_i[i] |=> $stable(data_o[i]))) else
+          (valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask))) else
           $error("data_o is unstable at output: %0d Check that parameter LockIn is set.", i);
       assert property (@(posedge clk_i) disable iff (~rst_ni)
           (valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]))) else


### PR DESCRIPTION
Fixing the reset polarity of assertions in `stream_xbar` and `stream_omega_net` (#200) uncovered numerous assertion failures in our  designs using `common_cells`.  One assertion failure we observe may result from intentional, functionally correct design.  

`stream_xbar` and `stream_omega_net` are commonly used for in-cycle banked SRAM interconnects (e.g. PULP TCDM), wherein parts of a valid payload may freely change if they are not relevant to that payload.

The most common example is a shared request channel for reads and writes. The write data is always part of the payload, but on reads (i.e. when the write enable in the payload is low), it is irrelevant to the request. Thus, efficient designs may opt to hardwire write data to a write-specific datapath, which may result in write data changes while a valid read request is pending. 

While functionally harmless, such changes trigger the current data stability assertions in `stream_xbar` and `stream_omega_net` which provide either strict stability assertions on all payload bits (`AxiVldRdy == 1`) or no stability assertions at all  (`AxiVldRdy == 0`).

This MR adds a mask parameter `AxiVldMask` allowing designers to choose on which payload bits stability should be asserted. Since the default mask is `'1`, this change is **non-breaking**.

