### PR TITLE
rr_arb_tree: Remove redundant param implication from lock asserts

### DIFF
--- a/src/rr_arb_tree.sv
+++ b/src/rr_arb_tree.sv
@@ -162,13 +162,13 @@ module rr_arb_tree #(
         end
 
         `ifndef COMMON_CELLS_ASSERTS_OFF
-          `ASSERT(lock, LockIn |-> req_o && (!gnt_i && !flush_i) |=> idx_o == $past(idx_o),
+          `ASSERT(lock, req_o && (!gnt_i && !flush_i) |=> idx_o == $past(idx_o),
                   clk_i, !rst_ni || flush_i,
                   "Lock implies same arbiter decision in next cycle if output is not ready.")
 
           logic [NumIn-1:0] req_tmp;
           assign req_tmp = req_q & req_i;
-          `ASSUME(lock_req, LockIn |-> lock_d |=> req_tmp == req_q, clk_i, !rst_ni || flush_i,
+          `ASSUME(lock_req, lock_d |=> req_tmp == req_q, clk_i, !rst_ni || flush_i,
                   "It is disallowed to deassert unserved request signals when LockIn is enabled.")
         `endif
 


### PR DESCRIPTION
The `rr_arb_tree` has two SV assertions (`lock` and `lock_req`) that have an implication operator with the parameter `LockIn` on their LHS. However, these assertions are embedded into a generate if-statement starting on line 145 that enables the whole block only if that `LockIn` parameter is true.

https://github.com/pulp-platform/common_cells/blob/f36828f3fd76fa6c79f80cb495829cf967bcf20c/src/rr_arb_tree.sv#L144-L173

Hence, the implication with `LockIn` is redundant. A smart tool should be able to realize this and optimize that first implication away.

Alas, not all the tools out there are smart. In fact, this mix of overlapped and non-overlapped implications in the same expression appears to severely affect the performance of a popular simulation tool. In some instances, the tool spends roughly 1/3 of the entire simulation time just evaluating these two assertions.

Therefore, this PR removes the redundant implication with `LockIn`, a change that results in a massive reduction in simulation time in some of our tests.

/cc @WRoenninger