### PR TITLE
[Verilator] Don't import deprecated SRAM with verilator

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -113,7 +113,7 @@ sources:
       # Level 4
       - src/mem_to_banks.sv
 
-  - target: simulation
+  - target: all(simulation, not(verilator))
     files:
       - src/deprecated/sram.sv
 


### PR DESCRIPTION
The deprecated SRAM imported with `simulation` breaks with verilator. This PR excludes said module from being imported with `verilator`.