### PR TITLE
Convert integer parameters to int unsigned

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ vcs-elab:
 sg-lint:
   timeout: 30min
   script:
-    - make sg-lint
+    - make sg-lint -j 4
 
 .test-tpl:
   needs:

--- a/src/cc_binary_to_gray.sv
+++ b/src/cc_binary_to_gray.sv
@@ -13,7 +13,7 @@
 
 /// A binary to gray code converter.
 module cc_binary_to_gray #(
-    parameter int N = -1
+    parameter int unsigned N = 0
 )(
     input  logic [N-1:0] A,
     output logic [N-1:0] Z

--- a/src/cc_binary_to_gray.sv
+++ b/src/cc_binary_to_gray.sv
@@ -13,7 +13,7 @@
 
 /// A binary to gray code converter.
 module cc_binary_to_gray #(
-    parameter int unsigned N = 0
+    parameter int unsigned N = 1
 )(
     input  logic [N-1:0] A,
     output logic [N-1:0] Z

--- a/src/cc_cdc_2phase_clearable.sv
+++ b/src/cc_cdc_2phase_clearable.sv
@@ -54,7 +54,7 @@
 module cc_cdc_2phase_clearable #(
   parameter type T = logic,
   parameter int unsigned SYNC_STAGES = 3,
-  parameter int CLEAR_ON_ASYNC_RESET = 1
+  parameter bit CLEAR_ON_ASYNC_RESET = 1
 )(
   input  logic src_rst_ni,
   input  logic src_clk_i,

--- a/src/cc_cdc_fifo_2phase.sv
+++ b/src/cc_cdc_fifo_2phase.sv
@@ -48,7 +48,7 @@ module cc_cdc_fifo_2phase #(
   /// The data type of the payload transported by the FIFO.
   parameter type T = logic,
   /// The FIFO's depth given as 2**LOG_DEPTH.
-  parameter int LOG_DEPTH = 3
+  parameter int unsigned LOG_DEPTH = 3
 )(
   input  logic src_rst_ni,
   input  logic src_clk_i,
@@ -68,7 +68,7 @@ module cc_cdc_fifo_2phase #(
   `ASSERT_INIT(log_depth_0, LOG_DEPTH > 0)
   `endif
 
-  localparam int PtrWidth = LOG_DEPTH+1;
+  localparam int unsigned PtrWidth = LOG_DEPTH+1;
   typedef logic [PtrWidth-1:0] pointer_t;
   typedef logic [LOG_DEPTH-1:0] index_t;
 

--- a/src/cc_cdc_fifo_gray.sv
+++ b/src/cc_cdc_fifo_gray.sv
@@ -106,9 +106,9 @@ module cc_cdc_fifo_gray #(
   /// The data type of the payload transported by the FIFO.
   parameter type T = logic [WIDTH-1:0],
   /// The FIFO's depth given as 2**LOG_DEPTH.
-  parameter int LOG_DEPTH = 3,
+  parameter int unsigned LOG_DEPTH = 3,
   /// The number of synchronization registers to insert on the async pointers.
-  parameter int SYNC_STAGES = 2
+  parameter int unsigned SYNC_STAGES = 2
 ) (
   input  logic src_rst_ni,
   input  logic src_clk_i,
@@ -170,8 +170,8 @@ endmodule
 (* no_boundary_optimization *)
 module cc_cdc_fifo_gray_src #(
   parameter type T = logic,
-  parameter int LOG_DEPTH = 3,
-  parameter int SYNC_STAGES = 2
+  parameter int unsigned LOG_DEPTH = 3,
+  parameter int unsigned SYNC_STAGES = 2
 )(
   input  logic src_rst_ni,
   input  logic src_clk_i,
@@ -184,7 +184,7 @@ module cc_cdc_fifo_gray_src #(
   input  logic [LOG_DEPTH:0]  async_rptr_i
 );
 
-  localparam int PtrWidth = LOG_DEPTH+1;
+  localparam int unsigned PtrWidth = LOG_DEPTH+1;
   localparam logic [PtrWidth-1:0] PtrFull = (1 << LOG_DEPTH);
 
   T [2**LOG_DEPTH-1:0] data_q, data_d;
@@ -230,8 +230,8 @@ endmodule
 (* no_boundary_optimization *)
 module cc_cdc_fifo_gray_dst #(
   parameter type T = logic,
