### PR TITLE
lzc: Correct comment and add enum for `MODE` parameter

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -46,6 +46,7 @@ sources:
       - src/lfsr_16bit.sv
       - src/lfsr_8bit.sv
       - src/lossy_valid_to_stream.sv
+      - src/lzc_pkg.sv
       - src/mv_filter.sv
       - src/onehot_to_bin.sv
       - src/plru_tree.sv

--- a/src/lzc.sv
+++ b/src/lzc.sv
@@ -5,20 +5,20 @@
 `include "common_cells/assertions.svh"
 
 /// A trailing zero counter / leading zero counter.
-/// Set MODE to 0 for trailing zero counter => cnt_o is the number of trailing zeros (from the LSB)
-/// Set MODE to 1 for leading zero counter  => cnt_o is the number of leading zeros  (from the MSB)
+/// Set MODE to TRAILING_ZERO_CNT for trailing zero counter => cnt_o is the number of trailing zeros (from the LSB)
+/// Set MODE to LEADING_ZERO_CNT for leading zero counter  => cnt_o is the number of leading zeros  (from the MSB)
 /// If the input does not contain a one, `empty_o` is asserted. Additionally `cnt_o` contains
 /// the maximum number of zeros - 1. For example:
-///   in_i = 000_0000, empty_o = 1, cnt_o = 6 (mode = 0)
-///   in_i = 000_0001, empty_o = 0, cnt_o = 0 (mode = 0)
-///   in_i = 000_1000, empty_o = 0, cnt_o = 3 (mode = 0)
+///   in_i = 000_0000, empty_o = 1, cnt_o = 6 (mode = TRAILING_ZERO_CNT)
+///   in_i = 000_0001, empty_o = 0, cnt_o = 0 (mode = TRAILING_ZERO_CNT)
+///   in_i = 000_1000, empty_o = 0, cnt_o = 3 (mode = TRAILING_ZERO_CNT)
 /// Furthermore, this unit contains a more efficient implementation for Verilator (simulation only).
 /// This speeds up simulation significantly.
-module lzc #(
+module lzc import lzc_pkg::*; #(
   /// The width of the input vector.
   parameter int unsigned WIDTH = 2,
-  /// Mode selection: 0 -> trailing zero, 1 -> leading zero
-  parameter bit          MODE  = 1'b0,
+  /// Trailing or leading zero mode selection
+  parameter lzc_mode_e   MODE  = TRAILING_ZERO_CNT,
   /// Dependent parameter. Do **not** change!
   ///
   /// Width of the output signal with the zero count.
@@ -51,7 +51,7 @@ module lzc #(
 
     logic [WIDTH-1:0] in_tmp;
 
-    if (MODE) begin : g_flip
+    if (MODE == LEADING_ZERO_CNT) begin : g_flip
       // Mode 1 (leading zero): flip input vector
       always_comb begin : flip_vector
         for (int unsigned i = 0; i < WIDTH; i++) begin

--- a/src/lzc_pkg.sv
+++ b/src/lzc_pkg.sv
@@ -1,0 +1,16 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Luca Colagrande <colluca@iis.ee.ethz.ch>
+//
+// Contains common defintions for the LZC IP.
+
+package lzc_pkg;
+
+typedef enum logic {
+  TRAILING_ZERO_CNT = 1'b0,
+  LEADING_ZERO_CNT = 1'b1
+} lzc_mode_e;
+
+endpackage : lzc_pkg


### PR DESCRIPTION
Use of an enumerated type enables self-documenting code where this module is instantiated.