### PR TITLE
Fix non-synchronized path in cdc_2phase_clearable

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -123,6 +123,7 @@ sources:
       - test/addr_decode_tb.sv
       - test/cb_filter_tb.sv
       - test/cdc_2phase_tb.sv
+      - test/cdc_4phase_tb.sv
       - test/cdc_2phase_clearable_tb.sv
       - test/cdc_fifo_tb.sv
       - test/cdc_fifo_clearable_tb.sv

--- a/src/cdc_4phase.sv
+++ b/src/cdc_4phase.sv
@@ -298,27 +298,19 @@ module cdc_4phase_dst #(
     end
   end
 
-  if (DECOUPLED) begin : gen_decoupled
-    // Decouple the output from the asynchronous data bus without introducing
-    // additional latency by inserting a spill register
-    spill_register #(
-      .T(T),
-      .Bypass(1'b0)
-    ) i_spill_register (
-      .clk_i,
-      .rst_ni,
-      .valid_i(data_valid),
-      .ready_o(output_ready),
-      .data_i(async_data_i),
-      .valid_o,
-      .ready_i,
-      .data_o
-    );
-  end else begin : gen_not_decoupled
-    assign valid_o      = data_valid;
-    assign output_ready = ready_i;
-    assign data_o       = async_data_i;
-  end
+  spill_register #(
+    .T(T),
+    .Bypass(1'b0)
+  ) i_spill_register (
+    .clk_i,
+    .rst_ni,
+    .valid_i(data_valid),
+    .ready_o(output_ready),
+    .data_i(async_data_i),
+    .valid_o,
+    .ready_i,
+    .data_o
+  );
 
   // Output assignments.
   assign async_ack_o = ack_dst_q;

