### PR TITLE
Fix SpyGlass CDC Lint issues in CDC FIFOs

### DIFF
--- a/src/cdc_fifo_gray.sv
+++ b/src/cdc_fifo_gray.sv
@@ -192,10 +192,12 @@ module cdc_fifo_gray_src #(
 
   // Data FIFO.
   assign async_data_o = data_q;
-  for (genvar i = 0; i < 2**LOG_DEPTH; i++) begin : gen_word
-    `FFLNR(data_q[i], src_data_i,
-          src_valid_i & src_ready_o & (wptr_bin[LOG_DEPTH-1:0] == i), src_clk_i)
+
+  always_comb begin
+    data_d                          = data_q;
+    data_d[wptr_bin[LOG_DEPTH-1:0]] = src_data_i;
   end
+  `FFLARN(data_q, data_d, src_valid_i & src_ready_o, '0, src_clk_i, src_rst_ni)
 
   // Read pointer.
   for (genvar i = 0; i < PtrWidth; i++) begin : gen_sync

--- a/src/cdc_fifo_gray.sv
+++ b/src/cdc_fifo_gray.sv
@@ -187,7 +187,7 @@ module cdc_fifo_gray_src #(
   localparam int PtrWidth = LOG_DEPTH+1;
   localparam logic [PtrWidth-1:0] PtrFull = (1 << LOG_DEPTH);
 
-  T [2**LOG_DEPTH-1:0] data_q;
+  T [2**LOG_DEPTH-1:0] data_q, data_d;
   logic [PtrWidth-1:0] wptr_q, wptr_d, wptr_bin, wptr_next, rptr, rptr_bin;
 
   // Data FIFO.

--- a/src/cdc_fifo_gray_clearable.sv
+++ b/src/cdc_fifo_gray_clearable.sv
@@ -285,15 +285,16 @@ module cdc_fifo_gray_src_clearable #(
   localparam int PtrWidth = LOG_DEPTH+1;
   localparam logic [PtrWidth-1:0] PtrFull = (1 << LOG_DEPTH);
 
-  T [2**LOG_DEPTH-1:0] data_q;
+  T [2**LOG_DEPTH-1:0] data_q, data_d;
   logic [PtrWidth-1:0] wptr_q, wptr_d, wptr_bin, wptr_next, rptr, rptr_bin;
 
   // Data FIFO.
   assign async_data_o = data_q;
-  for (genvar i = 0; i < 2**LOG_DEPTH; i++) begin : gen_word
-    `FFLNR(data_q[i], src_data_i,
-          src_valid_i & src_ready_o & (wptr_bin[LOG_DEPTH-1:0] == i), src_clk_i)
+  always_comb begin
+    data_d                          = data_q;
+    data_d[wptr_bin[LOG_DEPTH-1:0]] = src_data_i;
   end
+  `FFLARN(data_q, data_d, src_valid_i & src_ready_o, '0, src_clk_i, src_rst_ni)
 
   // Read pointer.
   for (genvar i = 0; i < PtrWidth; i++) begin : gen_sync


### PR DESCRIPTION
This PR fixes CDC linting issues of type `Ac_cdc01` in the modules `cdc_fifo_gray` and `cdc_fifo_gray_clearable`.
Currently, the tool flags "ClkCross Data Hold" violations of some (but not all) paths originating from single bits of `wptr_q`.

The issue arise from the formulation of pushing new data to the FIFO. Currently, the FIFO push is enabled by the expression 
`src_valid_i & src_ready_o & (wptr_bin[LOG_DEPTH-1:0] == i)`, which in SpyGlass CDC is viewed as the qualifier of the crossing. Unfortunately this leads SpyGlass CDC to evaluate individual bits of `wptr_q` as being qualifiers for multiple clock domain crossings, which leads to the pointer not being properly recognized as a CDC FIFO write pointer. In turn, the tool will complain that (some) of those `wptr_q` bits violate fast-to-slow clock domain data hold checks, since they are allowed to change multiple times within a target domain clock cycle.

Reformulating (practically) the same functionality by removing `wptr` from the enable condition fixes this, enabling this code to pass strict_qual for SpyGlass CDC linting.