### PR TITLE
Guard unsynthesizable `$isunknown` with ifndef SYNTHESIS

### DIFF
--- a/src/addr_decode_dync.sv
+++ b/src/addr_decode_dync.sv
@@ -144,6 +144,7 @@ module addr_decode_dync #(
   // check_start:        Enforces a smaller start than end address.
   // check_idx:          Enforces a valid index in the rule.
   // check_overlap:      Warns if there are overlapping address regions.
+  `ifndef SYNTHESIS
   always_comb begin : proc_check_addr_map
     if (!$isunknown(addr_map_i) && ~config_ongoing_i) begin
       for (int unsigned i = 0; i < NoRules; i++) begin
@@ -182,6 +183,7 @@ module addr_decode_dync #(
       end
     end
   end
+  `endif
   `endif
 
 endmodule

--- a/src/multiaddr_decode.sv
+++ b/src/multiaddr_decode.sv
@@ -132,6 +132,7 @@ module multiaddr_decode #(
 
   // These following assumptions check the validity of the address map.
   // check_idx: Enforces a valid index in the rule.
+  `ifndef SYNTHESIS
   always_comb begin : proc_check_addr_map
     if (!$isunknown(addr_map_i)) begin
       for (int unsigned i = 0; i < NoRules; i++) begin
@@ -146,6 +147,6 @@ module multiaddr_decode #(
       end
     end
   end
-
+  `endif
   `endif
 endmodule


### PR DESCRIPTION
While working on #233, I overlooked that the combinatorial blocks around the immediate assertions in `addr_decode_dync` and `multiaddr_decode` contain an unsynthesizable `$isunknown()` call. While the guard macros in `assertions.svh` do disable the assertions themselves when `SYNTHESIS` is defined, the `$isunknown` requires that the whole block is guarded as well. Sorry for missing this!