### PR TITLE
Fix inverted reset in delta_counter

### DIFF
--- a/src/delta_counter.sv
+++ b/src/delta_counter.sv
@@ -31,7 +31,7 @@ module delta_counter #(
 
         always_ff @(posedge clk_i or negedge rst_ni)
         begin
-            if(rst_ni) begin
+            if(!rst_ni) begin
                 overflow_q <= 1'b0;
             end else begin
                 overflow_q <= overflow_d;


### PR DESCRIPTION
A recent fix to the reset logic in delta_counter 10dac0ff33 looks like it accidentally inverted the reset logic.