### PR TITLE
popcount: Fix output width 

### DIFF
--- a/src/popcount.sv
+++ b/src/popcount.sv
@@ -12,7 +12,7 @@
 
 // Description: This module calculates the hamming weight (number of ones) in
 // its input vector. Any unsigned INPUT_WIDTH larger or equal 1 is legal. The output result
-// width is ceil(log2(INPUT_WIDTH))+1.
+// width is ceil(log2(INPUT_WIDTH+1)).
 //
 // This module used to be implemented using a binary added tree. However,
 // the heuristics of modern logic Synthesizers work much better with a flat high
@@ -21,7 +21,7 @@
 
 module popcount #(
     parameter  int unsigned INPUT_WIDTH   = 256,
-    localparam int unsigned PopcountWidth = $clog2(INPUT_WIDTH) + 1
+    localparam int unsigned PopcountWidth = $clog2(INPUT_WIDTH+1)
 ) (
     input  logic [  INPUT_WIDTH-1:0] data_i,
     output logic [PopcountWidth-1:0] popcount_o

--- a/test/popcount_tb.sv
+++ b/test/popcount_tb.sv
@@ -35,7 +35,7 @@ module popcount_tb;
    logic popcount_w1;
 
    logic [4:0] data_w5;
-   logic [3:0] popcount_w5;
+   logic [2:0] popcount_w5;
 
    logic [15:0] data_w16;
    logic [4:0]  popcount_w16;
@@ -47,7 +47,7 @@ module popcount_tb;
    logic [6:0]  popcount_w64;
 
    logic [980:0] data_w981;
-   logic [10:0]  popcount_w981;
+   logic [9:0]  popcount_w981;
 
    //--------------------- Instantiate MUT ---------------------
   popcount #(.INPUT_WIDTH(1)) i_popcount_w1


### PR DESCRIPTION
This PR fixes the popcount output width calculation. The hamming weight of an input of width **INPUT_WIDTH** can range from **0** (all bits deasserted) to **INPUT_WIDTH** (all bits asserted), giving a total of **INPUT_WIDTH + 1** values. The minimum number of bits required to represent these values is **ceil(log2(INPUT_WIDTH+1))**. 

Some simulation waveforms generated using Vivado2024 are shown below: 

![sim_data_w5](https://github.com/user-attachments/assets/8692d125-ba29-410e-8a39-f4e70271a4a6)
![sim_data_w981](https://github.com/user-attachments/assets/afc999a7-09d6-4461-b5bf-c9d5a212ef89)

Happy New Year!
diskouna