### PR TITLE
Replace all asserts & assumes with macros from `assertions.svh`

### DIFF
--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -6,8 +6,8 @@
 //  - Provides default clk and rst options to simplify code
 //  - Provides boiler plate template for common assertions
 
-`ifndef PRIM_ASSERT_SV
-`define PRIM_ASSERT_SV
+`ifndef COMMON_CELLS_ASSERTIONS_SVH
+`define COMMON_CELLS_ASSERTIONS_SVH
 
 `ifdef UVM
   // report assertion error with UVM if compiled
@@ -34,7 +34,7 @@
 `endif
 
 // Converts an arbitrary block of code into a Verilog string
-`define PRIM_STRINGIFY(__x) `"__x`"
+`define ASSERT_STRINGIFY(__x) `"__x`"
 
 // ASSERT_RPT is available to change the reporting mechanism when an assert fails
 `define ASSERT_RPT(__name)                                                  \
@@ -55,23 +55,23 @@
 
 // Immediate assertion
 // Note that immediate assertions are sensitive to simulation glitches.
-`define ASSERT_I(__name, __prop)           \
-`ifdef INC_ASSERT                          \
-  __name: assert (__prop)                  \
-    else begin                             \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
-    end                                    \
+`define ASSERT_I(__name, __prop)             \
+`ifdef INC_ASSERT                            \
+  __name: assert (__prop)                    \
+    else begin                               \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name)) \
+    end                                      \
 `endif
 
 // Assertion in initial block. Can be used for things like parameter checking.
-`define ASSERT_INIT(__name, __prop)          \
-`ifdef INC_ASSERT                            \
-  initial begin                              \
-    __name: assert (__prop)                  \
-      else begin                             \
-        `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
-      end                                    \
-  end                                        \
+`define ASSERT_INIT(__name, __prop)            \
+`ifdef INC_ASSERT                              \
+  initial begin                                \
+    __name: assert (__prop)                    \
+      else begin                               \
+        `ASSERT_RPT(`ASSERT_STRINGIFY(__name)) \
+      end                                      \
+  end                                          \
 `endif
 
 // Assertion in final block. Can be used for things like queues being empty
@@ -82,7 +82,7 @@
   final begin                                                                \
     __name: assert (__prop || $test$plusargs("disable_assert_final_checks")) \
       else begin                                                             \
-        `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                 \
+        `ASSERT_RPT(`ASSERT_STRINGIFY(__name))                               \
       end                                                                    \
   end                                                                        \
 `endif
@@ -93,7 +93,7 @@
 `ifdef INC_ASSERT                                                                        \
   __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
     else begin                                                                           \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                               \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name))                                             \
     end                                                                                  \
 `endif
 // Note: Above we use (__rst !== '0) in the disable iff statements instead of
@@ -106,7 +106,7 @@
 `ifdef INC_ASSERT                                                                              \
   __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) not (__prop))         \
     else begin                                                                                 \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                                     \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name))                                                   \
     end                                                                                        \
 `endif
 
@@ -157,17 +157,17 @@
 `ifdef INC_ASSERT                                                                        \
   __name: assume property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
     else begin                                                                           \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name))                                               \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name))                                             \
     end                                                                                  \
 `endif
 
 // Assume an immediate property
-`define ASSUME_I(__name, __prop)           \
-`ifdef INC_ASSERT                          \
-  __name: assume (__prop)                  \
-    else begin                             \
-      `ASSERT_RPT(`PRIM_STRINGIFY(__name)) \
-    end                                    \
+`define ASSUME_I(__name, __prop)             \
+`ifdef INC_ASSERT                            \
+  __name: assume (__prop)                    \
+    else begin                               \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name)) \
+    end                                      \
 `endif
 
 //////////////////////////////////
@@ -198,4 +198,4 @@
    `COVER(__name, __prop, __clk, __rst)                                                     \
 `endif
 
-`endif // PRIM_ASSERT_SV
+`endif // COMMON_CELLS_ASSERTIONS_SVH

--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -43,12 +43,14 @@
 `define ASSERT_STRINGIFY(__x) `"__x`"
 
 // ASSERT_RPT is available to change the reporting mechanism when an assert fails
-`define ASSERT_RPT(__name)                                                  \
-`ifdef UVM                                                                  \
-  assert_rpt_pkg::assert_rpt($sformatf("[%m] %s (%s:%0d)",                  \
-                             __name, `__FILE__, `__LINE__));                \
-`else                                                                       \
-  $error("[ASSERT FAILED] [%m] %s (%s:%0d)", __name, `__FILE__, `__LINE__); \
+`ifndef ASSERT_RPT
+`define ASSERT_RPT(__name, __desc = "")                                                 \
+`ifdef UVM                                                                              \
+  assert_rpt_pkg::assert_rpt($sformatf("[%m] %s: %s (%s:%0d)",                          \
+                             __name, __desc, `__FILE__, `__LINE__));                    \
+`else                                                                                   \
+  $error("[ASSERT FAILED] [%m] %s: %s (%s:%0d)", __name, __desc, `__FILE__, `__LINE__); \
+`endif
 `endif
 
 ///////////////////////////////////////
@@ -61,46 +63,46 @@
 
 // Immediate assertion
 // Note that immediate assertions are sensitive to simulation glitches.
-`define ASSERT_I(__name, __prop)             \
-`ifdef INC_ASSERT                            \
-  __name: assert (__prop)                    \
-    else begin                               \
-      `ASSERT_RPT(`ASSERT_STRINGIFY(__name)) \
-    end                                      \
+`define ASSERT_I(__name, __prop, __desc = "")        \
+`ifdef INC_ASSERT                                    \
+  __name: assert (__prop)                            \
+    else begin                                       \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name), __desc) \
+    end                                              \
 `endif
 
 // Assertion in initial block. Can be used for things like parameter checking.
-`define ASSERT_INIT(__name, __prop)            \
-`ifdef INC_ASSERT                              \
-  initial begin                                \
-    __name: assert (__prop)                    \
-      else begin                               \
-        `ASSERT_RPT(`ASSERT_STRINGIFY(__name)) \
-      end                                      \
-  end                                          \
+`define ASSERT_INIT(__name, __prop, __desc = "")       \
+`ifdef INC_ASSERT                                      \
+  initial begin                                        \
+    __name: assert (__prop)                            \
+      else begin                                       \
+        `ASSERT_RPT(`ASSERT_STRINGIFY(__name), __desc) \
+      end                                              \
+  end                                                  \
 `endif
 
 // Assertion in final block. Can be used for things like queues being empty
 // at end of sim, all credits returned at end of sim, state machines in idle
 // at end of sim.
-`define ASSERT_FINAL(__name, __prop)                                         \
+`define ASSERT_FINAL(__name, __prop, __desc = "")                            \
 `ifdef INC_ASSERT                                                            \
   final begin                                                                \
     __name: assert (__prop || $test$plusargs("disable_assert_final_checks")) \
       else begin                                                             \
