### PR TITLE
stream_join_dynamic: Assert inp readies only for selected streams

### DIFF
--- a/src/stream_join_dynamic.sv
+++ b/src/stream_join_dynamic.sv
@@ -34,7 +34,7 @@ module stream_join_dynamic #(
   // Corner case when `sel_i` is all 0s should not generate valid
   assign oup_valid_o = &(inp_valid_i | ~sel_i) && |sel_i;
   for (genvar i = 0; i < N_INP; i++) begin : gen_inp_ready
-    assign inp_ready_o[i] = oup_valid_o & oup_ready_i;
+    assign inp_ready_o[i] = oup_valid_o & oup_ready_i & sel_i[i];
   end
 
 `ifndef SYNTHESIS


### PR DESCRIPTION
Observed behavior: a successful handshake on the output ports asserts `ready=1` on all input ports regardless of `sel_i` selection. This leads to unwanted handshakes on the input channels which have `valid=1` but are not selected. This PR proposes a simple fix to ensure only selected input channels observe `ready=1`.