### PR TITLE
stream_arbiter_flushable: Do not lock prio arbiter

### DIFF
--- a/src/stream_arbiter_flushable.sv
+++ b/src/stream_arbiter_flushable.sv
@@ -58,7 +58,7 @@ module stream_arbiter_flushable #(
       .DataType   (DATA_T),
       .ExtPrio    (1'b1),
       .AxiVldRdy  (1'b1),
-      .LockIn     (1'b1)
+      .LockIn     (1'b0)
     ) i_arbiter (
       .clk_i,
       .rst_ni,


### PR DESCRIPTION
Setting `LockIn` while `ExtPrio = 1'b1` is disallowed by the `rr_arb_tree` and has no effect. Furthermore, locking a decision with a possibly lower priority violates the intent of the priority arbiter.

Therefore, clear the `LockIn` parameter for the priority arbiter.

Fixes #221.