-        `ASSERT_RPT(`ASSERT_STRINGIFY(__name))                               \
+        `ASSERT_RPT(`ASSERT_STRINGIFY(__name), __desc)                       \
       end                                                                    \
   end                                                                        \
 `endif
 
 // Assert a concurrent property directly.
 // It can be called as a module (or interface) body item.
-`define ASSERT(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                        \
-  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
-    else begin                                                                           \
-      `ASSERT_RPT(`ASSERT_STRINGIFY(__name))                                             \
-    end                                                                                  \
+`define ASSERT(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST, __desc = "") \
+`ifdef INC_ASSERT                                                                                     \
+  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))                    \
+    else begin                                                                                        \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name), __desc)                                                  \
+    end                                                                                               \
 `endif
 // Note: Above we use (__rst !== '0) in the disable iff statements instead of
 // (__rst == '1).  This properly disables the assertion in cases when reset is X at
@@ -108,19 +110,19 @@
 // assertion.
 
 // Assert a concurrent property NEVER happens
-`define ASSERT_NEVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                              \
-  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) not (__prop))         \
-    else begin                                                                                 \
-      `ASSERT_RPT(`ASSERT_STRINGIFY(__name))                                                   \
-    end                                                                                        \
+`define ASSERT_NEVER(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST, __desc = "") \
+`ifdef INC_ASSERT                                                                                           \
+  __name: assert property (@(posedge __clk) disable iff ((__rst) !== '0) not (__prop))                      \
+    else begin                                                                                              \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name), __desc)                                                        \
+    end                                                                                                     \
 `endif
 
 // Assert that signal has a known value (each bit is either '0' or '1') after reset.
 // It can be called as a module (or interface) body item.
-`define ASSERT_KNOWN(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                             \
-  `ASSERT(__name, !$isunknown(__sig), __clk, __rst)                                           \
+`define ASSERT_KNOWN(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST, __desc = "") \
+`ifdef INC_ASSERT                                                                                          \
+  `ASSERT(__name, !$isunknown(__sig), __clk, __rst, __desc)                                                \
 `endif
 
 //  Cover a concurrent property
@@ -134,24 +136,24 @@
 //////////////////////////////
 
 // Assert that signal is an active-high pulse with pulse length of 1 clock cycle
-`define ASSERT_PULSE(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                             \
-  `ASSERT(__name, $rose(__sig) |=> !(__sig), __clk, __rst)                                    \
+`define ASSERT_PULSE(__name, __sig, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST, __desc = "") \
+`ifdef INC_ASSERT                                                                                          \
+  `ASSERT(__name, $rose(__sig) |=> !(__sig), __clk, __rst, __desc)                                         \
 `endif
 
 // Assert that a property is true only when an enable signal is set.  It can be called as a module
 // (or interface) body item.
-`define ASSERT_IF(__name, __prop, __enable, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                                     \
-  `ASSERT(__name, (__enable) |-> (__prop), __clk, __rst)                                              \
+`define ASSERT_IF(__name, __prop, __enable, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST, __desc = "") \
+`ifdef INC_ASSERT                                                                                                  \
+  `ASSERT(__name, (__enable) |-> (__prop), __clk, __rst, __desc)                                                   \
 `endif
 
 // Assert that signal has a known value (each bit is either '0' or '1') after reset if enable is
 // set.  It can be called as a module (or interface) body item.
-`define ASSERT_KNOWN_IF(__name, __sig, __enable, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
+`define ASSERT_KNOWN_IF(__name, __sig, __enable, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST, __desc = "") \
 `ifdef INC_ASSERT                                                                                          \
-  `ASSERT_KNOWN(__name``KnownEnable, __enable, __clk, __rst)                                               \
-  `ASSERT_IF(__name, !$isunknown(__sig), __enable, __clk, __rst)                                           \
+  `ASSERT_KNOWN(__name``KnownEnable, __enable, __clk, __rst, __desc)                                                    \
+  `ASSERT_IF(__name, !$isunknown(__sig), __enable, __clk, __rst, __desc)                                                \
 `endif
 
 ///////////////////////
@@ -159,21 +161,21 @@
 ///////////////////////
 
 // Assume a concurrent property
-`define ASSUME(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef INC_ASSERT                                                                        \
-  __name: assume property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))       \
-    else begin                                                                           \
-      `ASSERT_RPT(`ASSERT_STRINGIFY(__name))                                             \
-    end                                                                                  \
+`define ASSUME(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST, __desc = "") \
+`ifdef INC_ASSERT                                                                                     \
+  __name: assume property (@(posedge __clk) disable iff ((__rst) !== '0) (__prop))                    \
+    else begin                                                                                        \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name), __desc)                                                  \
+    end                                                                                               \
 `endif
 
 // Assume an immediate property
-`define ASSUME_I(__name, __prop)             \
-`ifdef INC_ASSERT                            \
-  __name: assume (__prop)                    \
-    else begin                               \
-      `ASSERT_RPT(`ASSERT_STRINGIFY(__name)) \
-    end                                      \
+`define ASSUME_I(__name, __prop, __desc = "")        \
+`ifdef INC_ASSERT                                    \
+  __name: assume (__prop)                            \
+    else begin                                       \
+      `ASSERT_RPT(`ASSERT_STRINGIFY(__name), __desc) \
+    end                                              \
 `endif
 
 //////////////////////////////////
@@ -185,16 +187,16 @@
 
 // ASSUME_FPV
 // Assume a concurrent property during formal verification only.
-`define ASSUME_FPV(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST) \
-`ifdef FPV_ON                                                                                \
-   `ASSUME(__name, __prop, __clk, __rst)                                                     \
+`define ASSUME_FPV(__name, __prop, __clk = `ASSERT_DEFAULT_CLK, __rst = `ASSERT_DEFAULT_RST, __desc = "") \
+`ifdef FPV_ON                                                                                             \
+   `ASSUME(__name, __prop, __clk, __rst, __desc)                                                          \
 `endif
 
 // ASSUME_I_FPV
 // Assume a concurrent property during formal verification only.
-`define ASSUME_I_FPV(__name, __prop) \
-`ifdef FPV_ON                        \
-   `ASSUME_I(__name, __prop)         \
+`define ASSUME_I_FPV(__name, __prop, __desc = "") \
+`ifdef FPV_ON                                     \
+   `ASSUME_I(__name, __prop, __desc)              \
 `endif
 
 // COVER_FPV

--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -25,7 +25,7 @@
 ///////////////////
 
 // local helper macro to reduce code clutter. undefined at the end of this file
-`ifndef VERILATOR
+`ifndef ASSERTS_OFF
 `ifndef SYNTHESIS
 `ifndef XSIM
 `define INC_ASSERT

--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -29,7 +29,13 @@
 `ifndef SYNTHESIS
 `ifndef XSIM
 `define INC_ASSERT
+`endif
 `endif   
+`endif
+// forcefully enable assertions with ASSERTS_OVERRIDE_ON, overriding any define that turns them off
+`ifdef ASSERTS_OVERRIDE_ON
+`ifndef INC_ASSERT
+`define INC_ASSERT
 `endif
 `endif
 

--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -204,4 +204,11 @@
    `COVER(__name, __prop, __clk, __rst)                                                     \
 `endif
 
+
+// undefine local helper macros
+`ifdef INC_ASSERT
+`undef INC_ASSERT
+`endif
+`undef ASSERT_STRINGIFY
+
 `endif // COMMON_CELLS_ASSERTIONS_SVH

--- a/src/addr_decode_dync.sv
+++ b/src/addr_decode_dync.sv
@@ -14,6 +14,8 @@
 // - Michael Rogenmoser <michaero@iis.ee.ethz.ch>
 // - Thomas Benz <tbenz@iis.ee.ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 /// Address Decoder: Maps the input address combinatorially to an index.
 /// DYNamic Configuration (DYNC) version
 /// The address map `addr_map_i` is a packed array of rule_t structs.

--- a/src/addr_decode_dync.sv
+++ b/src/addr_decode_dync.sv
@@ -128,7 +128,7 @@ module addr_decode_dync #(
   initial begin : proc_check_parameters
     `ASSUME_I(addr_width_mismatch, $bits(addr_i) == $bits(addr_map_i[0].start_addr),
              $sformatf("Input address has %d bits and address map has %d bits.",
-	               $bits(addr_i), $bits(addr_map_i[0].start_addr)))
+                       $bits(addr_i), $bits(addr_map_i[0].start_addr)))
     `ASSUME_I(norules_0, NoRules > 0, $sformatf("At least one rule needed"))
     `ASSUME_I(noindices_0, NoIndices > 0, $sformatf("At least one index needed"))
   end

--- a/src/addr_decode_dync.sv
+++ b/src/addr_decode_dync.sv
@@ -125,8 +125,6 @@ module addr_decode_dync #(
 
   // Assumptions and assertions
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ifndef XSIM
-  `ifndef SYNTHESIS
   initial begin : proc_check_parameters
     `ASSUME_I(addr_width_mismatch, $bits(addr_i) == $bits(addr_map_i[0].start_addr),
              $sformatf("Input address has %d bits and address map has %d bits.",
@@ -135,8 +133,8 @@ module addr_decode_dync #(
     `ASSUME_I(noindices_0, NoIndices > 0, $sformatf("At least one index needed"))
   end
 
-  assert final ($onehot0(matched_rules) || config_ongoing_i) else
-    $warning("More than one bit set in the one-hot signal, matched_rules");
+  `ASSERT_FINAL(more_than_1_bit_set, $onehot0(matched_rules) || config_ongoing_i,
+                "More than one bit set in the one-hot signal, matched_rules")
 
   // These following assumptions check the validity of the address map.
   // The assumptions gets generated for each distinct pair of rules.
@@ -184,8 +182,6 @@ module addr_decode_dync #(
       end
     end
   end
-  `endif
-  `endif
   `endif
 
 endmodule

--- a/src/cb_filter.sv
+++ b/src/cb_filter.sv
@@ -241,9 +241,9 @@ module hash_block #(
   // assertions
   `ifndef SYNTHESIS
   initial begin
-    hash_conf: assume (InpWidth > HashWidth) else
-      $fatal(1, "%m:\nA Hash Function reduces the width of the input>\nInpWidth: %s\nOUT_WIDTH: %s",
-          InpWidth, HashWidth);
+    `ASSUME_I(hash_conf, InpWidth > HashWidth,
+      $sformatf("%m:\nA Hash Function reduces the width of the input>\nInpWidth: %s\nOUT_WIDTH: %s",
+          InpWidth, HashWidth))
   end
   `endif
 `endif

--- a/src/cb_filter.sv
+++ b/src/cb_filter.sv
@@ -239,12 +239,10 @@ module hash_block #(
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
   // assertions
-  `ifndef SYNTHESIS
   initial begin
     `ASSUME_I(hash_conf, InpWidth > HashWidth,
       $sformatf("%m:\nA Hash Function reduces the width of the input>\nInpWidth: %s\nOUT_WIDTH: %s",
           InpWidth, HashWidth))
   end
-  `endif
 `endif
 endmodule

--- a/src/cb_filter.sv
+++ b/src/cb_filter.sv
@@ -39,6 +39,8 @@
 //   - `filter_empty_o`:  Filter is empty.
 //   - `filter_error_o`:  One of the internal counters or buckets overflowed.
 
+`include "common_cells/assertions.svh"
+
 /// This is a counting bloom filter
 module cb_filter #(
   parameter int unsigned KHashes     =  32'd3,  // Number of hash functions

--- a/src/cdc_2phase_clearable.sv
+++ b/src/cdc_2phase_clearable.sv
@@ -188,9 +188,7 @@ module cdc_2phase_clearable #(
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
 
-  no_valid_i_during_clear_i : assert property (
-    @(posedge src_clk_i) disable iff (!src_rst_ni) src_clear_i |-> !src_valid_i
-  );
+  `ASSERT(no_valid_i_during_clear_i, src_clear_i |-> !src_valid_i, src_clk_i, !src_rst_ni)
 
 `endif
 

--- a/src/cdc_2phase_clearable.sv
+++ b/src/cdc_2phase_clearable.sv
@@ -257,10 +257,7 @@ module cdc_2phase_src_clearable #(
 
 // Assertions
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ifndef SYNTHESIS
   `ASSUME(no_clear_and_request, clear_i |-> ~valid_i, clk_i, !rst_ni, "No request allowed while clear_i is asserted.")
-
-  `endif
 `endif
 
 endmodule

--- a/src/cdc_2phase_clearable.sv
+++ b/src/cdc_2phase_clearable.sv
@@ -257,7 +257,8 @@ module cdc_2phase_src_clearable #(
 
 // Assertions
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ASSUME(no_clear_and_request, clear_i |-> ~valid_i, clk_i, !rst_ni, "No request allowed while clear_i is asserted.")
+  `ASSUME(no_clear_and_request, clear_i |-> ~valid_i, clk_i, !rst_ni,
+          "No request allowed while clear_i is asserted.")
 `endif
 
 endmodule

--- a/src/cdc_2phase_clearable.sv
+++ b/src/cdc_2phase_clearable.sv
@@ -49,6 +49,7 @@
 /* verilator lint_off DECLFILENAME */
 
 `include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
 
 module cdc_2phase_clearable #(
   parameter type T = logic,

--- a/src/cdc_2phase_clearable.sv
+++ b/src/cdc_2phase_clearable.sv
@@ -258,9 +258,7 @@ module cdc_2phase_src_clearable #(
 // Assertions
 `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef SYNTHESIS
-  no_clear_and_request: assume property (
-     @(posedge clk_i) disable iff(~rst_ni) (clear_i |-> ~valid_i))
-    else $fatal(1, "No request allowed while clear_i is asserted.");
+  `ASSUME(no_clear_and_request, clear_i |-> ~valid_i, clk_i, !rst_ni, "No request allowed while clear_i is asserted.")
 
   `endif
 `endif

--- a/src/cdc_fifo_2phase.sv
+++ b/src/cdc_fifo_2phase.sv
@@ -65,9 +65,7 @@ module cdc_fifo_2phase #(
 
   // Check the invariants.
   `ifndef SYNTHESIS
-  initial begin
-    assert(LOG_DEPTH > 0);
-  end
+  `ASSERT_INIT(log_depth_0, LOG_DEPTH > 0)
   `endif
 
   localparam int PtrWidth = LOG_DEPTH+1;

--- a/src/cdc_fifo_2phase.sv
+++ b/src/cdc_fifo_2phase.sv
@@ -11,6 +11,8 @@
 //
 // Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 /// A clock domain crossing FIFO, using 2-phase hand shakes.
 ///
 /// This FIFO has its push and pop ports in two separate clock domains. Its size

--- a/src/cdc_fifo_2phase.sv
+++ b/src/cdc_fifo_2phase.sv
@@ -64,7 +64,7 @@ module cdc_fifo_2phase #(
 );
 
   // Check the invariants.
-  `ifndef SYNTHESIS
+  `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT_INIT(log_depth_0, LOG_DEPTH > 0)
   `endif
 

--- a/src/cdc_fifo_gray.sv
+++ b/src/cdc_fifo_gray.sv
@@ -158,11 +158,9 @@ module cdc_fifo_gray #(
   );
 
   // Check the invariants.
-  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT_INIT(log_depth_0, LOG_DEPTH > 0)
   `ASSERT_INIT(sync_stages_gt_2, SYNC_STAGES >= 2)
-  `endif
   `endif
 
 endmodule

--- a/src/cdc_fifo_gray.sv
+++ b/src/cdc_fifo_gray.sv
@@ -96,6 +96,7 @@
 /// ```
 
 `include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
 
 (* no_ungroup *)
 (* no_boundary_optimization *)

--- a/src/cdc_fifo_gray.sv
+++ b/src/cdc_fifo_gray.sv
@@ -160,8 +160,8 @@ module cdc_fifo_gray #(
   // Check the invariants.
   `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  initial assert(LOG_DEPTH > 0);
-  initial assert(SYNC_STAGES >= 2);
+  `ASSERT_INIT(log_depth_0, LOG_DEPTH > 0)
+  `ASSERT_INIT(sync_stages_gt_2, SYNC_STAGES >= 2)
   `endif
   `endif
 

--- a/src/cdc_fifo_gray_clearable.sv
+++ b/src/cdc_fifo_gray_clearable.sv
@@ -257,8 +257,8 @@ module cdc_fifo_gray_clearable #(
   // Check the invariants.
   `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  initial assert(LOG_DEPTH > 0);
-  initial assert(SYNC_STAGES >= 2);
+  `ASSERT_INIT(log_depth_0, LOG_DEPTH > 0)
+  `ASSERT_INIT(sync_stages_lt_2, SYNC_STAGES >= 2)
   `endif
   `endif
 

--- a/src/cdc_fifo_gray_clearable.sv
+++ b/src/cdc_fifo_gray_clearable.sv
@@ -255,11 +255,9 @@ module cdc_fifo_gray_clearable #(
   assign dst_clear_pending_o = s_dst_isolate_req;
 
   // Check the invariants.
-  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT_INIT(log_depth_0, LOG_DEPTH > 0)
   `ASSERT_INIT(sync_stages_lt_2, SYNC_STAGES >= 2)
-  `endif
   `endif
 
 endmodule

--- a/src/cdc_fifo_gray_clearable.sv
+++ b/src/cdc_fifo_gray_clearable.sv
@@ -96,6 +96,7 @@
 /// async] ```
 
 `include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
 
 (* no_ungroup *)
 (* no_boundary_optimization *)

--- a/src/exp_backoff.sv
+++ b/src/exp_backoff.sv
@@ -83,13 +83,11 @@ module exp_backoff #(
 // assertions
 ///////////////////////////////////////////////////////
 
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   // assert wrong parameterizations
   `ASSERT_INIT(max_exp_0, MaxExp>0, "MaxExp must be greater than 0")
   `ASSERT_INIT(max_exp_gt_16, MaxExp<=16, "MaxExp cannot be greater than 16")
   `ASSERT_INIT(seed_0, Seed>0, "Zero seed is not allowed for LFSR")
-`endif
 `endif
 
 endmodule // exp_backoff

--- a/src/exp_backoff.sv
+++ b/src/exp_backoff.sv
@@ -85,15 +85,10 @@ module exp_backoff #(
 
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  initial begin
-    // assert wrong parameterizations
-    assert (MaxExp>0)
-      else $fatal(1,"MaxExp must be greater than 0");
-    assert (MaxExp<=16)
-      else $fatal(1,"MaxExp cannot be greater than 16");
-    assert (Seed>0)
-      else $fatal(1,"Zero seed is not allowed for LFSR");
-  end
+  // assert wrong parameterizations
+  `ASSERT_INIT(max_exp_0, MaxExp>0, "MaxExp must be greater than 0")
+  `ASSERT_INIT(max_exp_gt_16, MaxExp<=16, "MaxExp cannot be greater than 16")
+  `ASSERT_INIT(seed_0, Seed>0, "Zero seed is not allowed for LFSR")
 `endif
 `endif
 

--- a/src/exp_backoff.sv
+++ b/src/exp_backoff.sv
@@ -20,6 +20,8 @@
 // a successful trial (clr_i).
 //
 
+`include "common_cells/assertions.svh"
+
 module exp_backoff #(
   /// Seed for 16bit LFSR
   parameter int unsigned Seed   = 'hffff,

