### PR TITLE
Cast `'0` reset values to data type

### DIFF
--- a/src/cdc_2phase.sv
+++ b/src/cdc_2phase.sv
@@ -111,7 +111,7 @@ module cdc_2phase_src #(
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       req_src_q  <= 0;
-      data_src_q <= '0;
+      data_src_q <= T'('0);
     end else if (valid_i && ready_o) begin
       req_src_q  <= ~req_src_q;
       data_src_q <= data_i;
@@ -171,7 +171,7 @@ module cdc_2phase_dst #(
   // indicated by the async_req line changing levels.
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      data_dst_q <= '0;
+      data_dst_q <= T'('0);
     end else if (req_q0 != req_q1 && !valid_o) begin
       data_dst_q <= async_data_i;
     end

--- a/src/cdc_fifo_2phase.sv
+++ b/src/cdc_fifo_2phase.sv
@@ -90,7 +90,7 @@ module cdc_fifo_2phase #(
   for (genvar i = 0; i < 2**LOG_DEPTH; i++) begin : g_word
     always_ff @(posedge src_clk_i, negedge src_rst_ni) begin
       if (!src_rst_ni)
-        fifo_data_q[i] <= '0;
+        fifo_data_q[i] <= T'('0);
       else if (fifo_write && fifo_widx == i)
         fifo_data_q[i] <= fifo_wdata;
     end

--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -131,7 +131,7 @@ module fifo_v3 #(
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
         if(~rst_ni) begin
-            mem_q <= '0;
+            mem_q <= {FifoDepth{dtype'('0)}};
         end else if (!gate_clock) begin
             mem_q <= mem_n;
         end

--- a/src/lossy_valid_to_stream.sv
+++ b/src/lossy_valid_to_stream.sv
@@ -125,7 +125,7 @@ module lossy_valid_to_stream #(
       read_ptr_q           <= '0;
       write_ptr_q          <= '0;
       pending_tx_counter_q <= '0;
-      mem_q                <= '0;
+      mem_q                <= {2{T'('0)}};
     end else begin
       read_ptr_q           <= read_ptr_d;
       write_ptr_q          <= write_ptr_d;

--- a/src/shift_reg_gated.sv
+++ b/src/shift_reg_gated.sv
@@ -53,7 +53,7 @@ module shift_reg_gated #(
 
       // Gate each shift register with a valid flag to enable the synthsis tools to insert ICG for
       // better power comsumption.
-      `FFL(data_q[i], data_d[i], valid_d[i], '0, clk_i, rst_ni)
+      `FFL(data_q[i], data_d[i], valid_d[i], dtype'('0), clk_i, rst_ni)
     end
 
     // Output the shifted result.

--- a/src/spill_register_flushable.sv
+++ b/src/spill_register_flushable.sv
@@ -41,7 +41,7 @@ module spill_register_flushable #(
 
     always_ff @(posedge clk_i or negedge rst_ni) begin : ps_a_data
       if (!rst_ni)
-        a_data_q <= '0;
+        a_data_q <= T'('0);
       else if (a_fill)
         a_data_q <= data_i;
     end
@@ -60,7 +60,7 @@ module spill_register_flushable #(
 
     always_ff @(posedge clk_i or negedge rst_ni) begin : ps_b_data
       if (!rst_ni)
-        b_data_q <= '0;
+        b_data_q <= T'('0);
       else if (b_fill)
         b_data_q <= a_data_q;
     end

--- a/src/stream_register.sv
+++ b/src/stream_register.sv
@@ -34,7 +34,7 @@ module stream_register #(
     assign ready_o = ready_i | ~valid_o;
     assign reg_ena = valid_i & ready_o;
     // Load-enable FFs with synch clear
-    `FFLARNC(valid_o, valid_i, ready_o, clr_i, 1'b0, clk_i, rst_ni)
-    `FFLARNC(data_o,   data_i, reg_ena, clr_i,   '0, clk_i, rst_ni)
+    `FFLARNC(valid_o, valid_i, ready_o, clr_i, 1'b0  , clk_i, rst_ni)
+    `FFLARNC(data_o,   data_i, reg_ena, clr_i, T'('0), clk_i, rst_ni)
 
 endmodule


### PR DESCRIPTION
Several of the modules in this repository allow the user to specify a custom data type. Yet, the reset value for data registers is always `'0`, which causes linter errors if the data type is, for instance, an enum.

This PR casts all `'0` reset values for data registers to the respective data type (e.g., `T'('0)`), thus avoiding linter warnings.