### PR TITLE
cdc_*_tb: Fix mailbox type mismatch

### DIFF
--- a/test/cdc_2phase_tb.sv
+++ b/test/cdc_2phase_tb.sv
@@ -47,7 +47,7 @@ module cdc_2phase_tb;
   end
 
   // Mailbox with expected items on destination side.
-  mailbox #(int) dst_mbox = new();
+  mailbox #(integer) dst_mbox = new();
   int num_sent = 0;
   int num_received = 0;
   int num_failed = 0;

--- a/test/cdc_fifo_tb.sv
+++ b/test/cdc_fifo_tb.sv
@@ -51,7 +51,7 @@ module cdc_fifo_tb;
     cdc_fifo_2phase #(.T(logic [31:0]), .LOG_DEPTH(DEPTH)) i_dut (.*);
 
   // Mailbox with expected items on destination side.
-  mailbox #(int) dst_mbox = new();
+  mailbox #(integer) dst_mbox = new();
   int num_sent = 0;
   int num_received = 0;
   int num_failed = 0;


### PR DESCRIPTION
In both testbenches, `dst_mbox` is defined as `int` type but populated and read via `integer` variables. Hence, change the mailbox type to `integer`. Fixes a slang error (`argument of type 'integer' connects to 'ref' port of inequivalent type 'int'`)