--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -10,6 +10,8 @@
 
 // Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 module fifo_v3 #(
     parameter bit          FALL_THROUGH = 1'b0, // fifo is in fall-through mode
     parameter int unsigned DATA_WIDTH   = 32,   // default data width if the fifo is of type logic

--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -142,9 +142,11 @@ module fifo_v3 #(
 `ifndef COMMON_CELLS_ASSERTS_OFF
     `ASSERT_INIT(depth_0, DEPTH > 0, "DEPTH must be greater than 0.")
 
-    `ASSERT(full_write, full_o |-> ~push_i, clk_i, !rst_ni, "Trying to push new data although the FIFO is full.")
+    `ASSERT(full_write, full_o |-> ~push_i, clk_i, !rst_ni,
+            "Trying to push new data although the FIFO is full.")
 
-    `ASSERT(empty_read, empty_o |-> ~pop_i, clk_i, !rst_ni, "Trying to pop data although the FIFO is empty.")
+    `ASSERT(empty_read, empty_o |-> ~pop_i, clk_i, !rst_ni,
+            "Trying to pop data although the FIFO is empty.")
 `endif
 
 endmodule // fifo_v3

--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -141,9 +141,7 @@ module fifo_v3 #(
 
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-    initial begin
-        assert (DEPTH > 0)             else $error("DEPTH must be greater than 0.");
-    end
+    `ASSERT_INIT(depth_0, DEPTH > 0, "DEPTH must be greater than 0.")
 
     `ASSERT(full_write, full_o |-> ~push_i, clk_i, !rst_ni, "Trying to push new data although the FIFO is full.")
 

--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -139,14 +139,12 @@ module fifo_v3 #(
         end
     end
 
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     `ASSERT_INIT(depth_0, DEPTH > 0, "DEPTH must be greater than 0.")
 
     `ASSERT(full_write, full_o |-> ~push_i, clk_i, !rst_ni, "Trying to push new data although the FIFO is full.")
 
     `ASSERT(empty_read, empty_o |-> ~pop_i, clk_i, !rst_ni, "Trying to pop data although the FIFO is empty.")
-`endif
 `endif
 
 endmodule // fifo_v3

--- a/src/fifo_v3.sv
+++ b/src/fifo_v3.sv
@@ -145,13 +145,9 @@ module fifo_v3 #(
         assert (DEPTH > 0)             else $error("DEPTH must be greater than 0.");
     end
 
-    full_write : assert property(
-        @(posedge clk_i) disable iff (~rst_ni) (full_o |-> ~push_i))
-        else $fatal (1, "Trying to push new data although the FIFO is full.");
+    `ASSERT(full_write, full_o |-> ~push_i, clk_i, !rst_ni, "Trying to push new data although the FIFO is full.")
 
-    empty_read : assert property(
-        @(posedge clk_i) disable iff (~rst_ni) (empty_o |-> ~pop_i))
-        else $fatal (1, "Trying to pop data although the FIFO is empty.");
+    `ASSERT(empty_read, empty_o |-> ~pop_i, clk_i, !rst_ni, "Trying to pop data although the FIFO is empty.")
 `endif
 `endif
 

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -410,12 +410,8 @@ module id_queue #(
     // Validate parameters.
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-    initial begin: validate_params
-        assert (ID_WIDTH >= 1)
-            else $fatal(1, "The ID must at least be one bit wide!");
-        assert (CAPACITY >= 1)
-            else $fatal(1, "The queue must have capacity of at least one entry!");
-    end
+    `ASSERT_INIT(id_width_0, ID_WIDTH >= 1, "The ID must at least be one bit wide!")
+    `ASSERT_INIT(capacity_0, CAPACITY >= 1, "The queue must have capacity of at least one entry!")
 `endif
 `endif
 

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -408,11 +408,9 @@ module id_queue #(
     end
 
     // Validate parameters.
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     `ASSERT_INIT(id_width_0, ID_WIDTH >= 1, "The ID must at least be one bit wide!")
     `ASSERT_INIT(capacity_0, CAPACITY >= 1, "The queue must have capacity of at least one entry!")
-`endif
 `endif
 
 endmodule

--- a/src/id_queue.sv
+++ b/src/id_queue.sv
@@ -45,6 +45,8 @@
 // Maintainers:
 // - Andreas Kurth <akurth@iis.ee.ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 module id_queue #(
     parameter int ID_WIDTH  = 0,
     parameter int CAPACITY  = 0,

--- a/src/isochronous_4phase_handshake.sv
+++ b/src/isochronous_4phase_handshake.sv
@@ -39,6 +39,7 @@
 /// ratio will work.
 
 `include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
 
 module isochronous_4phase_handshake (
   input  logic src_clk_i,

--- a/src/isochronous_4phase_handshake.sv
+++ b/src/isochronous_4phase_handshake.sv
@@ -71,8 +71,10 @@ module isochronous_4phase_handshake (
 
  // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ASSERT(src_valid_unstable, src_valid_i && !src_ready_o |=> $stable(src_valid_i), src_clk_i, !src_rst_ni, "src_valid_i is unstable")
-  `ASSERT(dst_valid_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o), dst_clk_i, !dst_rst_ni, "dst_valid_o is unstable")
+  `ASSERT(src_valid_unstable, src_valid_i && !src_ready_o |=> $stable(src_valid_i),
+          src_clk_i, !src_rst_ni, "src_valid_i is unstable")
+  `ASSERT(dst_valid_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o),
+          dst_clk_i, !dst_rst_ni, "dst_valid_o is unstable")
   `endif
 
 endmodule

--- a/src/isochronous_4phase_handshake.sv
+++ b/src/isochronous_4phase_handshake.sv
@@ -69,12 +69,10 @@ module isochronous_4phase_handshake (
   // destination is valid if we didn't yet get acknowledge
   assign dst_valid_o = (dst_req_q != dst_ack_q);
 
- `ifndef SYNTHESIS
  // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT(src_valid_unstable, src_valid_i && !src_ready_o |=> $stable(src_valid_i), src_clk_i, !src_rst_ni, "src_valid_i is unstable")
   `ASSERT(dst_valid_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o), dst_clk_i, !dst_rst_ni, "dst_valid_o is unstable")
-  `endif
   `endif
 
 endmodule

--- a/src/isochronous_4phase_handshake.sv
+++ b/src/isochronous_4phase_handshake.sv
@@ -72,10 +72,8 @@ module isochronous_4phase_handshake (
  `ifndef SYNTHESIS
  // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)
-    (src_valid_i && !src_ready_o |=> $stable(src_valid_i))) else $error("src_valid_i is unstable");
-  assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
-    (dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o))) else $error("dst_valid_o is unstable");
+  `ASSERT(src_valid_unstable, src_valid_i && !src_ready_o |=> $stable(src_valid_i), src_clk_i, !src_rst_ni, "src_valid_i is unstable")
+  `ASSERT(dst_valid_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o), dst_clk_i, !dst_rst_ni, "dst_valid_o is unstable")
   `endif
   `endif
 

--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -98,9 +98,13 @@ module isochronous_spill_register #(
 
   // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ASSERT(src_valid_unstable, src_valid_i && !src_ready_o |=> $stable(src_valid_i), src_clk_i, !src_rst_ni, "src_valid_i is unstable")
-  `ASSERT(src_data_unstable, src_valid_i && !src_ready_o |=> $stable(src_data_i), src_clk_i, !src_rst_ni, "src_data_i is unstable")
-  `ASSERT(dst_valid_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o), dst_clk_i, !dst_rst_ni, "dst_valid_o is unstable")
-  `ASSERT(dst_data_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_data_o), dst_clk_i, !dst_rst_ni, "dst_data_o is unstable")
+  `ASSERT(src_valid_unstable, src_valid_i && !src_ready_o |=> $stable(src_valid_i),
+          src_clk_i, !src_rst_ni, "src_valid_i is unstable")
+  `ASSERT(src_data_unstable, src_valid_i && !src_ready_o |=> $stable(src_data_i),
+          src_clk_i, !src_rst_ni, "src_data_i is unstable")
+  `ASSERT(dst_valid_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o),
+          dst_clk_i, !dst_rst_ni, "dst_valid_o is unstable")
+  `ASSERT(dst_data_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_data_o),
+          dst_clk_i, !dst_rst_ni, "dst_data_o is unstable")
   `endif
 endmodule

--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -96,13 +96,11 @@ module isochronous_spill_register #(
     assign dst_data_o = mem_q[rd_pointer_q[0]];
   end
 
-  `ifndef SYNTHESIS
   // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT(src_valid_unstable, src_valid_i && !src_ready_o |=> $stable(src_valid_i), src_clk_i, !src_rst_ni, "src_valid_i is unstable")
   `ASSERT(src_data_unstable, src_valid_i && !src_ready_o |=> $stable(src_data_i), src_clk_i, !src_rst_ni, "src_data_i is unstable")
   `ASSERT(dst_valid_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o), dst_clk_i, !dst_rst_ni, "dst_valid_o is unstable")
   `ASSERT(dst_data_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_data_o), dst_clk_i, !dst_rst_ni, "dst_data_o is unstable")
-  `endif
   `endif
 endmodule

