### PR TITLE
Bender.yml: Exclude sram.sv when targeting CVA6

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -117,7 +117,7 @@ sources:
       # Level 4
       - src/mem_to_banks.sv
 
-  - target: all(simulation, not(verilator))
+  - target: all(simulation, not(verilator), not(cva6))
     files:
       - src/deprecated/sram.sv
 


### PR DESCRIPTION
CVA6 comes with its own `sram` module definition. Fixes a slang error.