--- a/test/cdc_4phase_tb.sv
+++ b/test/cdc_4phase_tb.sv
@@ -1,0 +1,267 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+module cdc_4phase_tb;
+
+  parameter int UNTIL = 10_000_000;
+  parameter bit INJECT_DELAYS = 1;
+  parameter bit POST_SYNTHESIS = 0;
+
+  time tck_src = 10ns;
+  time tck_dst = 10ns;
+  bit src_done = 0;
+  bit dst_done = 0;
+  bit done;
+  assign done = src_done & dst_done;
+
+  // Signals of the design under test.
+  logic        src_rst_ni  = 1;
+  logic        src_clk_i   = 0;
+  logic [31:0] src_data_i  = 0;
+  logic        src_valid_i = 0;
+  logic        src_ready_o;
+
+  logic        dst_rst_ni  = 1;
+  logic        dst_clk_i   = 0;
+  logic [31:0] dst_data_o;
+  logic        dst_valid_o;
+  logic        dst_ready_i = 0;
+
+  // Instantiate the design under test.
+  if (POST_SYNTHESIS) begin : g_dut
+    cdc_4phase_synth i_dut (.*);
+  end else if (INJECT_DELAYS) begin : g_dut
+    cdc_4phase_tb_delay_injector #(0.8ns) i_dut (.*);
+  end else begin : g_dut
+    cdc_4phase #(logic [31:0]) i_dut (.*);
+  end
+
+  // Mailbox with expected items on destination side.
+  mailbox #(int) dst_mbox = new();
+  int num_sent = 0;
+  int num_received = 0;
+  int num_failed = 0;
+
+  // Clock generators.
+  initial begin
+    static int num_items, num_clks;
+    num_items = 10;
+    num_clks = 0;
+    #10ns;
+    src_rst_ni = 0;
+    #10ns;
+    src_rst_ni = 1;
+    #10ns;
+    while (!done) begin
+      src_clk_i = 1;
+      #(tck_src/2);
+      src_clk_i = 0;
+      #(tck_src/2);
+
+      // Modulate the clock frequency.
+      num_clks++;
+      if (num_sent >= num_items && num_clks > 10) begin
+        num_items = num_sent + 10;
+        num_clks = 0;
+        tck_src = $urandom_range(1000, 100000) * 1ps;
+        assert(tck_src > 0);
+      end
+    end
+  end
+
+  initial begin
+    static int num_items, num_clks;
+    num_items = 10;
+    num_clks = 0;
+    #10ns;
+    dst_rst_ni = 0;
+    #10ns;
+    dst_rst_ni = 1;
+    #10ns;
+    while (!done) begin
+      dst_clk_i = 1;
+      #(tck_dst/2);
+      dst_clk_i = 0;
+      #(tck_dst/2);
+
+      // Modulate the clock frequency.
+      num_clks++;
+      if (num_received >= num_items && num_clks > 10) begin
+        num_items = num_received + 10;
+        num_clks = 0;
+        tck_dst = $urandom_range(1000, 100000) * 1ps;
+        assert(tck_dst > 0);
+      end
+    end
+  end
+
+  // Source side sender.
+  task src_cycle_start;
+    #(tck_src*0.8);
+  endtask
+
+  task src_cycle_end;
+    @(posedge src_clk_i);
+  endtask
+
+  initial begin
+    @(negedge src_rst_ni);
+    @(posedge src_rst_ni);
+    repeat(3) @(posedge src_clk_i);
+    for (int i = 0; i < UNTIL; i++) begin
+      static integer stimulus;
+      stimulus = $random();
+      src_data_i  <= #(tck_src*0.2) stimulus;
+      src_valid_i <= #(tck_src*0.2) 1;
+      dst_mbox.put(stimulus);
+      num_sent++;
+      src_cycle_start();
+      while (!src_ready_o) begin
+        src_cycle_end();
+        src_cycle_start();
+      end
+      src_cycle_end();
+      src_valid_i <= #(tck_src*0.2) 0;
+    end
+    src_done = 1;
+    $display("src done");
+  end
+
+  // Destination side receiver.
+  task dst_cycle_start;
+    #(tck_dst*0.8);
+  endtask
+
+  task dst_cycle_end;
+    @(posedge dst_clk_i);
+  endtask
+
+  initial begin
+    @(negedge dst_rst_ni);
+    @(posedge dst_rst_ni);
+    repeat(3) @(posedge dst_clk_i);
+    while (!src_done || dst_mbox.num() > 0) begin
+      static integer expected, actual;
+      static int cooldown;
+      dst_ready_i <= #(tck_dst*0.2) 1;
+      dst_cycle_start();
+      while (!dst_valid_o && !src_done) begin
+        dst_cycle_end();
+        dst_cycle_start();
+      end
+      if(src_done)
+        break;
+      actual = dst_data_o;
+      num_received++;
+      if (dst_mbox.num() == 0) begin
+        $error("unexpected transaction: data=%0h", actual);
+        num_failed++;
+      end else begin
+        dst_mbox.get(expected);
+        if (actual !== expected) begin
+          $error("transaction mismatch: exp=%0h, act=%0h", expected, actual);
+          num_failed++;
+        end
+      end
+      if(num_received%10000 == 0) begin
+        $display("transaction nr %d", num_received);
+      end
+      dst_cycle_end();
+      dst_ready_i <= #(tck_dst*0.2) 0;
+
+      // Insert a random cooldown period.
+      cooldown = $urandom_range(0, 40);
+      if (cooldown < 20) repeat(cooldown) @(posedge dst_clk_i);
+    end
+    $display("dst done");
+
+    if (num_sent != num_received) begin
+      $error("%0d items sent, but %0d items received", num_sent, num_received);
+    end
+    if (num_failed > 0) begin
+      $error("%0d/%0d items mismatched", num_failed, num_sent);
+    end else begin
+      $info("%0d items passed", num_sent);
+    end
+    dst_done = 1;
+  end
+
+endmodule
+
+
+module cdc_4phase_tb_delay_injector #(
+  parameter time MAX_DELAY = 0ns
+)(
+  input  logic        src_rst_ni,
+  input  logic        src_clk_i,
+  input  logic [31:0] src_data_i,
+  input  logic        src_valid_i,
+  output logic        src_ready_o,
+
+  input  logic        dst_rst_ni,
+  input  logic        dst_clk_i,
+  output logic [31:0] dst_data_o,
+  output logic        dst_valid_o,
+  input  logic        dst_ready_i
+);
+
+  logic async_req_o, async_req_i;
+  logic async_ack_o, async_ack_i;
+  logic [31:0] async_data_o, async_data_i;
+
+  always @(async_req_o) begin
+    automatic time d = $urandom_range(0, MAX_DELAY);
+    async_req_i <= #d async_req_o;
+  end
+
+  always @(async_ack_o) begin
+    automatic time d = $urandom_range(0, MAX_DELAY);
+    async_ack_i <= #d async_ack_o;
+  end
+
+  for (genvar i = 0; i < 32; i++) begin
+    always @(async_data_o[i]) begin
+      automatic time d = $urandom_range(0, MAX_DELAY);
+      async_data_i[i] <= #d async_data_o[i];
+    end
+  end
+
+  cdc_4phase_src #(
+    .T(logic [31:0]),
+    .DECOUPLED(1'b0)
+    ) i_src (
+    .rst_ni       ( src_rst_ni   ),
+    .clk_i        ( src_clk_i    ),
+    .data_i       ( src_data_i   ),
+    .valid_i      ( src_valid_i  ),
+    .ready_o      ( src_ready_o  ),
+    .async_req_o  ( async_req_o  ),
+    .async_ack_i  ( async_ack_i  ),
+    .async_data_o ( async_data_o )
+  );
+
+  cdc_4phase_dst #(
+    .T(logic [31:0]),
+    .DECOUPLED(1'b0)
+    ) i_dst (
+    .rst_ni       ( dst_rst_ni   ),
+    .clk_i        ( dst_clk_i    ),
+    .data_o       ( dst_data_o   ),
+    .valid_o      ( dst_valid_o  ),
+    .ready_i      ( dst_ready_i  ),
+    .async_req_i  ( async_req_i  ),
+    .async_ack_o  ( async_ack_o  ),
+    .async_data_i ( async_data_i )
+  );
+
+endmodule


### PR DESCRIPTION
As it stands, the `cdc_2phase_clearable` module has a path going from the source clock domain into the destination clock domain directly, without a 2-flop synchronizer.  
The path in question is in the reset/clear logic implemented in `cdc_reset_ctrlr`.  
Specifically `receiver_next_phase` is clocked by the source domain (side A in `cdc_reset_ctrlr`) and then goes into the other side (side B) where it goes into `i_state_transition_cdc_dst`, a `cdc_4phase_dst` with the `DECOUPLED` parameter set to zero.  
Setting this parameter to zero effectively bypasses the spill-register in there allowing the same _asynchronous_ signal to leave and go into the destination clock domain, where it shows up as `receiver_next_phase` used to create the isolate and clear signals on the destination side.

I strongly doubt this is intended behavior and would like to fix this issue.  

Further, this shows to me that especially the clock domain crossings need working testbenches that run in a CI to make sure they work as intended.  
As part of this PR, I also started to fix the testbenches which in the case of `cdc_2phase_clearable` did not even test the module but presumably some old development version instead. This happened because the module is essentially copied in the testbench instead of actually testing the module itself.