--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -99,14 +99,10 @@ module isochronous_spill_register #(
   `ifndef SYNTHESIS
   // stability guarantees
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)
-    (src_valid_i && !src_ready_o |=> $stable(src_valid_i))) else $error("src_valid_i is unstable");
-  assert property (@(posedge src_clk_i) disable iff (~src_rst_ni)
-    (src_valid_i && !src_ready_o |=> $stable(src_data_i))) else $error("src_data_i is unstable");
-  assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
-    (dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o))) else $error("dst_valid_o is unstable");
-  assert property (@(posedge dst_clk_i) disable iff (~dst_rst_ni)
-    (dst_valid_o && !dst_ready_i |=> $stable(dst_data_o))) else $error("dst_data_o is unstable");
+  `ASSERT(src_valid_unstable, src_valid_i && !src_ready_o |=> $stable(src_valid_i), src_clk_i, !src_rst_ni, "src_valid_i is unstable")
+  `ASSERT(src_data_unstable, src_valid_i && !src_ready_o |=> $stable(src_data_i), src_clk_i, !src_rst_ni, "src_data_i is unstable")
+  `ASSERT(dst_valid_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_valid_o), dst_clk_i, !dst_rst_ni, "dst_valid_o is unstable")
+  `ASSERT(dst_data_unstable, dst_valid_o && !dst_ready_i |=> $stable(dst_data_o), dst_clk_i, !dst_rst_ni, "dst_data_o is unstable")
   `endif
   `endif
 endmodule

--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -12,6 +12,7 @@
 // Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 
 `include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
 
 /// A register with handshakes that completely cuts any combinatorial paths
 /// between the input and output in isochronous clock domains.

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -293,11 +293,15 @@ end
 ////////////////////////////////////////////////////////////////////////
 `ifndef COMMON_CELLS_ASSERTS_OFF
 // these are the LUT limits
-`ASSERT_INIT(outwidth_gt_lfsrwidth, OutWidth <= LfsrWidth, "OutWidth must be smaller equal the LfsrWidth.")
+`ASSERT_INIT(outwidth_gt_lfsrwidth, OutWidth <= LfsrWidth,
+             "OutWidth must be smaller equal the LfsrWidth.")
 `ASSERT_INIT(rstval_0, RstVal > unsigned'(0), "RstVal must be nonzero.")
-`ASSERT_INIT(lfsrwidth_invalid, (LfsrWidth >= $low(Masks)) && (LfsrWidth <= $high(Masks)), "Unsupported LfsrWidth.")
-`ASSERT_INIT(mask_invalid, Masks[LfsrWidth][LfsrWidth-1], "LFSR mask is not correct. The MSB must be 1.")
-`ASSERT_INIT(cipherlayers_invalid, (CipherLayers > 0) && (LfsrWidth == 64) || (CipherLayers == 0), "Use additional cipher layers only in conjunction with an LFSR width of 64 bit.")
+`ASSERT_INIT(lfsrwidth_invalid, (LfsrWidth >= $low(Masks)) && (LfsrWidth <= $high(Masks)),
+             "Unsupported LfsrWidth.")
+`ASSERT_INIT(mask_invalid, Masks[LfsrWidth][LfsrWidth-1],
+             "LFSR mask is not correct. The MSB must be 1.")
+`ASSERT_INIT(cipherlayers_invalid, (CipherLayers > 0) && (LfsrWidth == 64) || (CipherLayers == 0),
+             "Use additional cipher layers only in conjunction with an LFSR width of 64 bit.")
 
   `ASSERT(all_zero, en_i |-> lfsr_d, clk_i, !rst_ni, "Lfsr must not be all-zero.")
 `endif

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -293,19 +293,12 @@ end
 ////////////////////////////////////////////////////////////////////////
 `ifndef COMMON_CELLS_ASSERTS_OFF
 `ifndef SYNTHESIS
-initial begin
-  // these are the LUT limits
-  assert(OutWidth <= LfsrWidth) else
-    $fatal(1,"OutWidth must be smaller equal the LfsrWidth.");
-  assert(RstVal > unsigned'(0)) else
-    $fatal(1,"RstVal must be nonzero.");
-  assert((LfsrWidth >= $low(Masks)) && (LfsrWidth <= $high(Masks))) else
-    $fatal(1,"Unsupported LfsrWidth.");
-  assert(Masks[LfsrWidth][LfsrWidth-1]) else
-    $fatal(1, "LFSR mask is not correct. The MSB must be 1." );
-  assert((CipherLayers > 0) && (LfsrWidth == 64) || (CipherLayers == 0)) else
-    $fatal(1, "Use additional cipher layers only in conjunction with an LFSR width of 64 bit." );
-end
+// these are the LUT limits
+`ASSERT_INIT(outwidth_gt_lfsrwidth, OutWidth <= LfsrWidth, "OutWidth must be smaller equal the LfsrWidth.")
+`ASSERT_INIT(rstval_0, RstVal > unsigned'(0), "RstVal must be nonzero.")
+`ASSERT_INIT(lfsrwidth_invalid, (LfsrWidth >= $low(Masks)) && (LfsrWidth <= $high(Masks)), "Unsupported LfsrWidth.")
+`ASSERT_INIT(mask_invalid, Masks[LfsrWidth][LfsrWidth-1], "LFSR mask is not correct. The MSB must be 1.")
+`ASSERT_INIT(cipherlayers_invalid, (CipherLayers > 0) && (LfsrWidth == 64) || (CipherLayers == 0), "Use additional cipher layers only in conjunction with an LFSR width of 64 bit.")
 
   `ASSERT(all_zero, en_i |-> lfsr_d, clk_i, !rst_ni, "Lfsr must not be all-zero.")
 `endif

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -292,7 +292,6 @@ end
 // assertions
 ////////////////////////////////////////////////////////////////////////
 `ifndef COMMON_CELLS_ASSERTS_OFF
-`ifndef SYNTHESIS
 // these are the LUT limits
 `ASSERT_INIT(outwidth_gt_lfsrwidth, OutWidth <= LfsrWidth, "OutWidth must be smaller equal the LfsrWidth.")
 `ASSERT_INIT(rstval_0, RstVal > unsigned'(0), "RstVal must be nonzero.")
@@ -301,7 +300,6 @@ end
 `ASSERT_INIT(cipherlayers_invalid, (CipherLayers > 0) && (LfsrWidth == 64) || (CipherLayers == 0), "Use additional cipher layers only in conjunction with an LFSR width of 64 bit.")
 
   `ASSERT(all_zero, en_i |-> lfsr_d, clk_i, !rst_ni, "Lfsr must not be all-zero.")
-`endif
 `endif
 
 endmodule // lfsr

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -19,6 +19,8 @@
 // patterns. The additional cipher layers can only be used for an LFSR width
 // of 64bit, since the block cipher has been designed for that block length.
 
+`include "common_cells/assertions.svh"
+
 module lfsr #(
   parameter int unsigned          LfsrWidth     = 64,   // [4,64]
   parameter int unsigned          OutWidth      = 8,    // [1,LfsrWidth]

--- a/src/lfsr.sv
+++ b/src/lfsr.sv
@@ -307,9 +307,7 @@ initial begin
     $fatal(1, "Use additional cipher layers only in conjunction with an LFSR width of 64 bit." );
 end
 
-  all_zero: assert property (
-    @(posedge clk_i) disable iff (!rst_ni) en_i |-> lfsr_d)
-      else $fatal(1,"Lfsr must not be all-zero.");
+  `ASSERT(all_zero, en_i |-> lfsr_d, clk_i, !rst_ni, "Lfsr must not be all-zero.")
 `endif
 `endif
 

--- a/src/lfsr_16bit.sv
+++ b/src/lfsr_16bit.sv
@@ -61,7 +61,8 @@ module lfsr_16bit #(
     end
 
   `ifndef COMMON_CELLS_ASSERTS_OFF
-    `ASSERT_INIT(width_gt_16, WIDTH <= 16, "WIDTH needs to be less than 16 because of the 16-bit LFSR")
+    `ASSERT_INIT(width_gt_16, WIDTH <= 16,
+                 "WIDTH needs to be less than 16 because of the 16-bit LFSR")
   `endif
 
 endmodule

--- a/src/lfsr_16bit.sv
+++ b/src/lfsr_16bit.sv
@@ -12,6 +12,8 @@
 // Date: 5.11.2018
 // Description: 16-bit LFSR
 
+`include "common_cells/assertions.svh"
+
 // --------------
 // 16-bit LFSR
 // --------------

--- a/src/lfsr_16bit.sv
+++ b/src/lfsr_16bit.sv
@@ -62,10 +62,7 @@ module lfsr_16bit #(
 
   `ifndef COMMON_CELLS_ASSERTS_OFF
     `ifndef SYNTHESIS
-    initial begin
-        assert (WIDTH <= 16)
-            else $fatal(1, "WIDTH needs to be less than 16 because of the 16-bit LFSR");
-    end
+    `ASSERT_INIT(width_gt_16, WIDTH <= 16, "WIDTH needs to be less than 16 because of the 16-bit LFSR")
     `endif
   `endif
 

--- a/src/lfsr_16bit.sv
+++ b/src/lfsr_16bit.sv
@@ -61,9 +61,7 @@ module lfsr_16bit #(
     end
 
   `ifndef COMMON_CELLS_ASSERTS_OFF
-    `ifndef SYNTHESIS
     `ASSERT_INIT(width_gt_16, WIDTH <= 16, "WIDTH needs to be less than 16 because of the 16-bit LFSR")
-    `endif
   `endif
 
 endmodule

--- a/src/lfsr_8bit.sv
+++ b/src/lfsr_8bit.sv
@@ -56,9 +56,7 @@ module lfsr_8bit #(
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef SYNTHESIS
-  initial begin
-    assert (WIDTH <= 8) else $fatal(1, "WIDTH needs to be less than 8 because of the 8-bit LFSR");
-  end
+  `ASSERT_INIT(width_gt_8, WIDTH <= 8, "WIDTH needs to be less than 8 because of the 8-bit LFSR")
   `endif
 `endif
 

--- a/src/lfsr_8bit.sv
+++ b/src/lfsr_8bit.sv
@@ -13,6 +13,8 @@
 // Date: 12.11.2017
 // Description: 8-bit LFSR
 
+`include "common_cells/assertions.svh"
+
 /// 8 bit Linear Feedback Shift register
 module lfsr_8bit #(
   parameter logic        [7:0] SEED  = 8'b0,

--- a/src/lfsr_8bit.sv
+++ b/src/lfsr_8bit.sv
@@ -55,9 +55,7 @@ module lfsr_8bit #(
   end
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ifndef SYNTHESIS
   `ASSERT_INIT(width_gt_8, WIDTH <= 8, "WIDTH needs to be less than 8 because of the 8-bit LFSR")
-  `endif
 `endif
 
 endmodule

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -43,9 +43,7 @@ module lzc #(
 
   `ifndef COMMON_CELLS_ASSERTS_OFF
     `ifndef SYNTHESIS
-    initial begin
-      assert(WIDTH > 0) else $fatal(1, "input must be at least one bit wide");
-    end
+    `ASSERT_INIT(width_0, WIDTH > 0, "input must be at least one bit wide")
     `endif
   `endif
 
@@ -105,10 +103,7 @@ module lzc #(
 
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  initial begin: validate_params
-    assert (WIDTH >= 1)
-      else $fatal(1, "The WIDTH must at least be one bit wide!");
-  end
+  `ASSERT_INIT(width_0, WIDTH >= 1, "The WIDTH must at least be one bit wide!")
 `endif
 `endif
 

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -2,6 +2,8 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 
+`include "common_cells/assertions.svh"
+
 /// A trailing zero counter / leading zero counter.
 /// Set MODE to 0 for trailing zero counter => cnt_o is the number of trailing zeros (from the LSB)
 /// Set MODE to 1 for leading zero counter  => cnt_o is the number of leading zeros  (from the MSB)

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -42,9 +42,7 @@ module lzc #(
     localparam int unsigned NumLevels = $clog2(WIDTH);
 
   `ifndef COMMON_CELLS_ASSERTS_OFF
-    `ifndef SYNTHESIS
     `ASSERT_INIT(width_0, WIDTH > 0, "input must be at least one bit wide")
-    `endif
   `endif
 
     logic [WIDTH-1:0][NumLevels-1:0] index_lut;
@@ -101,10 +99,8 @@ module lzc #(
 
   end : gen_lzc
 
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT_INIT(width_0, WIDTH >= 1, "The WIDTH must at least be one bit wide!")
-`endif
 `endif
 
 endmodule : lzc

--- a/src/mem_to_banks_detailed.sv
+++ b/src/mem_to_banks_detailed.sv
@@ -10,6 +10,8 @@
 //
 // Author: Wolfgang Roenninger <wroennin@ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 /// Split memory access over multiple parallel banks, where each bank has its own req/gnt
 /// request and valid response direction.
 module mem_to_banks_detailed #(

--- a/src/mem_to_banks_detailed.sv
+++ b/src/mem_to_banks_detailed.sv
@@ -220,9 +220,7 @@ module mem_to_banks_detailed #(
   assign rvalid_o = &(resp_valid | dead_response);
 
   // Assertions
-  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ifndef SYNTHESIS
     initial begin
       `ASSUME_I(datawidth_not_power_of_2, DataWidth != 0 && (DataWidth & (DataWidth - 1)) == 0,
                "Data width must be a power of two!")
@@ -231,7 +229,5 @@ module mem_to_banks_detailed #(
       `ASSUME_I(bank_datawidth_not_divisible_by_8, (DataWidth / NumBanks) % 8 == 0,
                "Data width of each bank must be divisible into 8-bit bytes!")
     end
-  `endif
-  `endif
   `endif
 endmodule

--- a/src/mem_to_banks_detailed.sv
+++ b/src/mem_to_banks_detailed.sv
@@ -224,12 +224,12 @@ module mem_to_banks_detailed #(
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef SYNTHESIS
     initial begin
-      assume (DataWidth != 0 && (DataWidth & (DataWidth - 1)) == 0)
-        else $fatal(1, "Data width must be a power of two!");
-      assume (DataWidth % NumBanks == 0)
-        else $fatal(1, "Data width must be evenly divisible over banks!");
-      assume ((DataWidth / NumBanks) % 8 == 0)
-        else $fatal(1, "Data width of each bank must be divisible into 8-bit bytes!");
+      `ASSUME_I(datawidth_not_power_of_2, DataWidth != 0 && (DataWidth & (DataWidth - 1)) == 0,
+               "Data width must be a power of two!")
+      `ASSUME_I(datawidth_not_divisible_by_banks, DataWidth % NumBanks == 0,
+               "Data width must be evenly divisible over banks!")
+      `ASSUME_I(bank_datawidth_not_divisible_by_8, (DataWidth / NumBanks) % 8 == 0,
+               "Data width of each bank must be divisible into 8-bit bytes!")
     end
   `endif
   `endif

--- a/src/mem_to_banks_detailed.sv
+++ b/src/mem_to_banks_detailed.sv
@@ -222,7 +222,7 @@ module mem_to_banks_detailed #(
   // Assertions
   `ifndef COMMON_CELLS_ASSERTS_OFF
     initial begin
-      `ASSUME_I(datawidth_not_power_of_2, DataWidth != 0 && (DataWidth & (DataWidth - 1)) == 0,
+      `ASSUME_I(datawidth_not_power_of_2, DataWidth != 0 && 2**$clog2(DataWidth) == DataWidth,
                "Data width must be a power of two!")
       `ASSUME_I(datawidth_not_divisible_by_banks, DataWidth % NumBanks == 0,
                "Data width must be evenly divisible over banks!")

--- a/src/multiaddr_decode.sv
+++ b/src/multiaddr_decode.sv
@@ -10,6 +10,8 @@
 
 // Author: Luca Colagrande <colluca@ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 /// Multi-address Decoder: Combinational module which takes an address set
 /// in {addr, mask} representation and returns a bit mask `select_o` indicating which
 /// address map rules in `addr_map_i` it matches.

--- a/src/multiaddr_decode.sv
+++ b/src/multiaddr_decode.sv
@@ -126,11 +126,10 @@ module multiaddr_decode #(
   `ifndef XSIM
   `ifndef SYNTHESIS
   initial begin : proc_check_parameters
-    assume (NoRules > 0) else
-      $fatal(1, $sformatf("At least one rule needed"));
-    assume ($bits(addr_i) == $bits(addr_map_i[0].addr)) else
-      $warning($sformatf("Input address has %d bits and address map has %d bits.",
-        $bits(addr_i), $bits(addr_map_i[0].addr)));
+    `ASSUME_I(norules_0, NoRules > 0, $sformatf("At least one rule needed"))
+    `ASSUME_I(addr_width_not_equal, $bits(addr_i) == $bits(addr_map_i[0].addr),
+             $sformatf("Input address has %d bits and address map has %d bits.",
+                       $bits(addr_i), $bits(addr_map_i[0].addr)))
   end
 
   // These following assumptions check the validity of the address map.
@@ -139,13 +138,13 @@ module multiaddr_decode #(
     if (!$isunknown(addr_map_i)) begin
       for (int unsigned i = 0; i < NoRules; i++) begin
         // check the SLV ids
-        check_idx : assume (addr_map_i[i].idx < NoIndices) else
-            $fatal(1, $sformatf("This rule has a IDX that is not allowed!!!\n\
+        `ASSUME_I(check_idx, addr_map_i[i].idx < NoIndices,
+            $sformatf("This rule has a IDX that is not allowed!!!\n\
             Violating rule %d.\n\
             Rule> IDX: %h\n\
             Rule> MAX_IDX: %h\n\
             #####################################################",
-            i, addr_map_i[i].idx, (NoIndices-1)));
+            i, addr_map_i[i].idx, (NoIndices-1)))
       end
     end
   end

--- a/src/multiaddr_decode.sv
+++ b/src/multiaddr_decode.sv
@@ -123,8 +123,6 @@ module multiaddr_decode #(
 
   // Assumptions and assertions
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ifndef XSIM
-  `ifndef SYNTHESIS
   initial begin : proc_check_parameters
     `ASSUME_I(norules_0, NoRules > 0, $sformatf("At least one rule needed"))
     `ASSUME_I(addr_width_not_equal, $bits(addr_i) == $bits(addr_map_i[0].addr),
@@ -149,7 +147,5 @@ module multiaddr_decode #(
     end
   end
 
-  `endif
-  `endif
   `endif
 endmodule

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -32,6 +32,6 @@ module onehot_to_bin #(
     end
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
-    `ASSERT_FINAL(more_than_2_bits, $onehot0(onehot), "[onehot_to_bin] More than two bit set in the one-hot signal")
+    `ASSERT_FINAL(more_than_2_bits, $onehot0(onehot), "More than two bit set in the one-hot signal")
 `endif
 endmodule

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -33,8 +33,7 @@ module onehot_to_bin #(
 
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-    assert final ($onehot0(onehot)) else
-        $fatal(1, "[onehot_to_bin] More than two bit set in the one-hot signal");
+    `ASSERT_FINAL(more_than_2_bits, $onehot0(onehot), "[onehot_to_bin] More than two bit set in the one-hot signal")
 `endif
 `endif
 endmodule

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -10,6 +10,8 @@
 
 // Franceco Conti <fconti@iis.ee.ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 module onehot_to_bin #(
     parameter int unsigned ONEHOT_WIDTH = 16,
     // Do Not Change

--- a/src/onehot_to_bin.sv
+++ b/src/onehot_to_bin.sv
@@ -31,9 +31,7 @@ module onehot_to_bin #(
         assign bin[j] = |(tmp_mask & onehot);
     end
 
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     `ASSERT_FINAL(more_than_2_bits, $onehot0(onehot), "[onehot_to_bin] More than two bit set in the one-hot signal")
-`endif
 `endif
 endmodule

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -120,12 +120,10 @@ module plru_tree #(
         end
     end
 
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     `ASSERT_INIT(entries_not_power_of_2, ENTRIES == 2**LogEntries, "Entries must be a power of two")
 
     `ASSERT(output_onehot, $onehot0(plru_o), clk_i, !rst_ni, "More than one bit set in PLRU output.")
-`endif
 `endif
 
 endmodule

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -123,7 +123,8 @@ module plru_tree #(
 `ifndef COMMON_CELLS_ASSERTS_OFF
     `ASSERT_INIT(entries_not_power_of_2, ENTRIES == 2**LogEntries, "Entries must be a power of two")
 
-    `ASSERT(output_onehot, $onehot0(plru_o), clk_i, !rst_ni, "More than one bit set in PLRU output.")
+    `ASSERT(output_onehot, $onehot0(plru_o), clk_i, !rst_ni,
+            "More than one bit set in PLRU output.")
 `endif
 
 endmodule

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -122,9 +122,7 @@ module plru_tree #(
 
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-    initial begin
-        assert (ENTRIES == 2**LogEntries) else $error("Entries must be a power of two");
-    end
+    `ASSERT_INIT(entries_not_power_of_2, ENTRIES == 2**LogEntries, "Entries must be a power of two")
 
     `ASSERT(output_onehot, $onehot0(plru_o), clk_i, !rst_ni, "More than one bit set in PLRU output.")
 `endif

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -126,9 +126,7 @@ module plru_tree #(
         assert (ENTRIES == 2**LogEntries) else $error("Entries must be a power of two");
     end
 
-    output_onehot : assert property(
-        @(posedge clk_i) disable iff (~rst_ni) ($onehot0(plru_o)))
-        else $fatal (1, "More than one bit set in PLRU output.");
+    `ASSERT(output_onehot, $onehot0(plru_o), clk_i, !rst_ni, "More than one bit set in PLRU output.")
 `endif
 `endif
 

--- a/src/plru_tree.sv
+++ b/src/plru_tree.sv
@@ -14,6 +14,8 @@
 // Description: Pseudo Least Recently Used Tree (PLRU)
 // See: https://en.wikipedia.org/wiki/Pseudo-LRU
 
+`include "common_cells/assertions.svh"
+
 module plru_tree #(
   parameter int unsigned ENTRIES = 16
 ) (

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -13,6 +13,8 @@
 // Date: 02.04.2019
 // Description: logarithmic arbitration tree with round robin arbitration scheme.
 
+`include "common_cells/assertions.svh"
+
 /// The rr_arb_tree employs non-starving round robin-arbitration - i.e., the priorities
 /// rotate each cycle.
 ///

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -162,13 +162,14 @@ module rr_arb_tree #(
         end
 
         `ifndef COMMON_CELLS_ASSERTS_OFF
-          `ASSERT(lock, LockIn |-> req_o && (!gnt_i && !flush_i) |=> idx_o == $past(idx_o), clk_i, !rst_ni || flush_i, "Lock implies same arbiter decision in next cycle if output is not \
-                            ready.")
+          `ASSERT(lock, LockIn |-> req_o && (!gnt_i && !flush_i) |=> idx_o == $past(idx_o),
+                  clk_i, !rst_ni || flush_i,
+                  "Lock implies same arbiter decision in next cycle if output is not ready.")
 
           logic [NumIn-1:0] req_tmp;
           assign req_tmp = req_q & req_i;
-          `ASSUME(lock_req, LockIn |-> lock_d |=> req_tmp == req_q, clk_i, !rst_ni || flush_i, "It is disallowed to deassert unserved request signals when LockIn is \
-                            enabled.")
+          `ASSUME(lock_req, LockIn |-> lock_d |=> req_tmp == req_q, clk_i, !rst_ni || flush_i,
+                  "It is disallowed to deassert unserved request signals when LockIn is enabled.")
         `endif
 
         always_ff @(posedge clk_i or negedge rst_ni) begin : p_req_regs
@@ -295,15 +296,19 @@ module rr_arb_tree #(
 
     `ifndef COMMON_CELLS_ASSERTS_OFF
     `ASSERT_INIT(numin_0, NumIn, "Input must be at least one element wide.")
-    `ASSERT_INIT(lockin_and_extprio, !(LockIn && ExtPrio), "Cannot use LockIn feature together with external ExtPrio.")
+    `ASSERT_INIT(lockin_and_extprio, !(LockIn && ExtPrio),
+                 "Cannot use LockIn feature together with external ExtPrio.")
 
-    `ASSERT(hot_one, $onehot0(gnt_o), clk_i, !rst_ni || flush_i, "Grant signal must be hot1 or zero.")
+    `ASSERT(hot_one, $onehot0(gnt_o), clk_i, !rst_ni || flush_i,
+            "Grant signal must be hot1 or zero.")
 
     `ASSERT(gnt0, |gnt_o |-> gnt_i, clk_i, !rst_ni || flush_i, "Grant out implies grant in.")
 
-    `ASSERT(gnt1, req_o |-> gnt_i |-> |gnt_o, clk_i, !rst_ni || flush_i, "Req out and grant in implies grant out.")
+    `ASSERT(gnt1, req_o |-> gnt_i |-> |gnt_o, clk_i, !rst_ni || flush_i,
+            "Req out and grant in implies grant out.")
 
-    `ASSERT(gnt_idx, req_o |->  gnt_i |-> gnt_o[idx_o], clk_i, !rst_ni || flush_i, "Idx_o / gnt_o do not match.")
+    `ASSERT(gnt_idx, req_o |->  gnt_i |-> gnt_o[idx_o], clk_i, !rst_ni || flush_i,
+            "Idx_o / gnt_o do not match.")
 
     `ASSERT(req0, |req_i |-> req_o, clk_i, !rst_ni || flush_i, "Req in implies req out.")
 

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -111,17 +111,6 @@ module rr_arb_tree #(
   output idx_t                idx_o
 );
 