-  parameter int LOG_DEPTH = 3,
-  parameter int SYNC_STAGES = 2
+  parameter int unsigned LOG_DEPTH = 3,
+  parameter int unsigned SYNC_STAGES = 2
 )(
   input  logic dst_rst_ni,
   input  logic dst_clk_i,
@@ -244,7 +244,7 @@ module cc_cdc_fifo_gray_dst #(
   output logic [LOG_DEPTH:0]  async_rptr_o
 );
 
-  localparam int PtrWidth = LOG_DEPTH+1;
+  localparam int unsigned PtrWidth = LOG_DEPTH+1;
   localparam logic [PtrWidth-1:0] PtrEmpty = '0;
 
   T dst_data;

--- a/src/cc_cdc_fifo_gray_clearable.sv
+++ b/src/cc_cdc_fifo_gray_clearable.sv
@@ -106,13 +106,13 @@ module cc_cdc_fifo_gray_clearable #(
   /// The data type of the payload transported by the FIFO.
   parameter type T = logic [WIDTH-1:0],
   /// The FIFO's depth given as 2**LOG_DEPTH.
-  parameter int LOG_DEPTH = 3,
+  parameter int unsigned LOG_DEPTH = 3,
   /// The number of synchronization registers to insert on the async pointers
   /// between the FIFOs. If CLEAR_ON_ASYNC reset is enabled, we need at least 4
   /// synchronizer stages to provide the clear synchronizer lower latency than
   /// the async reset. I.e. if CLEAR_ON_ASYNC_RESET==1 -> SYNC_STAGES >= 4 else
   /// SYNC_STAGES >= 2.
-  parameter int SYNC_STAGES = 3,
+  parameter int unsigned SYNC_STAGES = 3,
   parameter int CLEAR_ON_ASYNC_RESET = 1
 ) (
   input  logic src_rst_ni,
@@ -267,8 +267,8 @@ endmodule
 (* no_boundary_optimization *)
 module cc_cdc_fifo_gray_src_clearable #(
   parameter type T = logic,
-  parameter int LOG_DEPTH = 3,
-  parameter int SYNC_STAGES = 2
+  parameter int unsigned LOG_DEPTH = 3,
+  parameter int unsigned SYNC_STAGES = 2
 )(
   input  logic src_rst_ni,
   input  logic src_clk_i,
@@ -282,7 +282,7 @@ module cc_cdc_fifo_gray_src_clearable #(
   input  logic [LOG_DEPTH:0]  async_rptr_i
 );
 
-  localparam int PtrWidth = LOG_DEPTH+1;
+  localparam int unsigned PtrWidth = LOG_DEPTH+1;
   localparam logic [PtrWidth-1:0] PtrFull = (1 << LOG_DEPTH);
 
   T [2**LOG_DEPTH-1:0] data_q, data_d;
@@ -327,8 +327,8 @@ endmodule
 (* no_boundary_optimization *)
 module cc_cdc_fifo_gray_dst_clearable #(
   parameter type T = logic,
-  parameter int LOG_DEPTH = 3,
-  parameter int SYNC_STAGES = 2
+  parameter int unsigned LOG_DEPTH = 3,
+  parameter int unsigned SYNC_STAGES = 2
 )(
   input  logic dst_rst_ni,
   input  logic dst_clk_i,
@@ -342,7 +342,7 @@ module cc_cdc_fifo_gray_dst_clearable #(
   output logic [LOG_DEPTH:0]  async_rptr_o
 );
 
-  localparam int PtrWidth = LOG_DEPTH+1;
+  localparam int unsigned PtrWidth = LOG_DEPTH+1;
   localparam logic [PtrWidth-1:0] PtrEmpty = '0;
 
   T dst_data;

--- a/src/cc_cdc_fifo_gray_clearable.sv
+++ b/src/cc_cdc_fifo_gray_clearable.sv
@@ -113,7 +113,7 @@ module cc_cdc_fifo_gray_clearable #(
   /// the async reset. I.e. if CLEAR_ON_ASYNC_RESET==1 -> SYNC_STAGES >= 4 else
   /// SYNC_STAGES >= 2.
   parameter int unsigned SYNC_STAGES = 3,
