### PR TITLE
treewide: Replace non-resettable FFs

### DIFF
--- a/src/isochronous_spill_register.sv
+++ b/src/isochronous_spill_register.sv
@@ -84,7 +84,7 @@ module isochronous_spill_register #(
     `FFLARN(rd_pointer_q, rd_pointer_q+1, (dst_valid_o && dst_ready_i), '0, dst_clk_i, dst_rst_ni)
 
     T [1:0] mem_d, mem_q;
-    `FFLNR(mem_q, mem_d, (src_valid_i && src_ready_o), src_clk_i)
+    `FFL(mem_q, mem_d, (src_valid_i && src_ready_o), '0, src_clk_i, src_rst_ni)
     always_comb begin
       mem_d = mem_q;
       mem_d[wr_pointer_q[0]] = src_data_i;


### PR DESCRIPTION
Following https://github.com/pulp-platform/snitch_cluster/pull/154, there are still some non-resettable FFs in the Snitch cluster, that can be traced back to the `isochronous_spill_register` IP.

This PR is a placeholder for addressing this issue. The current solution has to be revised to ensure safety against metastability conditions.