-  `ifndef SYNTHESIS
-  `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ifndef VERILATOR
-  `ifndef XSIM
-  // Default SVA reset
-  default disable iff (!rst_ni || flush_i);
-  `endif
-  `endif
-  `endif
-  `endif
-
   // just pass through in this corner case
   if (NumIn == unsigned'(1)) begin : gen_pass_through
     assign req_o    = req_i[0];

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -174,11 +174,8 @@ module rr_arb_tree #(
 
         `ifndef SYNTHESIS
         `ifndef COMMON_CELLS_ASSERTS_OFF
-          lock: assert property(
-            @(posedge clk_i) disable iff (!rst_ni || flush_i)
-                LockIn |-> req_o && (!gnt_i && !flush_i) |=> idx_o == $past(idx_o)) else
-                $fatal (1, "Lock implies same arbiter decision in next cycle if output is not \
-                            ready.");
+          `ASSERT(lock, LockIn |-> req_o && (!gnt_i && !flush_i) |=> idx_o == $past(idx_o), clk_i, !rst_ni || flush_i, "Lock implies same arbiter decision in next cycle if output is not \
+                            ready.")
 
           logic [NumIn-1:0] req_tmp;
           assign req_tmp = req_q & req_i;
@@ -322,29 +319,17 @@ module rr_arb_tree #(
         else $fatal(1,"Cannot use LockIn feature together with external ExtPrio.");
     end
 
-    hot_one : assert property(
-      @(posedge clk_i) disable iff (!rst_ni || flush_i) $onehot0(gnt_o))
-        else $fatal (1, "Grant signal must be hot1 or zero.");
+    `ASSERT(hot_one, $onehot0(gnt_o), clk_i, !rst_ni || flush_i, "Grant signal must be hot1 or zero.")
 
-    gnt0 : assert property(
-      @(posedge clk_i) disable iff (!rst_ni || flush_i) |gnt_o |-> gnt_i)
-        else $fatal (1, "Grant out implies grant in.");
+    `ASSERT(gnt0, |gnt_o |-> gnt_i, clk_i, !rst_ni || flush_i, "Grant out implies grant in.")
 
-    gnt1 : assert property(
-      @(posedge clk_i) disable iff (!rst_ni || flush_i) req_o |-> gnt_i |-> |gnt_o)
-        else $fatal (1, "Req out and grant in implies grant out.");
+    `ASSERT(gnt1, req_o |-> gnt_i |-> |gnt_o, clk_i, !rst_ni || flush_i, "Req out and grant in implies grant out.")
 
-    gnt_idx : assert property(
-      @(posedge clk_i) disable iff (!rst_ni || flush_i) req_o |->  gnt_i |-> gnt_o[idx_o])
-        else $fatal (1, "Idx_o / gnt_o do not match.");
+    `ASSERT(gnt_idx, req_o |->  gnt_i |-> gnt_o[idx_o], clk_i, !rst_ni || flush_i, "Idx_o / gnt_o do not match.")
 