-  parameter int CLEAR_ON_ASYNC_RESET = 1
+  parameter bit CLEAR_ON_ASYNC_RESET = 1
 ) (
   input  logic src_rst_ni,
   input  logic src_clk_i,

--- a/src/cc_gray_to_binary.sv
+++ b/src/cc_gray_to_binary.sv
@@ -13,7 +13,7 @@
 
 /// A gray code to binary converter.
 module cc_gray_to_binary #(
-    parameter int unsigned N = 0
+    parameter int unsigned N = 1
 )(
     input  logic [N-1:0] A,
     output logic [N-1:0] Z

--- a/src/cc_gray_to_binary.sv
+++ b/src/cc_gray_to_binary.sv
@@ -13,7 +13,7 @@
 
 /// A gray code to binary converter.
 module cc_gray_to_binary #(
-    parameter int N = -1
+    parameter int unsigned N = 0
 )(
     input  logic [N-1:0] A,
     output logic [N-1:0] Z

--- a/src/cc_id_queue.sv
+++ b/src/cc_id_queue.sv
@@ -48,11 +48,11 @@
 `include "common_cells/assertions.svh"
 
 module cc_id_queue #(
-    parameter int ID_WIDTH  = 1,
-    parameter int CAPACITY  = 1,
+    parameter int unsigned ID_WIDTH  = 1,
+    parameter int unsigned CAPACITY  = 1,
     parameter bit FULL_BW   = 0,
     parameter bit CUT_OUP_POP_INP_GNT = 0,
-    parameter int NUM_CMP_PORTS = 1,
+    parameter int unsigned NUM_CMP_PORTS = 1,
     parameter type data_t   = logic[31:0],
     // Dependent parameters, DO NOT OVERRIDE!
     localparam type id_t    = logic[ID_WIDTH-1:0]
@@ -84,8 +84,8 @@ module cc_id_queue #(
 
     // Capacity of the head-tail table, which associates an ID with corresponding head and tail
     // indices.
-    localparam int NIds = 2**ID_WIDTH;
-    localparam int HtCapacity = (NIds <= CAPACITY) ? NIds : CAPACITY;
+    localparam int unsigned NIds = 2**ID_WIDTH;
+    localparam int unsigned HtCapacity = (NIds <= CAPACITY) ? NIds : CAPACITY;
     localparam int unsigned HtIdxWidth = cc_pkg::idx_width(HtCapacity);
     localparam int unsigned LdIdxWidth = cc_pkg::idx_width(CAPACITY);
 

--- a/src/cc_onehot.sv
+++ b/src/cc_onehot.sv
@@ -25,7 +25,7 @@ module cc_onehot #(
   if (Width == 1) begin : gen_degenerated_onehot
     assign is_onehot_o = d_i;
   end else begin : gen_onehot
-    localparam int LVLS = $clog2(Width) + 1;
+    localparam int unsigned LVLS = $clog2(Width) + 1;
 
     logic [LVLS-1:0][2**(LVLS-1)-1:0] sum, carry;
     logic [LVLS-2:0] carry_array;

--- a/src/cc_stream_arbiter.sv
+++ b/src/cc_stream_arbiter.sv
@@ -15,7 +15,7 @@
 
 module cc_stream_arbiter #(
     parameter type      DATA_T = logic,   // Vivado requires a default value for type parameters.
-    parameter integer   N_INP = 1,        // Synopsys DC requires a default value for parameters.
+    parameter int unsigned N_INP = 1,     // Synopsys DC requires a default value for parameters.
     parameter           ARBITER = "rr"    // "rr" or "prio"
 ) (
     input  logic              clk_i,

--- a/src/cc_stream_arbiter_flushable.sv
+++ b/src/cc_stream_arbiter_flushable.sv
@@ -15,7 +15,7 @@
 
 module cc_stream_arbiter_flushable #(
     parameter type      DATA_T = logic,   // Vivado requires a default value for type parameters.
-    parameter integer   N_INP = 1,        // Synopsys DC requires a default value for parameters.
+    parameter int unsigned N_INP = 1,     // Synopsys DC requires a default value for parameters.
     parameter           ARBITER = "rr"    // "rr" or "prio"
 ) (
     input  logic              clk_i,

--- a/src/cc_stream_delay.sv
+++ b/src/cc_stream_delay.sv
@@ -12,10 +12,10 @@
 // Description: Delay (or randomize) AXI-like handshaking
 
 module cc_stream_delay #(
-    parameter bit   StallRandom = 0,
-    parameter int   FixedDelay  = 1,
-    parameter type  payload_t  = logic,
-    parameter logic [15:0] Seed = '0
+    parameter bit          StallRandom = 0,
+    parameter int unsigned FixedDelay  = 1,
+    parameter type         payload_t   = logic,
+    parameter logic [15:0] Seed        = '0
 )(
     input  logic     clk_i,
     input  logic     rst_ni,

--- a/src/cc_stream_mux.sv
+++ b/src/cc_stream_mux.sv
@@ -15,9 +15,9 @@
 
 module cc_stream_mux #(
   parameter type DATA_T = logic,  // Vivado requires a default value for type parameters.
-  parameter integer N_INP = 0,    // Synopsys DC requires a default value for value parameters.
+  parameter int unsigned N_INP = 1,    // Synopsys DC requires a default value for value parameters.
   /// Dependent parameters, DO NOT OVERRIDE!
-  localparam integer SEL_WIDTH = cc_pkg::idx_width(N_INP)
+  localparam int unsigned SEL_WIDTH = cc_pkg::idx_width(N_INP)
 ) (
   input  DATA_T [N_INP-1:0]     inp_data_i,
   input  logic  [N_INP-1:0]     inp_valid_i,

--- a/src/cc_stream_omega_net.sv
+++ b/src/cc_stream_omega_net.sv
@@ -32,14 +32,14 @@ module cc_stream_omega_net #(
   /// Adds a spill register stage at each output.
   parameter bit          SpillReg = 1'b0,
   /// Use external priority for the individual `rr_arb_trees`.
-  parameter int unsigned ExtPrio     = 1'b0,
+  parameter bit          ExtPrio     = 1'b0,
   /// Use strict AXI valid ready handshaking.
   /// To be protocol conform also the parameter `LockIn` has to be set.
-  parameter int unsigned AxiVldRdy   = 1'b1,
+  parameter bit          AxiVldRdy   = 1'b1,
   /// Lock in the arbitration decision of the `cc_rr_arb_tree`.
   /// When this is set, valids have to be asserted until the corresponding transaction is indicated
   /// by ready.
-  parameter int unsigned LockIn      = 1'b1,
+  parameter bit          LockIn      = 1'b1,
   /// If `AxiVldReady` is 1, which bits of the payload to check for stability on valid inputs.
   /// In some cases, we may want to allow parts of the payload to change depending on the value of
   /// other parts (e.g. write data in read requests), requiring more nuanced external assertions.

--- a/src/cc_stream_xbar.sv
+++ b/src/cc_stream_xbar.sv
@@ -27,14 +27,14 @@ module cc_stream_xbar #(
   /// Adds a spill register stage at each output.
   parameter bit          OutSpillReg = 1'b0,
   /// Use external priority for the individual `rr_arb_trees`.
-  parameter int unsigned ExtPrio     = 1'b0,
+  parameter bit          ExtPrio     = 1'b0,
   /// Use strict AXI valid ready handshaking.
   /// To be protocol conform also the parameter `LockIn` has to be set.
-  parameter int unsigned AxiVldRdy   = 1'b1,
+  parameter bit          AxiVldRdy   = 1'b1,
   /// Lock in the arbitration decision of the `cc_rr_arb_tree`.
   /// When this is set, valids have to be asserted until the corresponding transaction is indicated
   /// by ready.
-  parameter int unsigned LockIn      = 1'b1,
+  parameter bit          LockIn      = 1'b1,
   /// If `AxiVldReady` is 1, which bits of the payload to check for stability on valid inputs.
   /// In some cases, we may want to allow parts of the payload to change depending on the value of
   /// other parts (e.g. write data in read requests), requiring more nuanced external assertions.


### PR DESCRIPTION
- Address https://github.com/pulp-platform/common_cells/issues/309, replacing `parameter integer` and `localparam integer` with `parameter int unsigned` / `localparam int unsigned`
- Add `unsigned` to all int parameters that do not represent signed quantities
- Convert boolean parameters from `int` to `bit` type
- Parallelizes the spyglass CI tests to meet timeout

**TODO:**
- [x] merge after https://github.com/pulp-platform/common_cells/pull/308