### PR TITLE
Add missing assertion guards to align with common_cells convention

### DIFF
--- a/src/credit_counter.sv
+++ b/src/credit_counter.sv
@@ -48,8 +48,10 @@ module credit_counter #(
   assign credit_left_o  = (credit_q != '0);
   assign credit_crit_o  = (credit_q == NumCredits-1);
   assign credit_full_o  = (credit_q == NumCredits);
-
+  
+  `ifndef COMMON_CELLS_ASSERTS_OFF
   `ASSERT_NEVER(CreditUnderflow, credit_o == '0 && decrement)
   `ASSERT_NEVER(CreditOverflow, credit_o == NumCredits && increment)
+  `endif
 
 endmodule

--- a/src/passthrough_stream_fifo.sv
+++ b/src/passthrough_stream_fifo.sv
@@ -114,9 +114,11 @@ module passthrough_stream_fifo #(
 
     `FFL(data_q, data_d, load_data, '0, clk_i, rst_ni)
 
+    `ifndef COMMON_CELLS_ASSERTS_OFF
     // no full push
     `ASSERT_NEVER(CheckFullPush, (!ready_o & valid_i), clk_i, !rst_ni)
     // empty pop
     `ASSERT_NEVER(CheckEmptyPop, (!valid_o & ready_i), clk_i, !rst_ni)
-
+    `endif
+    
 endmodule

--- a/src/ring_buffer.sv
+++ b/src/ring_buffer.sv
@@ -131,6 +131,7 @@ module ring_buffer #(
             max_step = Depth - rptr_q[AddrWidth-1:0] + wptr_d[AddrWidth-1:0];
     end
 
+    `ifndef COMMON_CELLS_ASSERTS_OFF
     // Read pointer should not overtake write pointer.
     `ASSERT(
         ReadPtrOvertakesWritePtr,
@@ -169,5 +170,6 @@ module ring_buffer #(
 
     // Currently only power-of-2 depths are supported, could be loosened in future
     `ASSERT_INIT(CheckDepthPow2, cf_math_pkg::is_power_of_2(Depth))
+    `endif
 
 endmodule


### PR DESCRIPTION
Add missing `ifndef COMMON_CELLS_ASSERTS_OFF` on:
- `credit_counter` 
- `passthrough_stream_fifo` 
- `ring_buffer`

aligning with all other `common_cells` modules.