-    req0 : assert property(
-      @(posedge clk_i) disable iff (!rst_ni || flush_i) |req_i |-> req_o)
-        else $fatal (1, "Req in implies req out.");
+    `ASSERT(req0, |req_i |-> req_o, clk_i, !rst_ni || flush_i, "Req in implies req out.")
 
-    req1 : assert property(
-      @(posedge clk_i) disable iff (!rst_ni || flush_i) req_o |-> |req_i)
-        else $fatal (1, "Req out implies req in.");
+    `ASSERT(req1, req_o |-> |req_i, clk_i, !rst_ni || flush_i, "Req out implies req in.")
     `endif
     `endif
     `endif

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -172,7 +172,6 @@ module rr_arb_tree #(
           end
         end
 
-        `ifndef SYNTHESIS
         `ifndef COMMON_CELLS_ASSERTS_OFF
           `ASSERT(lock, LockIn |-> req_o && (!gnt_i && !flush_i) |=> idx_o == $past(idx_o), clk_i, !rst_ni || flush_i, "Lock implies same arbiter decision in next cycle if output is not \
                             ready.")
@@ -181,7 +180,6 @@ module rr_arb_tree #(
           assign req_tmp = req_q & req_i;
           `ASSUME(lock_req, LockIn |-> lock_d |=> req_tmp == req_q, clk_i, !rst_ni || flush_i, "It is disallowed to deassert unserved request signals when LockIn is \
                             enabled.")
-        `endif
         `endif
 
         always_ff @(posedge clk_i or negedge rst_ni) begin : p_req_regs
@@ -306,9 +304,7 @@ module rr_arb_tree #(
       end
     end
 
-    `ifndef SYNTHESIS
     `ifndef COMMON_CELLS_ASSERTS_OFF
-    `ifndef XSIM
     `ASSERT_INIT(numin_0, NumIn, "Input must be at least one element wide.")
     `ASSERT_INIT(lockin_and_extprio, !(LockIn && ExtPrio), "Cannot use LockIn feature together with external ExtPrio.")
 
@@ -323,8 +319,6 @@ module rr_arb_tree #(
     `ASSERT(req0, |req_i |-> req_o, clk_i, !rst_ni || flush_i, "Req in implies req out.")
 
     `ASSERT(req1, req_o |-> |req_i, clk_i, !rst_ni || flush_i, "Req out implies req in.")
-    `endif
-    `endif
     `endif
   end
 

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -179,11 +179,8 @@ module rr_arb_tree #(
 
           logic [NumIn-1:0] req_tmp;
           assign req_tmp = req_q & req_i;
-          lock_req: assume property(
-            @(posedge clk_i) disable iff (!rst_ni || flush_i)
-                LockIn |-> lock_d |=> req_tmp == req_q) else
-                $fatal (1, "It is disallowed to deassert unserved request signals when LockIn is \
-                            enabled.");
+          `ASSUME(lock_req, LockIn |-> lock_d |=> req_tmp == req_q, clk_i, !rst_ni || flush_i, "It is disallowed to deassert unserved request signals when LockIn is \
+                            enabled.")
         `endif
         `endif
 

--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -309,12 +309,8 @@ module rr_arb_tree #(
     `ifndef SYNTHESIS
     `ifndef COMMON_CELLS_ASSERTS_OFF
     `ifndef XSIM
-    initial begin : p_assert
-      assert(NumIn)
-        else $fatal(1, "Input must be at least one element wide.");
-      assert(!(LockIn && ExtPrio))
-        else $fatal(1,"Cannot use LockIn feature together with external ExtPrio.");
-    end
+    `ASSERT_INIT(numin_0, NumIn, "Input must be at least one element wide.")
+    `ASSERT_INIT(lockin_and_extprio, !(LockIn && ExtPrio), "Cannot use LockIn feature together with external ExtPrio.")
 
     `ASSERT(hot_one, $onehot0(gnt_o), clk_i, !rst_ni || flush_i, "Grant signal must be hot1 or zero.")
 

--- a/src/spill_register_flushable.sv
+++ b/src/spill_register_flushable.sv
@@ -11,6 +11,7 @@
 //
 // Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 
+`include "common_cells/assertions.svh"
 
 /// A register with handshakes that completely cuts any combinational paths
 /// between the input and output. This spill register can be flushed.

--- a/src/spill_register_flushable.sv
+++ b/src/spill_register_flushable.sv
@@ -95,12 +95,9 @@ module spill_register_flushable #(
     // We empty the spill register before the slice register.
     assign data_o = b_full_q ? b_data_q : a_data_q;
 
-    `ifndef SYNTHESIS
     `ifndef COMMON_CELLS_ASSERTS_OFF
-    flush_valid : assert property (
-      @(posedge clk_i) disable iff (~rst_ni) (flush_i |-> ~valid_i)) else
-      $warning("Trying to flush and feed the spill register simultaneously. You will lose data!");
+    `ASSERT(flush_valid, flush_i |-> ~valid_i, clk_i, !rst_ni,
+           "Trying to flush and feed the spill register simultaneously. You will lose data!")
    `endif
-     `endif
   end
 endmodule

--- a/src/stream_fork.sv
+++ b/src/stream_fork.sv
@@ -126,9 +126,7 @@ module stream_fork #(
 
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-    initial begin: p_assertions
-        assert (N_OUP >= 1) else $fatal(1, "Number of outputs must be at least 1!");
-    end
+    `ASSERT_INIT(n_oup_0, N_OUP >= 1, "Number of outputs must be at least 1!")
 `endif
 `endif
 

--- a/src/stream_fork.sv
+++ b/src/stream_fork.sv
@@ -124,10 +124,8 @@ module stream_fork #(
     assign all_ones = '1;   // Synthesis fix for Vivado, which does not correctly compute the width
                             // of the '1 literal when assigned to a port of parametrized width.
 
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
     `ASSERT_INIT(n_oup_0, N_OUP >= 1, "Number of outputs must be at least 1!")
-`endif
 `endif
 
 endmodule

--- a/src/stream_fork.sv
+++ b/src/stream_fork.sv
@@ -16,6 +16,8 @@
 // This module has no data ports because stream data does not need to be forked: the data of the
 // input stream can just be applied at all output streams.
 
+`include "common_cells/assertions.svh"
+
 module stream_fork #(
     parameter int unsigned N_OUP = 0    // Synopsys DC requires a default value for parameters.
 ) (

--- a/src/stream_fork_dynamic.sv
+++ b/src/stream_fork_dynamic.sv
@@ -11,6 +11,8 @@
 // Authors:
 // - Andreas Kurth <akurth@iis.ee.ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 /// Dynamic stream fork: Connects the input stream (ready-valid) handshake to a combination of output
 /// stream handshake.  The combination is determined dynamically through another stream, which
 /// provides a bitmask for the fork.  For each input stream handshake, every output stream handshakes

--- a/src/stream_fork_dynamic.sv
+++ b/src/stream_fork_dynamic.sv
@@ -89,9 +89,7 @@ module stream_fork_dynamic #(
 
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  initial begin: p_assertions
-    assert (N_OUP >= 1) else $fatal(1, "N_OUP must be at least 1!");
-  end
+  `ASSERT_INIT(n_oup_0, N_OUP >= 1, "N_OUP must be at least 1!")
 `endif
 `endif
 endmodule

--- a/src/stream_fork_dynamic.sv
+++ b/src/stream_fork_dynamic.sv
@@ -87,9 +87,7 @@ module stream_fork_dynamic #(
     .ready_i ( int_oup_ready )
   );
 
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT_INIT(n_oup_0, N_OUP >= 1, "N_OUP must be at least 1!")
-`endif
 `endif
 endmodule

--- a/src/stream_intf.sv
+++ b/src/stream_intf.sv
@@ -42,8 +42,8 @@ interface STREAM_DV #(
   // Make sure that the handshake and payload is stable
   `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  assert property (@(posedge clk_i) (valid && !ready |=> $stable(data)));
-  assert property (@(posedge clk_i) (valid && !ready |=> valid));
+  `ASSERT(data_unstable, (valid && !ready |=> $stable(data)), clk_i, !rst_ni)
+  `ASSERT(valid_unstable, (valid && !ready |=> valid), clk_i, !rst_ni)
   `endif
   `endif
 endinterface

--- a/src/stream_intf.sv
+++ b/src/stream_intf.sv
@@ -11,6 +11,8 @@
 
 // Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 /// A stream interface with custom payload of type `payload_t`.
 /// Handshaking rules as defined in the AXI standard.
 interface STREAM_DV #(

--- a/src/stream_intf.sv
+++ b/src/stream_intf.sv
@@ -40,10 +40,8 @@ interface STREAM_DV #(
   );
 
   // Make sure that the handshake and payload is stable
-  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT(data_unstable, (valid && !ready |=> $stable(data)), clk_i, !rst_ni)
   `ASSERT(valid_unstable, (valid && !ready |=> valid), clk_i, !rst_ni)
-  `endif
   `endif
 endinterface

--- a/src/stream_intf.sv
+++ b/src/stream_intf.sv
@@ -41,7 +41,7 @@ interface STREAM_DV #(
 
   // Make sure that the handshake and payload is stable
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ASSERT(data_unstable, (valid && !ready |=> $stable(data)), clk_i, !rst_ni)
-  `ASSERT(valid_unstable, (valid && !ready |=> valid), clk_i, !rst_ni)
+  `ASSERT(data_unstable, (valid && !ready |=> $stable(data)), clk_i, 1'b0)
+  `ASSERT(valid_unstable, (valid && !ready |=> valid), clk_i, 1'b0)
   `endif
 endinterface

--- a/src/stream_join_dynamic.sv
+++ b/src/stream_join_dynamic.sv
@@ -39,9 +39,7 @@ module stream_join_dynamic #(
     assign inp_ready_o[i] = oup_valid_o & oup_ready_i;
   end
 
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT_INIT(n_inp_0, N_INP >= 1, "N_INP must be at least 1!")
-`endif
 `endif
 endmodule

--- a/src/stream_join_dynamic.sv
+++ b/src/stream_join_dynamic.sv
@@ -11,6 +11,8 @@
 // Authors:
 // - Luca Colagrande <colluca@iis.ee.ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 // Stream join dynamic: Joins a parametrizable number of input streams (i.e. valid-ready
 // handshaking with dependency rules as in AXI4) to a single output stream. The subset of streams
 // to join can be configured dynamically via `sel_i`. The output handshake happens only after

--- a/src/stream_join_dynamic.sv
+++ b/src/stream_join_dynamic.sv
@@ -41,9 +41,7 @@ module stream_join_dynamic #(
 
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  initial begin: p_assertions
-    assert (N_INP >= 1) else $fatal(1, "N_INP must be at least 1!");
-  end
+  `ASSERT_INIT(n_inp_0, N_INP >= 1, "N_INP must be at least 1!")
 `endif
 `endif
 endmodule

--- a/src/stream_mux.sv
+++ b/src/stream_mux.sv
@@ -37,10 +37,8 @@ module stream_mux #(
   assign oup_data_o   = inp_data_i[inp_sel_i];
   assign oup_valid_o  = inp_valid_i[inp_sel_i];
 
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT_INIT(n_inp_0, N_INP >= 1, "The number of inputs must be at least 1!")
-`endif
 `endif
 
 endmodule

--- a/src/stream_mux.sv
+++ b/src/stream_mux.sv
@@ -8,6 +8,8 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 
+`include "common_cells/assertions.svh"
+
 /// Stream multiplexer: connects the output to one of `N_INP` data streams with valid-ready
 /// handshaking.
 

--- a/src/stream_mux.sv
+++ b/src/stream_mux.sv
@@ -39,9 +39,7 @@ module stream_mux #(
 
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
-  initial begin: p_assertions
-    assert (N_INP >= 1) else $fatal (1, "The number of inputs must be at least 1!");
-  end
+  `ASSERT_INIT(n_inp_0, N_INP >= 1, "The number of inputs must be at least 1!")
 `endif
 `endif
 

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -288,14 +288,9 @@ module stream_omega_net #(
       end
     end
 
-    initial begin : proc_parameter_assertions
-      assert ((2**$clog2(Radix) == Radix) && (Radix > 32'd1)) else
-          $fatal(1, "Radix %0d is not power of two.", Radix);
-      assert (2**$clog2(NumRouters) == NumRouters) else
-          $fatal(1, "NumRouters %0d is not power of two.", NumRouters);
-      assert ($clog2(NumLanes) % SelW == 0) else
-          $fatal(1, "Bit slicing of the internal selection signal is broken.");
-    end
+    `ASSERT_INIT(radix_not_power_of_2, (2**$clog2(Radix) == Radix) && (Radix > 32'd1), "Radix is not power of two.")
+    `ASSERT_INIT(num_routers_not_power_of_2, 2**$clog2(NumRouters) == NumRouters, "NumRouters is not power of two.")
+    `ASSERT_INIT(bit_sclicing_broken, $clog2(NumLanes) % SelW == 0, "Bit slicing of the internal selection signal is broken.")
     `endif
     `endif
   end

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -299,7 +299,7 @@ module stream_omega_net #(
                  "Radix is not power of two.")
     `ASSERT_INIT(num_routers_not_power_of_2, 2**$clog2(NumRouters) == NumRouters,
                  "NumRouters is not power of two.")
-    `ASSERT_INIT(bit_sclicing_broken, $clog2(NumLanes) % SelW == 0,
+    `ASSERT_INIT(bit_slicing_broken, $clog2(NumLanes) % SelW == 0,
                  "Bit slicing of the internal selection signal is broken.")
     `endif
   end

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -272,33 +272,19 @@ module stream_omega_net #(
     default disable iff (~rst_ni);
     `endif
     for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
-      assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_i[i] |-> sel_i[i] < NumOut)) else
-          $fatal(1, "Non-existing output is selected!");
+      `ASSERT(non_existing_output, valid_i[i] |-> sel_i[i] < NumOut, clk_i, !rst_ni, "Non-existing output is selected!")
     end
 
     if (AxiVldRdy) begin : gen_handshake_assertions
       for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_inp_assertions
-        assert property (@(posedge clk_i) disable iff (~rst_ni)
-            (valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask))) else
-            $error("data_i is unstable at input: %0d", i);
-        assert property (@(posedge clk_i) disable iff (~rst_ni)
-            (valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]))) else
-            $error("sel_i is unstable at input: %0d", i);
-        assert property (@(posedge clk_i) disable iff (~rst_ni)
-            (valid_i[i] && !ready_o[i] |=> valid_i[i])) else
-            $error("valid_i at input %0d has been taken away without a ready.", i);
+        `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask), clk_i, !rst_ni, "data_i is unstable at input: %0d", i)
+        `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]), clk_i, !rst_ni, "sel_i is unstable at input: %0d", i)
+        `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni, "valid_i at input %0d has been taken away without a ready.", i)
       end
       for (genvar i = 0; unsigned'(i) < NumOut; i++) begin : gen_out_assertions
-        assert property (@(posedge clk_i) disable iff (~rst_ni)
-            (valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask))) else
-            $error("data_o is unstable at output: %0d Check that parameter LockIn is set.", i);
-        assert property (@(posedge clk_i) disable iff (~rst_ni)
-            (valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]))) else
-            $error("idx_o is unstable at output: %0d Check that parameter LockIn is set.", i);
-        assert property (@(posedge clk_i) disable iff (~rst_ni)
-            (valid_o[i] && !ready_i[i] |=> valid_o[i])) else
-            $error("valid_o at output %0d has been taken away without a ready.", i);
+        `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask), clk_i, !rst_ni, "data_o is unstable at output: %0d Check that parameter LockIn is set.", i)
+        `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]), clk_i, !rst_ni, "idx_o is unstable at output: %0d Check that parameter LockIn is set.", i)
+        `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni, "valid_o at output %0d has been taken away without a ready.", i)
       end
     end
 

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -266,7 +266,6 @@ module stream_omega_net #(
 
     // Assertions
     // Make sure that the handshake and payload is stable
