### PR TITLE
Add `iomsb`, `min` and `max` functions

### DIFF
--- a/src/cf_math_pkg.sv
+++ b/src/cf_math_pkg.sv
@@ -64,4 +64,9 @@ package cf_math_pkg;
         return (value != 0) && (value & (value - 1)) == 0;
     endfunction
 
+    // Return either the argument minus 1 or 0 if 0; useful for IO vector width declaration
+    function automatic integer unsigned iomsb (input integer unsigned width);
+        return (width != 32'd0) ? unsigned'(width-1) : 32'd0;
+    endfunction
+
 endpackage

--- a/src/cf_math_pkg.sv
+++ b/src/cf_math_pkg.sv
@@ -69,4 +69,21 @@ package cf_math_pkg;
         return (width != 32'd0) ? unsigned'(width-1) : 32'd0;
     endfunction
 
+    /// Returns the maximum between two integers
+    function automatic int max(int a, int b);
+        if (a >= b) begin
+            return a;
+        end
+        return b;
+    endfunction
+
+    /// Returns the minimum between two integers
+    function automatic int min(int a, int b);
+        if (a >= b) begin
+            return b;
+        end
+        return a;
+    endfunction
+
+
 endpackage


### PR DESCRIPTION
I believe this is a more convenient place to have the `iomsb` function, rather than every repo redefining it. Also adding the `min` function used here https://github.com/pulp-platform/cluster_icache/pull/32.