### PR TITLE
[delta_counter] Attach reset properly to overflow FF

### DIFF
--- a/src/delta_counter.sv
+++ b/src/delta_counter.sv
@@ -33,12 +33,11 @@ module delta_counter #(
         begin
             if(rst_ni) begin
                 overflow_q <= 1'b0;
-            end
-            else begin
+            end else begin
                 overflow_q <= overflow_d;
             end
         end
-        
+
         always_comb begin
             overflow_d = overflow_q;
             if (clear_i || load_i) begin

--- a/src/delta_counter.sv
+++ b/src/delta_counter.sv
@@ -28,7 +28,17 @@ module delta_counter #(
     logic [WIDTH:0] counter_q, counter_d;
     if (STICKY_OVERFLOW) begin : gen_sticky_overflow
         logic overflow_d, overflow_q;
-        always_ff @(posedge clk_i or negedge rst_ni) overflow_q <= ~rst_ni ? 1'b0 : overflow_d;
+
+        always_ff @(posedge clk_i or negedge rst_ni)
+        begin
+            if(rst_ni) begin
+                overflow_q <= 1'b0;
+            end
+            else begin
+                overflow_q <= overflow_d;
+            end
+        end
+        
         always_comb begin
             overflow_d = overflow_q;
             if (clear_i || load_i) begin


### PR DESCRIPTION
In the previous version of the code, the flip-flop was described non-idiomatically, using a ternary operator to implement the asynchronous reset. Some synthesis tools do not properly interpret this as a reset, resulting in gates being inserted on the reset network, which is undesirable.