-    `ifndef SYNTHESIS
     `ifndef COMMON_CELLS_ASSERTS_OFF
     `ifndef VERILATOR
     default disable iff (~rst_ni);
@@ -291,7 +290,6 @@ module stream_omega_net #(
     `ASSERT_INIT(radix_not_power_of_2, (2**$clog2(Radix) == Radix) && (Radix > 32'd1), "Radix is not power of two.")
     `ASSERT_INIT(num_routers_not_power_of_2, 2**$clog2(NumRouters) == NumRouters, "NumRouters is not power of two.")
     `ASSERT_INIT(bit_sclicing_broken, $clog2(NumLanes) % SelW == 0, "Bit slicing of the internal selection signal is broken.")
-    `endif
     `endif
   end
 endmodule

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -273,14 +273,14 @@ module stream_omega_net #(
 
     if (AxiVldRdy) begin : gen_handshake_assertions
       for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_inp_assertions
-        `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask), clk_i, !rst_ni, "data_i is unstable at input: %0d", i)
-        `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]), clk_i, !rst_ni, "sel_i is unstable at input: %0d", i)
-        `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni, "valid_i at input %0d has been taken away without a ready.", i)
+        `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask), clk_i, !rst_ni, $sformatf("data_i is unstable at input: %0d", i))
+        `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]), clk_i, !rst_ni, $sformatf("sel_i is unstable at input: %0d", i))
+        `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni, $sformatf("valid_i at input %0d has been taken away without a ready.", i))
       end
       for (genvar i = 0; unsigned'(i) < NumOut; i++) begin : gen_out_assertions
-        `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask), clk_i, !rst_ni, "data_o is unstable at output: %0d Check that parameter LockIn is set.", i)
-        `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]), clk_i, !rst_ni, "idx_o is unstable at output: %0d Check that parameter LockIn is set.", i)
-        `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni, "valid_o at output %0d has been taken away without a ready.", i)
+        `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask), clk_i, !rst_ni, $sformatf("data_o is unstable at output: %0d Check that parameter LockIn is set.", i))
+        `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]), clk_i, !rst_ni, $sformatf("idx_o is unstable at output: %0d Check that parameter LockIn is set.", i))
+        `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni, $sformatf("valid_o at output %0d has been taken away without a ready.", i))
       end
     end
 

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -267,9 +267,6 @@ module stream_omega_net #(
     // Assertions
     // Make sure that the handshake and payload is stable
     `ifndef COMMON_CELLS_ASSERTS_OFF
-    `ifndef VERILATOR
-    default disable iff (~rst_ni);
-    `endif
     for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
       `ASSERT(non_existing_output, valid_i[i] |-> sel_i[i] < NumOut, clk_i, !rst_ni, "Non-existing output is selected!")
     end

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -268,25 +268,39 @@ module stream_omega_net #(
     // Make sure that the handshake and payload is stable
     `ifndef COMMON_CELLS_ASSERTS_OFF
     for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
-      `ASSERT(non_existing_output, valid_i[i] |-> sel_i[i] < NumOut, clk_i, !rst_ni, "Non-existing output is selected!")
+      `ASSERT(non_existing_output, valid_i[i] |-> sel_i[i] < NumOut, clk_i, !rst_ni,
+              "Non-existing output is selected!")
     end
 
     if (AxiVldRdy) begin : gen_handshake_assertions
       for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_inp_assertions
-        `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask), clk_i, !rst_ni, $sformatf("data_i is unstable at input: %0d", i))
-        `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]), clk_i, !rst_ni, $sformatf("sel_i is unstable at input: %0d", i))
-        `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni, $sformatf("valid_i at input %0d has been taken away without a ready.", i))
+        `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask),
+                clk_i, !rst_ni, $sformatf("data_i is unstable at input: %0d", i))
+        `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]),
+                clk_i, !rst_ni, $sformatf("sel_i is unstable at input: %0d", i))
+        `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni,
+                $sformatf("valid_i at input %0d has been taken away without a ready.", i))
       end
       for (genvar i = 0; unsigned'(i) < NumOut; i++) begin : gen_out_assertions
-        `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask), clk_i, !rst_ni, $sformatf("data_o is unstable at output: %0d Check that parameter LockIn is set.", i))
-        `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]), clk_i, !rst_ni, $sformatf("idx_o is unstable at output: %0d Check that parameter LockIn is set.", i))
-        `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni, $sformatf("valid_o at output %0d has been taken away without a ready.", i))
+        `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask),
+                clk_i, !rst_ni,
+                $sformatf("data_o is unstable at output: %0d Check that parameter LockIn is set.",
+                          i))
+        `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]),
+                clk_i, !rst_ni,
+                $sformatf("idx_o is unstable at output: %0d Check that parameter LockIn is set.",
+                          i))
+        `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni,
+                $sformatf("valid_o at output %0d has been taken away without a ready.", i))
       end
     end
 
-    `ASSERT_INIT(radix_not_power_of_2, (2**$clog2(Radix) == Radix) && (Radix > 32'd1), "Radix is not power of two.")
-    `ASSERT_INIT(num_routers_not_power_of_2, 2**$clog2(NumRouters) == NumRouters, "NumRouters is not power of two.")
-    `ASSERT_INIT(bit_sclicing_broken, $clog2(NumLanes) % SelW == 0, "Bit slicing of the internal selection signal is broken.")
+    `ASSERT_INIT(radix_not_power_of_2, (2**$clog2(Radix) == Radix) && (Radix > 32'd1),
+                 "Radix is not power of two.")
+    `ASSERT_INIT(num_routers_not_power_of_2, 2**$clog2(NumRouters) == NumRouters,
+                 "NumRouters is not power of two.")
+    `ASSERT_INIT(bit_sclicing_broken, $clog2(NumLanes) % SelW == 0,
+                 "Bit slicing of the internal selection signal is broken.")
     `endif
   end
 endmodule

--- a/src/stream_omega_net.sv
+++ b/src/stream_omega_net.sv
@@ -10,6 +10,8 @@
 
 // Author: Wolfgang Roenninger <wroennin@ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 /// Omega network using multiple `stream_xbar` as switches.
 ///
 /// An omega network is isomorphic to a butterfly network.

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -120,11 +120,15 @@ module stream_to_mem #(
 // Assertions
 `ifndef COMMON_CELLS_ASSERTS_OFF
   if (BufDepth > 0) begin : gen_buf_asserts
-    `ASSERT(memory_response_lost, mem_resp_valid_i |-> buf_ready, clk_i, !rst_ni, "Memory response lost!")
-    `ASSERT(counter_underflowed, cnt_q == '0 |=> cnt_q != '1, clk_i, !rst_ni, "Counter underflowed!")
-    `ASSERT(counter_overflowed, cnt_q == BufDepth |=> cnt_q != BufDepth + 1, clk_i, !rst_ni, "Counter overflowed!")
+    `ASSERT(memory_response_lost, mem_resp_valid_i |-> buf_ready, clk_i, !rst_ni,
+            "Memory response lost!")
+    `ASSERT(counter_underflowed, cnt_q == '0 |=> cnt_q != '1, clk_i, !rst_ni,
+            "Counter underflowed!")
+    `ASSERT(counter_overflowed, cnt_q == BufDepth |=> cnt_q != BufDepth + 1, clk_i, !rst_ni,
+            "Counter overflowed!")
   end else begin : gen_no_buf_asserts
-    `ASSUME(no_memory_response, mem_req_valid_o & mem_req_ready_i |-> mem_resp_valid_i, clk_i, !rst_ni, "Without BufDepth = 0, the memory must respond in the same cycle!")
+    `ASSUME(no_memory_response, mem_req_valid_o & mem_req_ready_i |-> mem_resp_valid_i,
+            clk_i, !rst_ni, "Without BufDepth = 0, the memory must respond in the same cycle!")
   end
 `endif
 endmodule

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -118,7 +118,6 @@ module stream_to_mem #(
   assign mem_req_o = req_i;
 
 // Assertions
-`ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   if (BufDepth > 0) begin : gen_buf_asserts
     `ASSERT(memory_response_lost, mem_resp_valid_i |-> buf_ready, clk_i, !rst_ni, "Memory response lost!")
@@ -127,6 +126,5 @@ module stream_to_mem #(
   end else begin : gen_no_buf_asserts
     `ASSUME(no_memory_response, mem_req_valid_o & mem_req_ready_i |-> mem_resp_valid_i, clk_i, !rst_ni, "Without BufDepth = 0, the memory must respond in the same cycle!")
   end
-`endif
 `endif
 endmodule

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -125,8 +125,7 @@ module stream_to_mem #(
     `ASSERT(counter_underflowed, cnt_q == '0 |=> cnt_q != '1, clk_i, !rst_ni, "Counter underflowed!")
     `ASSERT(counter_overflowed, cnt_q == BufDepth |=> cnt_q != BufDepth + 1, clk_i, !rst_ni, "Counter overflowed!")
   end else begin : gen_no_buf_asserts
-    assume property (@(posedge clk_i) mem_req_valid_o & mem_req_ready_i |-> mem_resp_valid_i)
-      else $error("Without BufDepth = 0, the memory must respond in the same cycle!");
+    `ASSUME(no_memory_response, mem_req_valid_o & mem_req_ready_i |-> mem_resp_valid_i, clk_i, !rst_ni, "Without BufDepth = 0, the memory must respond in the same cycle!")
   end
 `endif
 `endif

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -121,12 +121,9 @@ module stream_to_mem #(
 `ifndef SYNTHESIS
 `ifndef COMMON_CELLS_ASSERTS_OFF
   if (BufDepth > 0) begin : gen_buf_asserts
-    assert property (@(posedge clk_i) mem_resp_valid_i |-> buf_ready)
-      else $error("Memory response lost!");
-    assert property (@(posedge clk_i) cnt_q == '0 |=> cnt_q != '1)
-      else $error("Counter underflowed!");
-    assert property (@(posedge clk_i) cnt_q == BufDepth |=> cnt_q != BufDepth + 1)
-      else $error("Counter overflowed!");
+    `ASSERT(memory_response_lost, mem_resp_valid_i |-> buf_ready, clk_i, !rst_ni, "Memory response lost!")
+    `ASSERT(counter_underflowed, cnt_q == '0 |=> cnt_q != '1, clk_i, !rst_ni, "Counter underflowed!")
+    `ASSERT(counter_overflowed, cnt_q == BufDepth |=> cnt_q != BufDepth + 1, clk_i, !rst_ni, "Counter overflowed!")
   end else begin : gen_no_buf_asserts
     assume property (@(posedge clk_i) mem_req_valid_o & mem_req_ready_i |-> mem_resp_valid_i)
       else $error("Without BufDepth = 0, the memory must respond in the same cycle!");

--- a/src/stream_to_mem.sv
+++ b/src/stream_to_mem.sv
@@ -11,9 +11,11 @@
 // Authors:
 // - Andreas Kurth <akurth@iis.ee.ethz.ch>
 
+`include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
+
 /// `stream_to_mem`: Allows to use memories with flow control (`valid`/`ready`) for requests but without flow
 /// control for output data to be used in streams.
-`include "common_cells/registers.svh"
 module stream_to_mem #(
   /// Memory request payload type, usually write enable, write data, etc.
   parameter type         mem_req_t  = logic,

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -177,14 +177,14 @@ module stream_xbar #(
 
   if (AxiVldRdy) begin : gen_handshake_assertions
     for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_inp_assertions
-      `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask), clk_i, !rst_ni, "data_i is unstable at input: %0d", i)
-      `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]), clk_i, !rst_ni, "sel_i is unstable at input: %0d", i)
-      `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni, "valid_i at input %0d has been taken away without a ready.", i)
+      `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask), clk_i, !rst_ni, $sformatf("data_i is unstable at input: %0d", i))
+      `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]), clk_i, !rst_ni, $sformatf("sel_i is unstable at input: %0d", i))
+      `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni, $sformatf("valid_i at input %0d has been taken away without a ready.", i))
     end
     for (genvar i = 0; unsigned'(i) < NumOut; i++) begin : gen_out_assertions
-      `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask), clk_i, !rst_ni, "data_o is unstable at output: %0d Check that parameter LockIn is set.", i)
-      `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]), clk_i, !rst_ni, "idx_o is unstable at output: %0d Check that parameter LockIn is set.", i)
-      `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni, "valid_o at output %0d has been taken away without a ready.", i)
+      `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask), clk_i, !rst_ni, $sformatf("data_o is unstable at output: %0d Check that parameter LockIn is set.", i))
+      `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]), clk_i, !rst_ni, $sformatf("idx_o is unstable at output: %0d Check that parameter LockIn is set.", i))
+      `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni, $sformatf("valid_o at output %0d has been taken away without a ready.", i))
     end
   end
 

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -176,33 +176,19 @@ module stream_xbar #(
   default disable iff (~rst_ni);
   `endif
   for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
