### PR TITLE
Avoid wide signals in sensitivity lists of immediate assertions

### DIFF
--- a/src/addr_decode_dync.sv
+++ b/src/addr_decode_dync.sv
@@ -146,7 +146,7 @@ module addr_decode_dync #(
   // check_start:        Enforces a smaller start than end address.
   // check_idx:          Enforces a valid index in the rule.
   // check_overlap:      Warns if there are overlapping address regions.
-  always @(addr_map_i or config_ongoing_i) #0 begin : proc_check_addr_map
+  always_comb begin : proc_check_addr_map
     if (!$isunknown(addr_map_i) && ~config_ongoing_i) begin
       for (int unsigned i = 0; i < NoRules; i++) begin
         check_start : assume (Napot || addr_map_i[i].start_addr < addr_map_i[i].end_addr ||

--- a/src/multiaddr_decode.sv
+++ b/src/multiaddr_decode.sv
@@ -133,7 +133,7 @@ module multiaddr_decode #(
 
   // These following assumptions check the validity of the address map.
   // check_idx: Enforces a valid index in the rule.
-  always @(addr_map_i) #0 begin : proc_check_addr_map
+  always_comb begin : proc_check_addr_map
     if (!$isunknown(addr_map_i)) begin
       for (int unsigned i = 0; i < NoRules; i++) begin
         // check the SLV ids


### PR DESCRIPTION
The `addr_decode_dync` and `multiaddr_decode` modules feature some complex assertions (actually `assume`s to be precise) that are quite complex — too complex for Verilator it seems, which fails in unpredictable ways when these modules are present. Therefore, this PR disables those assertions in Verilator (based on whether the `VERILATOR` pre-processor macro is defined).