### PR TITLE
assertions: Keep helper macros defined

### DIFF
--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -24,7 +24,7 @@
 // Helper macros //
 ///////////////////
 
-// local helper macro to reduce code clutter. undefined at the end of this file
+// helper macro to reduce code clutter, can be used to hide signal defs only used for assertions
 `ifndef ASSERTS_OFF
 `ifndef SYNTHESIS
 `ifndef XSIM
@@ -206,11 +206,5 @@
    `COVER(__name, __prop, __clk, __rst)                                                     \
 `endif
 
-
-// undefine local helper macros
-`ifdef INC_ASSERT
-`undef INC_ASSERT
-`endif
-`undef ASSERT_STRINGIFY
 
 `endif // COMMON_CELLS_ASSERTIONS_SVH


### PR DESCRIPTION
Another day, another fix for PR #233. This time I realized that undefining a helper macro that is still needed later on is not a smart idea — turns out that due to this the assertion macros were not enabled so far.

Also, a comment in lowRISC's implementation made me realize that the helper macro can be useful outside of the header:

https://github.com/lowRISC/opentitan/blob/28af81ab6e41d9ee6b270f28c7e62761d6c62c31/hw/ip/prim/rtl/prim_assert.sv#L59-L60