-    assert property (@(posedge clk_i) disable iff (~rst_ni)
-        (valid_i[i] |-> sel_i[i] < NumOut)) else
-        $fatal(1, "Non-existing output is selected!");
+    `ASSERT(non_existing_output, valid_i[i] |-> sel_i[i] < NumOut, clk_i, !rst_ni, "Non-existing output is selected!")
   end
 
   if (AxiVldRdy) begin : gen_handshake_assertions
     for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_inp_assertions
-      assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask))) else
-          $error("data_i is unstable at input: %0d", i);
-      assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]))) else
-          $error("sel_i is unstable at input: %0d", i);
-      assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_i[i] && !ready_o[i] |=> valid_i[i])) else
-          $error("valid_i at input %0d has been taken away without a ready.", i);
+      `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask), clk_i, !rst_ni, "data_i is unstable at input: %0d", i)
+      `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]), clk_i, !rst_ni, "sel_i is unstable at input: %0d", i)
+      `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni, "valid_i at input %0d has been taken away without a ready.", i)
     end
     for (genvar i = 0; unsigned'(i) < NumOut; i++) begin : gen_out_assertions
-      assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask))) else
-          $error("data_o is unstable at output: %0d Check that parameter LockIn is set.", i);
-      assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]))) else
-          $error("idx_o is unstable at output: %0d Check that parameter LockIn is set.", i);
-      assert property (@(posedge clk_i) disable iff (~rst_ni)
-          (valid_o[i] && !ready_i[i] |=> valid_o[i])) else
-          $error("valid_o at output %0d has been taken away without a ready.", i);
+      `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask), clk_i, !rst_ni, "data_o is unstable at output: %0d Check that parameter LockIn is set.", i)
+      `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]), clk_i, !rst_ni, "idx_o is unstable at output: %0d Check that parameter LockIn is set.", i)
+      `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni, "valid_o at output %0d has been taken away without a ready.", i)
     end
   end
 

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -171,9 +171,6 @@ module stream_xbar #(
   // Assertions
   // Make sure that the handshake and payload is stable
   `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ifndef VERILATOR
-  default disable iff (~rst_ni);
-  `endif
   for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
     `ASSERT(non_existing_output, valid_i[i] |-> sel_i[i] < NumOut, clk_i, !rst_ni, "Non-existing output is selected!")
   end

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -10,6 +10,8 @@
 
 // Author: Wolfgang Roenninger <wroennin@ethz.ch>
 
+`include "common_cells/assertions.svh"
+
 /// Fully connected stream crossbar.
 ///
 /// Handshaking rules as defined by the `AMBA AXI` standard on default.

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -170,7 +170,6 @@ module stream_xbar #(
 
   // Assertions
   // Make sure that the handshake and payload is stable
-  `ifndef SYNTHESIS
   `ifndef COMMON_CELLS_ASSERTS_OFF
   `ifndef VERILATOR
   default disable iff (~rst_ni);
@@ -194,6 +193,5 @@ module stream_xbar #(
 
   `ASSERT_INIT(numinp_0, NumInp > 32'd0, "NumInp has to be > 0!")
   `ASSERT_INIT(numout_0, NumOut > 32'd0, "NumOut has to be > 0!")
-  `endif
   `endif
 endmodule

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -192,10 +192,8 @@ module stream_xbar #(
     end
   end
 
-  initial begin : proc_parameter_assertions
-    assert (NumInp > 32'd0) else $fatal(1, "NumInp has to be > 0!");
-    assert (NumOut > 32'd0) else $fatal(1, "NumOut has to be > 0!");
-  end
+  `ASSERT_INIT(numinp_0, NumInp > 32'd0, "NumInp has to be > 0!")
+  `ASSERT_INIT(numout_0, NumOut > 32'd0, "NumOut has to be > 0!")
   `endif
   `endif
 endmodule

--- a/src/stream_xbar.sv
+++ b/src/stream_xbar.sv
@@ -172,19 +172,27 @@ module stream_xbar #(
   // Make sure that the handshake and payload is stable
   `ifndef COMMON_CELLS_ASSERTS_OFF
   for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_sel_assertions
-    `ASSERT(non_existing_output, valid_i[i] |-> sel_i[i] < NumOut, clk_i, !rst_ni, "Non-existing output is selected!")
+    `ASSERT(non_existing_output, valid_i[i] |-> sel_i[i] < NumOut, clk_i, !rst_ni,
+            "Non-existing output is selected!")
   end
 
   if (AxiVldRdy) begin : gen_handshake_assertions
     for (genvar i = 0; unsigned'(i) < NumInp; i++) begin : gen_inp_assertions
-      `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask), clk_i, !rst_ni, $sformatf("data_i is unstable at input: %0d", i))
-      `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]), clk_i, !rst_ni, $sformatf("sel_i is unstable at input: %0d", i))
-      `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni, $sformatf("valid_i at input %0d has been taken away without a ready.", i))
+      `ASSERT(input_data_unstable, valid_i[i] && !ready_o[i] |=> $stable(data_i[i] & AxiVldMask),
+              clk_i, !rst_ni, $sformatf("data_i is unstable at input: %0d", i))
+      `ASSERT(input_sel_unstable, valid_i[i] && !ready_o[i] |=> $stable(sel_i[i]), clk_i, !rst_ni,
+              $sformatf("sel_i is unstable at input: %0d", i))
+      `ASSERT(input_valid_taken, valid_i[i] && !ready_o[i] |=> valid_i[i], clk_i, !rst_ni,
+              $sformatf("valid_i at input %0d has been taken away without a ready.", i))
     end
     for (genvar i = 0; unsigned'(i) < NumOut; i++) begin : gen_out_assertions
-      `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask), clk_i, !rst_ni, $sformatf("data_o is unstable at output: %0d Check that parameter LockIn is set.", i))
-      `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]), clk_i, !rst_ni, $sformatf("idx_o is unstable at output: %0d Check that parameter LockIn is set.", i))
-      `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni, $sformatf("valid_o at output %0d has been taken away without a ready.", i))
+      `ASSERT(output_data_unstable, valid_o[i] && !ready_i[i] |=> $stable(data_o[i] & AxiVldMask),
+              clk_i, !rst_ni,
+              $sformatf("data_o is unstable at output: %0d Check that parameter LockIn is set.", i))
+      `ASSERT(output_idx_unstable, valid_o[i] && !ready_i[i] |=> $stable(idx_o[i]), clk_i, !rst_ni,
+              $sformatf("idx_o is unstable at output: %0d Check that parameter LockIn is set.", i))
+      `ASSERT(output_valid_taken, valid_o[i] && !ready_i[i] |=> valid_o[i], clk_i, !rst_ni,
+              $sformatf("valid_o at output %0d has been taken away without a ready.", i))
     end
   end
 


### PR DESCRIPTION
This PR replaces all assertions (and assumes) in the common cells sources with macros from [`assertions.svh`](https://github.com/pulp-platform/common_cells/blob/master/include/common_cells/assertions.svh).

Additionally, the `assertions.svh` itself is modified as follows:
- Some defines (such as the guard block at the start of the header) are renamed for consistency and to avoid name collisions in the same style as in [`registers.svh`](https://github.com/pulp-platform/common_cells/blob/master/include/common_cells/registers.svh).
- The `` `ifndef VERILATOR`` is removed because Verilator has supported assertions for a while now.
- An option to override any of the default defines that cause assertions to be turned off (such as `SYNTHESIS`) is added (so even if a tool defines, e.g., `SYNTHESIS`, it still has the option to forcefully enable assertions by also defining `ASSERTS_OVERRIDE_ON` now — yes, there are tools out there that require that :roll_eyes:).
- Helper macros are undefined at the end of the file (a comment did claim that this was already the case, but it was not).
- An optional extra argument is added to all assertions macros, which allows to specify a custom error message to be displayed when the assertion fails. For backwards compatibility, this extra argument is added at the end and defaults to  `""`.

In order to replace all the assertions in the sources while avoiding typos and other oversights as best as possible, I have replaced almost all of them using sed commands. The specific commands used for each change are part of the respective commit messages.

Some noteworthy subtle changes that go along with this move:
- The macros in `assertions.svh` require that all assertions have a name, so I added one for all those who did not have one (and I tried to hard to keep them consistent).
- So far, assertions used a mix of `$fatal`, `$error`, and sometimes `$warning` to report failing assertions. The macros in `assertions.svh` universally use `$error` and all instances of `$fatal` are now changed to `$error`. I reviewed all those that used `$warning` but since they all appear to be pretty critical issues as well, they now also use the macros which report an `$error` (the affected files are `src/addr_decode_dync.sv`, `src/cdc_fifo_gray_clearable.sv`, `src/multiaddr_decode.sv`, and `src/spill_register_flushable.sv`, so the authors of these @WRoenninger, @fabianschuiki, @zarubaf, @meggiman, and @colluca might want to take a look).
- Assertions that were previously declared as `assert initial` or `assert final` are now immediate assertions in a `initial` or `final` block, respectively.
- `src/rr_arb_tree.sv`, `src/stream_omega_net.sv`, and `src/stream_xbar.sv` previously used a default disable (e.g., `default disable iff (~rst_ni);`), which btw is also not supported by Verilator. Each assertion macro has an `disable iff !rst_ni` instead, so I removed those.

Also, the following files make use of assertions in a pretty advanced/adventurous way (which btw also causes Verilator 5.018 to fail as reported in #229):
- `src/addr_decode_dync.sv`: Includes a huge `always` block with `assume`s all over the place.
- `src/multiaddr_decode.sv`: Again an `always` block with an `assume` in it.

I'd like to ask the respective authors (@WRoenninger and @colluca) to review the changes to these files (you are of course welcome to review changes to the other files as well).

Merging this PR closes #232.