### PR TITLE
Refactor cdc_2phase_clearable clock domains

### DIFF
--- a/formal/cc_cdc_reset_ctrlr_half_properties.sv
+++ b/formal/cc_cdc_reset_ctrlr_half_properties.sv
@@ -89,6 +89,8 @@ module cc_cdc_reset_ctrlr_half_properties #(
 
   logic init_q = 1'b0;
 
+  // Reset modeling: force the first sampled cycle into reset so the proof starts
+  // from a reachable reset-controller half state.
   always_ff @(posedge clk_i) begin
     init_q <= 1'b1;
     if (!init_q) begin
@@ -96,6 +98,8 @@ module cc_cdc_reset_ctrlr_half_properties #(
     end
   end
 
+  // Combinational contract: These checks tie the public clear/isolate
+  // outputs to the initiator/receiver halves and validate receiver phase decode.
   always_comb begin
     if (!rst_ni) begin
       if (CLEAR_ON_ASYNC_RESET) begin
@@ -180,6 +184,8 @@ module cc_cdc_reset_ctrlr_half_properties #(
     end
   end
 
+  // Sequential local-state checks. These assert the output contract of each
+  // initiator state and require stalled receiver phases to stay stable.
   always_ff @(posedge clk_i) begin
     if (rst_ni && init_q) begin
       if (receiver_phase_req && !receiver_phase_ack) begin
@@ -241,6 +247,8 @@ module cc_cdc_reset_ctrlr_half_properties #(
       end
     end
 
+    // Initiator transition relation: the next state must match the previous
+    // clear request, phase-CDC acknowledgement, and local isolate/clear ack.
     if (rst_ni && $past(rst_ni) && init_q) begin
       case ($past(initiator_state_q))
         InitIdle: begin
@@ -300,6 +308,8 @@ module cc_cdc_reset_ctrlr_half_properties #(
       endcase
     end
 
+    // Cover the main local and remote clear phases
+    // so bounded runs exercise both sides of the bidirectional half.
     cover (rst_ni && initiator_state_q == InitClear);
     cover (rst_ni && initiator_state_q == InitPostClear);
     cover (rst_ni && receiver_phase_q == PhaseClear);

--- a/formal/cc_cdc_reset_ctrlr_properties.sv
+++ b/formal/cc_cdc_reset_ctrlr_properties.sv
@@ -69,6 +69,8 @@ module cc_cdc_reset_ctrlr_composed_harness (
     .b_isolate_ack_i ( b_isolate_ack_q )
   );
 
+  // Each clock domain is independently initialized in reset, then held out of
+  // reset so the proof focuses on the synchronous clear sequence.
   always_ff @(posedge a_clk_i) begin
     a_init_q <= 1'b1;
     if (!a_init_q) begin
@@ -97,6 +99,8 @@ module cc_cdc_reset_ctrlr_composed_harness (
     end
   end
 
+  // Local acknowledgement for side A: the connected CDC side reports
+  // isolate and clear completion one A-clock cycle after the request.
   always_ff @(posedge a_clk_i, negedge a_rst_ni) begin
     if (!a_rst_ni) begin
       a_isolate_ack_q <= 1'b0;
@@ -107,6 +111,8 @@ module cc_cdc_reset_ctrlr_composed_harness (
     end
   end
 
+  // Local acknowledgement for side B mirrors side A, but is sampled on the
+  // independent B clock to preserve the two-domain composition.
   always_ff @(posedge b_clk_i, negedge b_rst_ni) begin
     if (!b_rst_ni) begin
       b_isolate_ack_q <= 1'b0;
@@ -117,6 +123,8 @@ module cc_cdc_reset_ctrlr_composed_harness (
     end
   end
 
+  // Cross-domain contract: clear implies isolate locally, and any active
+  // clear on either side requires both sides to be isolated.
   always_comb begin
     if (a_rst_ni) begin
       assert (!a_clear_o || a_isolate_o);

--- a/src/cc_cdc_2phase_clearable.sv
+++ b/src/cc_cdc_2phase_clearable.sv
@@ -21,7 +21,12 @@
 /// A two-phase clock domain crossing.
 ///
 /// CONSTRAINT: Requires max_delay of min_period(src_clk_i, dst_clk_i) through
-/// the paths async_req, async_ack, async_data.
+/// all asynchronous paths between the domains. The payload CDC uses
+/// async_payload_req, async_payload_ack, and async_payload_data for the actual
+/// data handshake. The clear sequencer CDCs use async_reset_src2dst_req,
+/// async_reset_dst2src_ack, async_reset_src2dst_next_phase,
+/// async_reset_dst2src_req, async_reset_src2dst_ack, and
+/// async_reset_dst2src_next_phase to handshake the clearing state machines.
 ///
 ///
 /// Reset Behavior:
@@ -201,6 +206,16 @@ module cc_cdc_2phase_dst_domain_clearable #(
   logic dst_isolate_ack_q;
   logic dst_valid;
 
+  if (ClearOnAsyncReset) begin : gen_elaboration_assertion
+    if (SyncStages < 3)
+      $error("The clearable 2-phase CDC with async reset",
+             "synchronization requires at least 3 synchronizer stages for the FIFO.");
+  end else begin : gen_elaboration_assertion
+    if (SyncStages < 2) begin : gen_sync_stage_assertion
+      $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+    end
+  end
+
   // Keep the clear-control path one synchronizer stage ahead of the payload CDC
   // when async reset propagation is enabled, but never below two stages.
   localparam int unsigned ResetSyncStages = (SyncStages > 2) ? SyncStages - 1 : 2;
@@ -286,6 +301,16 @@ module cc_cdc_2phase_src_domain_clearable #(
   logic src_ready;
   logic src_isolate_req;
   logic src_isolate_ack_q;
+
+  if (ClearOnAsyncReset) begin : gen_elaboration_assertion
+    if (SyncStages < 3)
+      $error("The clearable 2-phase CDC with async reset",
+             "synchronization requires at least 3 synchronizer stages for the FIFO.");
+  end else begin : gen_elaboration_assertion
+    if (SyncStages < 2) begin : gen_sync_stage_assertion
+      $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+    end
+  end
 
   // Keep the clear-control path one synchronizer stage ahead of the payload CDC
   // when async reset propagation is enabled, but never below two stages.

--- a/src/cc_cdc_2phase_clearable.sv
+++ b/src/cc_cdc_2phase_clearable.sv
@@ -12,7 +12,7 @@
 // Authors:
 // - Fabian Schuiki <fschuiki@iis.ee.ethz.ch> (original CDC)
 // - Manuel Eggimann <meggimann@iis.ee.ethz.ch> (clearability feature)
-// - Philippe Sauter <phsauter@iis.ee.ethz.ch> (verification)
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch> (source/destination split)
 //
 // Description: Clearable Two-Phase CDC
 // Transfer payloads with a two-phase handshake while coordinating synchronous
@@ -78,21 +78,18 @@ module cc_cdc_2phase_clearable #(
   output logic  dst_valid_o,
   input  logic  dst_ready_i
 );
-  logic        s_src_clear_req;
-  logic        s_src_clear_ack_q;
-  logic        s_src_ready;
-  logic        s_src_isolate_req;
-  logic        s_src_isolate_ack_q;
-  logic        s_dst_clear_req;
-  logic        s_dst_clear_ack_q;
-  logic        s_dst_valid;
-  logic        s_dst_isolate_req;
-  logic        s_dst_isolate_ack_q;
+  // Asynchronous payload handshake signals between the source and destination.
+  (* dont_touch = "true" *) logic async_payload_req;
+  (* dont_touch = "true" *) logic async_payload_ack;
+  (* dont_touch = "true" *) data_t async_payload_data;
 
-  // Asynchronous handshake signals between the CDCs
-  (* dont_touch = "true" *) logic  async_req;
-  (* dont_touch = "true" *) logic  async_ack;
-  (* dont_touch = "true" *) data_t async_data;
+  // Asynchronous clear-controller phase handshakes between the domains.
+  (* dont_touch = "true" *) logic async_reset_src2dst_req;
+  (* dont_touch = "true" *) logic async_reset_dst2src_ack;
+  (* dont_touch = "true" *) cc_pkg::cdc_clear_seq_phase_e async_reset_src2dst_next_phase;
+  (* dont_touch = "true" *) logic async_reset_dst2src_req;
+  (* dont_touch = "true" *) logic async_reset_src2dst_ack;
+  (* dont_touch = "true" *) cc_pkg::cdc_clear_seq_phase_e async_reset_dst2src_next_phase;
 
   // Clear/isolate contract:
   // - src/dst_clear_pending_o are the local isolate requests.
@@ -114,99 +111,236 @@ module cc_cdc_2phase_clearable #(
   end
 
 
-  // The sender in the source domain.
-  cc_cdc_2phase_src_clearable #(
-    .data_t      ( data_t     ),
-    .SyncStages  ( SyncStages )
-  ) i_src (
-    .rst_ni       ( src_rst_ni                       ),
-    .clk_i        ( src_clk_i                        ),
-    .clear_i      ( s_src_clear_req                      ),
-    .data_i       ( src_data_i                       ),
-    .valid_i      ( src_valid_i & !s_src_isolate_req ),
-    .ready_o      ( s_src_ready                      ),
-    .async_req_o  ( async_req                        ),
-    .async_ack_i  ( async_ack                        ),
-    .async_data_o ( async_data                       )
-  );
-
-  assign src_ready_o = s_src_ready & !s_src_isolate_req;
-
-
-  // The receiver in the destination domain.
-  cc_cdc_2phase_dst_clearable #(
-    .data_t      ( data_t     ),
-    .SyncStages  ( SyncStages )
-  ) i_dst (
-    .rst_ni       ( dst_rst_ni                       ),
-    .clk_i        ( dst_clk_i                        ),
-    .clear_i      ( s_dst_clear_req                      ),
-    .data_o       ( dst_data_o                       ),
-    .valid_o      ( s_dst_valid                      ),
-    .ready_i      ( dst_ready_i & !s_dst_isolate_req ),
-    .async_req_i  ( async_req                        ),
-    .async_ack_o  ( async_ack                        ),
-    .async_data_i ( async_data                       )
-  );
-
-  assign dst_valid_o = s_dst_valid & !s_dst_isolate_req;
-
-  // Synchronize the clear and reset signaling in both directions (see header of
-  // the cc_cdc_reset_ctrlr module for more details.)
-  cc_cdc_reset_ctrlr #(
-    .SyncStages        ( SyncStages - 1    ),
+  // The source-domain wrapper owns the payload CDC half, local clear/isolate
+  // acknowledgements, and the local reset-controller half.
+  cc_cdc_2phase_src_domain_clearable #(
+    .data_t            ( data_t            ),
+    .SyncStages        ( SyncStages        ),
     .ClearOnAsyncReset ( ClearOnAsyncReset )
-  ) i_cdc_reset_ctrlr (
-    .a_clk_i         ( src_clk_i           ),
-    .a_rst_ni        ( src_rst_ni          ),
-    .a_clear_i       ( src_clear_i         ),
-    .a_clear_o       ( s_src_clear_req     ),
-    .a_clear_ack_i   ( s_src_clear_ack_q   ),
-    .a_isolate_o     ( s_src_isolate_req   ),
-    .a_isolate_ack_i ( s_src_isolate_ack_q ),
-    .b_clk_i         ( dst_clk_i           ),
-    .b_rst_ni        ( dst_rst_ni          ),
-    .b_clear_i       ( dst_clear_i         ),
-    .b_clear_o       ( s_dst_clear_req     ),
-    .b_clear_ack_i   ( s_dst_clear_ack_q   ),
-    .b_isolate_o     ( s_dst_isolate_req   ),
-    .b_isolate_ack_i ( s_dst_isolate_ack_q )
+  ) i_src_domain (
+    .src_rst_ni                ( src_rst_ni                     ),
+    .src_clk_i                 ( src_clk_i                      ),
+    .src_clear_i               ( src_clear_i                    ),
+    .src_clear_pending_o       ( src_clear_pending_o            ),
+    .src_data_i                ( src_data_i                     ),
+    .src_valid_i               ( src_valid_i                    ),
+    .src_ready_o               ( src_ready_o                    ),
+    (* async *) .async_payload_req_o  ( async_payload_req  ),
+    (* async *) .async_payload_ack_i  ( async_payload_ack  ),
+    (* async *) .async_payload_data_o ( async_payload_data ),
+    (* async *) .async_reset_next_phase_o ( async_reset_src2dst_next_phase ),
+    (* async *) .async_reset_req_o        ( async_reset_src2dst_req        ),
+    (* async *) .async_reset_ack_i        ( async_reset_dst2src_ack        ),
+    (* async *) .async_reset_next_phase_i ( async_reset_dst2src_next_phase ),
+    (* async *) .async_reset_req_i        ( async_reset_dst2src_req        ),
+    (* async *) .async_reset_ack_o        ( async_reset_src2dst_ack        )
   );
 
-  // Just delay the isolate request by one cycle. We can ensure isolation within
-  // one cycle by just deasserting valid and ready signals on both sides of the CDC.
-  always_ff @(posedge src_clk_i, negedge src_rst_ni) begin
-    if (!src_rst_ni) begin
-      s_src_isolate_ack_q <= 1'b0;
-      s_src_clear_ack_q   <= 1'b0;
-    end else begin
-      s_src_isolate_ack_q <= s_src_isolate_req;
-      s_src_clear_ack_q   <= s_src_clear_req;
-    end
-  end
 
-  always_ff @(posedge dst_clk_i, negedge dst_rst_ni) begin
-    if (!dst_rst_ni) begin
-      s_dst_isolate_ack_q <= 1'b0;
-      s_dst_clear_ack_q   <= 1'b0;
-    end else begin
-      s_dst_isolate_ack_q <= s_dst_isolate_req;
-      s_dst_clear_ack_q   <= s_dst_clear_req;
-    end
-  end
-
-
-  assign src_clear_pending_o = s_src_isolate_req; // The isolate signal stays
-  // asserted during the whole
-  // clear sequence.
-  assign dst_clear_pending_o = s_dst_isolate_req;
-
+  // The destination-domain wrapper owns the payload CDC half, local
+  // clear/isolate acknowledgements, and the local reset-controller half.
+  cc_cdc_2phase_dst_domain_clearable #(
+    .data_t            ( data_t            ),
+    .SyncStages        ( SyncStages        ),
+    .ClearOnAsyncReset ( ClearOnAsyncReset )
+  ) i_dst_domain (
+    .dst_rst_ni                ( dst_rst_ni                     ),
+    .dst_clk_i                 ( dst_clk_i                      ),
+    .dst_clear_i               ( dst_clear_i                    ),
+    .dst_clear_pending_o       ( dst_clear_pending_o            ),
+    .dst_data_o                ( dst_data_o                     ),
+    .dst_valid_o               ( dst_valid_o                    ),
+    .dst_ready_i               ( dst_ready_i                    ),
+    (* async *) .async_payload_req_i  ( async_payload_req  ),
+    (* async *) .async_payload_ack_o  ( async_payload_ack  ),
+    (* async *) .async_payload_data_i ( async_payload_data ),
+    (* async *) .async_reset_next_phase_o ( async_reset_dst2src_next_phase ),
+    (* async *) .async_reset_req_o        ( async_reset_dst2src_req        ),
+    (* async *) .async_reset_ack_i        ( async_reset_src2dst_ack        ),
+    (* async *) .async_reset_next_phase_i ( async_reset_src2dst_next_phase ),
+    (* async *) .async_reset_req_i        ( async_reset_src2dst_req        ),
+    (* async *) .async_reset_ack_o        ( async_reset_dst2src_ack        )
+  );
 
 `ifndef COMMON_CELLS_ASSERTS_OFF
 
   `ASSERT(no_valid_i_during_clear_i, src_clear_i |-> !src_valid_i, src_clk_i, !src_rst_ni)
 
 `endif
+
+endmodule
+
+
+/// Destination-domain wrapper for the clearable two-phase CDC.
+module cc_cdc_2phase_dst_domain_clearable #(
+  parameter type data_t = logic,
+  parameter int unsigned SyncStages = 2,
+  parameter bit ClearOnAsyncReset = 1
+) (
+  input  logic dst_rst_ni,
+  input  logic dst_clk_i,
+  input  logic dst_clear_i,
+  output logic dst_clear_pending_o,
+  output data_t dst_data_o,
+  output logic dst_valid_o,
+  input  logic dst_ready_i,
+  input  logic async_payload_req_i,
+  output logic async_payload_ack_o,
+  input  data_t async_payload_data_i,
+  output cc_pkg::cdc_clear_seq_phase_e async_reset_next_phase_o,
+  output logic async_reset_req_o,
+  input  logic async_reset_ack_i,
+  input  cc_pkg::cdc_clear_seq_phase_e async_reset_next_phase_i,
+  input  logic async_reset_req_i,
+  output logic async_reset_ack_o
+);
+
+  logic dst_clear_req;
+  logic dst_clear_ack_q;
+  logic dst_isolate_req;
+  logic dst_isolate_ack_q;
+  logic dst_valid;
+
+  // Keep the clear-control path one synchronizer stage ahead of the payload CDC
+  // when async reset propagation is enabled, but never below two stages.
+  localparam int unsigned ResetSyncStages = (SyncStages > 2) ? SyncStages - 1 : 2;
+
+  cc_cdc_reset_ctrlr_half #(
+    .SyncStages        ( ResetSyncStages    ),
+    .ClearOnAsyncReset ( ClearOnAsyncReset )
+  ) i_cdc_reset_ctrlr_half (
+    .clk_i              ( dst_clk_i                  ),
+    .rst_ni             ( dst_rst_ni                 ),
+    .clear_i            ( dst_clear_i                ),
+    .clear_o            ( dst_clear_req              ),
+    .clear_ack_i        ( dst_clear_ack_q            ),
+    .isolate_o          ( dst_isolate_req            ),
+    .isolate_ack_i      ( dst_isolate_ack_q          ),
+    (* async *) .async_next_phase_o ( async_reset_next_phase_o ),
+    (* async *) .async_req_o        ( async_reset_req_o        ),
+    (* async *) .async_ack_i        ( async_reset_ack_i        ),
+    (* async *) .async_next_phase_i ( async_reset_next_phase_i ),
+    (* async *) .async_req_i        ( async_reset_req_i        ),
+    (* async *) .async_ack_o        ( async_reset_ack_o        )
+  );
+
+  cc_cdc_2phase_dst_clearable #(
+    .data_t     ( data_t     ),
+    .SyncStages ( SyncStages )
+  ) i_dst (
+    .rst_ni       ( dst_rst_ni                         ),
+    .clk_i        ( dst_clk_i                          ),
+    .clear_i      ( dst_clear_req                      ),
+    .data_o       ( dst_data_o                         ),
+    .valid_o      ( dst_valid                          ),
+    .ready_i      ( dst_ready_i & !dst_isolate_req     ),
+    (* async *) .async_req_i  ( async_payload_req_i  ),
+    (* async *) .async_ack_o  ( async_payload_ack_o  ),
+    (* async *) .async_data_i ( async_payload_data_i )
+  );
+
+  assign dst_valid_o = dst_valid & !dst_isolate_req;
+
+  // Isolation and clear are acknowledged one cycle after the local request.
+  always_ff @(posedge dst_clk_i, negedge dst_rst_ni) begin
+    if (!dst_rst_ni) begin
+      dst_isolate_ack_q <= 1'b0;
+      dst_clear_ack_q   <= 1'b0;
+    end else begin
+      dst_isolate_ack_q <= dst_isolate_req;
+      dst_clear_ack_q   <= dst_clear_req;
+    end
+  end
+
+  assign dst_clear_pending_o = dst_isolate_req;
+
+endmodule
+
+
+/// Source-domain wrapper for the clearable two-phase CDC.
+module cc_cdc_2phase_src_domain_clearable #(
+  parameter type data_t = logic,
+  parameter int unsigned SyncStages = 2,
+  parameter bit ClearOnAsyncReset = 1
+) (
+  input  logic src_rst_ni,
+  input  logic src_clk_i,
+  input  logic src_clear_i,
+  output logic src_clear_pending_o,
+  input  data_t src_data_i,
+  input  logic src_valid_i,
+  output logic src_ready_o,
+  output logic async_payload_req_o,
+  input  logic async_payload_ack_i,
+  output data_t async_payload_data_o,
+  output cc_pkg::cdc_clear_seq_phase_e async_reset_next_phase_o,
+  output logic async_reset_req_o,
+  input  logic async_reset_ack_i,
+  input  cc_pkg::cdc_clear_seq_phase_e async_reset_next_phase_i,
+  input  logic async_reset_req_i,
+  output logic async_reset_ack_o
+);
+
+  logic src_clear_req;
+  logic src_clear_ack_q;
+  logic src_ready;
+  logic src_isolate_req;
+  logic src_isolate_ack_q;
+
+  // Keep the clear-control path one synchronizer stage ahead of the payload CDC
+  // when async reset propagation is enabled, but never below two stages.
+  localparam int unsigned ResetSyncStages = (SyncStages > 2) ? SyncStages - 1 : 2;
+
+  cc_cdc_reset_ctrlr_half #(
+    .SyncStages        ( ResetSyncStages    ),
+    .ClearOnAsyncReset ( ClearOnAsyncReset )
+  ) i_cdc_reset_ctrlr_half (
+    .clk_i              ( src_clk_i                  ),
+    .rst_ni             ( src_rst_ni                 ),
+    .clear_i            ( src_clear_i                ),
+    .clear_o            ( src_clear_req              ),
+    .clear_ack_i        ( src_clear_ack_q            ),
+    .isolate_o          ( src_isolate_req            ),
+    .isolate_ack_i      ( src_isolate_ack_q          ),
+    (* async *) .async_next_phase_o ( async_reset_next_phase_o ),
+    (* async *) .async_req_o        ( async_reset_req_o        ),
+    (* async *) .async_ack_i        ( async_reset_ack_i        ),
+    (* async *) .async_next_phase_i ( async_reset_next_phase_i ),
+    (* async *) .async_req_i        ( async_reset_req_i        ),
+    (* async *) .async_ack_o        ( async_reset_ack_o        )
+  );
+
+  cc_cdc_2phase_src_clearable #(
+    .data_t     ( data_t     ),
+    .SyncStages ( SyncStages )
+  ) i_src (
+    .rst_ni       ( src_rst_ni                         ),
+    .clk_i        ( src_clk_i                          ),
+    .clear_i      ( src_clear_req                      ),
+    .data_i       ( src_data_i                         ),
+    .valid_i      ( src_valid_i & !src_isolate_req     ),
+    .ready_o      ( src_ready                          ),
+    (* async *) .async_req_o  ( async_payload_req_o  ),
+    (* async *) .async_ack_i  ( async_payload_ack_i  ),
+    (* async *) .async_data_o ( async_payload_data_o )
+  );
+
+  assign src_ready_o = src_ready & !src_isolate_req;
+
+  // Isolation and clear are acknowledged one cycle after the local request.
+  always_ff @(posedge src_clk_i, negedge src_rst_ni) begin
+    if (!src_rst_ni) begin
+      src_isolate_ack_q <= 1'b0;
+      src_clear_ack_q   <= 1'b0;
+    end else begin
+      src_isolate_ack_q <= src_isolate_req;
+      src_clear_ack_q   <= src_clear_req;
+    end
+  end
+
+  assign src_clear_pending_o = src_isolate_req; // The isolate signal stays
+                                                // asserted during the whole
+                                                // clear sequence.
 
 endmodule
 

--- a/test/cc_cdc_2phase_clearable_tb.sv
+++ b/test/cc_cdc_2phase_clearable_tb.sv
@@ -94,6 +94,8 @@ module cc_cdc_2phase_clearable_tb;
 
   dst_ready_mode_e dst_ready_mode = DstReadyLow;
 
+  // Instantiate either the plain DUT or the timed delay-injection harness used
+  // by sweeps to perturb every explicit asynchronous channel.
   if (INJECT_DELAYS) begin : gen_delayed_dut
     cc_cdc_2phase_clearable_tb_delay_injector #(
       .SYNC_STAGES          ( SYNC_STAGES          ),
@@ -157,6 +159,8 @@ module cc_cdc_2phase_clearable_tb;
     endcase
   end
 
+  // Scoreboard source and destination handshakes. During clear/reset windows,
+  // accepted source items are stale: they may later complete or be dropped.
   always @(posedge src_clk_i) begin
     if (!src_rst_ni) begin
       // Reset is handled by the DUT. The scoreboard is controlled by the test
@@ -205,6 +209,8 @@ module cc_cdc_2phase_clearable_tb;
     end
   end
 
+  // Small shared helpers for reporting, cycle waits, and the stale-item window
+  // used whenever a clear/reset may intentionally discard in-flight traffic.
   task automatic report_error(input string msg);
     num_errors++;
     $error("%s", msg);
@@ -281,6 +287,8 @@ module cc_cdc_2phase_clearable_tb;
     drop_window = 1'b0;
   endtask
 
+  // Clear/reset completion helpers. They check that both domains see the
+  // pending sequence and then wait for the CDC to settle before fresh traffic.
   task automatic wait_pending_seen(input bit expect_src, input bit expect_dst, input string test_name);
     bit seen_src;
     bit seen_dst;
@@ -341,6 +349,8 @@ module cc_cdc_2phase_clearable_tb;
     src_valid_i = 1'b0;
   endtask
 
+  // Transfer helpers for normal traffic: send ordered words, wait for the
+  // scoreboard to drain, and verify the source has returned to ready.
   task automatic wait_scoreboard_empty(input string test_name);
     for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
       if (expected_q.size() == 0) begin
@@ -539,6 +549,8 @@ module cc_cdc_2phase_clearable_tb;
                        DstReadyHigh);
   endtask
 
+  // Active-traffic stress keeps a source driver running while randomized
+  // clear/reset events interrupt the CDC from either side.
   task automatic pause_active_source(input string test_name);
     active_src_pause = 1'b1;
     wait_src_cycles(2);
@@ -675,6 +687,7 @@ module cc_cdc_2phase_clearable_tb;
 
     reset_both_domains();
 
+    // Baseline ordered transfer with the destination always ready.
     run_transfer_check("basic fixed-ready transfer", 32, 32'h1000_0000, DstReadyHigh);
 
     // Idle synchronous clears from source, destination, and both domains,
@@ -688,6 +701,8 @@ module cc_cdc_2phase_clearable_tb;
     run_control_event(EventBothClear, "simultaneous synchronous idle clear");
     run_transfer_check("post-simultaneous-clear transfer", 16, 32'h4000_0000, DstReadyHigh);
 
+    // One-sided asynchronous resets are only a cross-domain clear source when
+    // the feature is enabled.
     if (CLEAR_ON_ASYNC_RESET) begin
       run_control_event(EventSrcReset, "source asynchronous idle reset");
       run_transfer_check("post-source-async-reset transfer", 16, 32'h5000_0000, DstReadyHigh);
@@ -714,8 +729,12 @@ module cc_cdc_2phase_clearable_tb;
       run_backpressured_control_check(EventDstReset, 32'hc1ea_8001, 32'hc1ea_9000);
     end
 
+    // Long mixed stress run with random traffic, destination backpressure, and
+    // interleaved source/destination clear or reset events.
     run_active_traffic_stress();
 
+    // Final randomized-ready transfer checks ordinary payload ordering after
+    // all disruptive control-event categories have completed.
     run_transfer_check("randomized ready transfer", NUM_RANDOM_TRANSFERS, 32'h7000_0000,
                        DstReadyRandom);
 
@@ -731,6 +750,8 @@ module cc_cdc_2phase_clearable_tb;
     $finish;
   end
 
+  // Bind a simulation-only monitor into each reset-controller half. It mirrors
+  // the formal invariants to catch invalid internal clear FSM behavior in Questa.
   bind cc_cdc_reset_ctrlr_half cc_cdc_reset_ctrlr_half_monitor i_monitor (
     .clk_i,
     .rst_ni,
@@ -758,6 +779,8 @@ module cc_cdc_2phase_clearable_tb;
 endmodule
 
 
+// Per-bit inertial delay model used to sweep relative async channel timing in
+// simulation without changing the production DUT hierarchy.
 module cc_cdc_2phase_clearable_tb_bit_delay #(
   parameter int unsigned MAX_DELAY_PS = 0
 )(
@@ -781,6 +804,8 @@ module cc_cdc_2phase_clearable_tb_bit_delay #(
 endmodule
 
 
+// Bus delay wrapper that applies independent random per-bit delay. This stresses
+// bundled payload and phase buses under the same async timing assumptions.
 module cc_cdc_2phase_clearable_tb_bus_delay #(
   parameter int unsigned Width = 1,
   parameter int unsigned MAX_DELAY_PS = 0
@@ -804,6 +829,8 @@ module cc_cdc_2phase_clearable_tb_bus_delay #(
 endmodule
 
 
+// Timed test harness equivalent to the clearable DUT, but with explicit delay
+// elements inserted on all payload and reset-controller async wires.
 module cc_cdc_2phase_clearable_tb_delay_injector
   import cc_pkg::*;
 #(
@@ -833,210 +860,155 @@ module cc_cdc_2phase_clearable_tb_delay_injector
 
   localparam int unsigned ClearPhaseWidth = $bits(cdc_clear_seq_phase_e);
 
-  logic        payload_req_from_src;
-  logic        payload_req_to_dst;
-  logic        payload_ack_from_dst;
-  logic        payload_ack_to_src;
-  logic [31:0] payload_data_from_src;
-  logic [31:0] payload_data_to_dst;
+  logic        async_payload_req_from_src;
+  logic        async_payload_req_to_dst;
+  logic        async_payload_ack_from_dst;
+  logic        async_payload_ack_to_src;
+  logic [31:0] async_payload_data_from_src;
+  logic [31:0] async_payload_data_to_dst;
 
-  logic s_src_clear_req;
-  logic s_src_clear_ack_q;
-  logic s_src_ready;
-  logic s_src_isolate_req;
-  logic s_src_isolate_ack_q;
-  logic s_dst_clear_req;
-  logic s_dst_clear_ack_q;
-  logic s_dst_valid;
-  logic s_dst_isolate_req;
-  logic s_dst_isolate_ack_q;
+  cdc_clear_seq_phase_e async_reset_src2dst_next_phase_from_src;
+  cdc_clear_seq_phase_e async_reset_src2dst_next_phase_to_dst;
+  cdc_clear_seq_phase_e async_reset_dst2src_next_phase_from_dst;
+  cdc_clear_seq_phase_e async_reset_dst2src_next_phase_to_src;
+  logic [ClearPhaseWidth-1:0] async_reset_src2dst_next_phase_from_src_bits;
+  logic [ClearPhaseWidth-1:0] async_reset_src2dst_next_phase_to_dst_bits;
+  logic [ClearPhaseWidth-1:0] async_reset_dst2src_next_phase_from_dst_bits;
+  logic [ClearPhaseWidth-1:0] async_reset_dst2src_next_phase_to_src_bits;
+  logic async_reset_src2dst_req_from_src;
+  logic async_reset_src2dst_req_to_dst;
+  logic async_reset_dst2src_ack_from_dst;
+  logic async_reset_dst2src_ack_to_src;
+  logic async_reset_dst2src_req_from_dst;
+  logic async_reset_dst2src_req_to_src;
+  logic async_reset_src2dst_ack_from_src;
+  logic async_reset_src2dst_ack_to_dst;
 
-  cdc_clear_seq_phase_e src2dst_phase_from_src;
-  cdc_clear_seq_phase_e src2dst_phase_to_dst;
-  cdc_clear_seq_phase_e dst2src_phase_from_dst;
-  cdc_clear_seq_phase_e dst2src_phase_to_src;
-  logic [ClearPhaseWidth-1:0] src2dst_phase_from_src_bits;
-  logic [ClearPhaseWidth-1:0] src2dst_phase_to_dst_bits;
-  logic [ClearPhaseWidth-1:0] dst2src_phase_from_dst_bits;
-  logic [ClearPhaseWidth-1:0] dst2src_phase_to_src_bits;
-  logic src2dst_req_from_src;
-  logic src2dst_req_to_dst;
-  logic src2dst_ack_from_dst;
-  logic src2dst_ack_to_src;
-  logic dst2src_req_from_dst;
-  logic dst2src_req_to_src;
-  logic dst2src_ack_from_src;
-  logic dst2src_ack_to_dst;
-
-  assign src2dst_phase_from_src_bits = src2dst_phase_from_src;
-  assign src2dst_phase_to_dst = cdc_clear_seq_phase_e'(src2dst_phase_to_dst_bits);
-  assign dst2src_phase_from_dst_bits = dst2src_phase_from_dst;
-  assign dst2src_phase_to_src = cdc_clear_seq_phase_e'(dst2src_phase_to_src_bits);
+  assign async_reset_src2dst_next_phase_from_src_bits = async_reset_src2dst_next_phase_from_src;
+  assign async_reset_src2dst_next_phase_to_dst =
+      cdc_clear_seq_phase_e'(async_reset_src2dst_next_phase_to_dst_bits);
+  assign async_reset_dst2src_next_phase_from_dst_bits = async_reset_dst2src_next_phase_from_dst;
+  assign async_reset_dst2src_next_phase_to_src =
+      cdc_clear_seq_phase_e'(async_reset_dst2src_next_phase_to_src_bits);
 
   cc_cdc_2phase_clearable_tb_bit_delay #(
     .MAX_DELAY_PS ( MAX_DELAY_PS )
-  ) i_payload_req_delay (
-    .in_i  ( payload_req_from_src ),
-    .out_o ( payload_req_to_dst   )
+  ) i_async_payload_req_delay (
+    .in_i  ( async_payload_req_from_src ),
+    .out_o ( async_payload_req_to_dst   )
   );
 
   cc_cdc_2phase_clearable_tb_bit_delay #(
     .MAX_DELAY_PS ( MAX_DELAY_PS )
-  ) i_payload_ack_delay (
-    .in_i  ( payload_ack_from_dst ),
-    .out_o ( payload_ack_to_src   )
+  ) i_async_payload_ack_delay (
+    .in_i  ( async_payload_ack_from_dst ),
+    .out_o ( async_payload_ack_to_src   )
   );
 
   cc_cdc_2phase_clearable_tb_bus_delay #(
     .Width        ( 32           ),
     .MAX_DELAY_PS ( MAX_DELAY_PS )
-  ) i_payload_data_delay (
-    .in_i  ( payload_data_from_src ),
-    .out_o ( payload_data_to_dst   )
+  ) i_async_payload_data_delay (
+    .in_i  ( async_payload_data_from_src ),
+    .out_o ( async_payload_data_to_dst   )
   );
 
   cc_cdc_2phase_clearable_tb_bus_delay #(
     .Width        ( ClearPhaseWidth ),
     .MAX_DELAY_PS ( MAX_DELAY_PS    )
-  ) i_src2dst_phase_delay (
-    .in_i  ( src2dst_phase_from_src_bits ),
-    .out_o ( src2dst_phase_to_dst_bits   )
+  ) i_async_reset_src2dst_next_phase_delay (
+    .in_i  ( async_reset_src2dst_next_phase_from_src_bits ),
+    .out_o ( async_reset_src2dst_next_phase_to_dst_bits   )
   );
 
   cc_cdc_2phase_clearable_tb_bit_delay #(
     .MAX_DELAY_PS ( MAX_DELAY_PS )
-  ) i_src2dst_req_delay (
-    .in_i  ( src2dst_req_from_src ),
-    .out_o ( src2dst_req_to_dst   )
+  ) i_async_reset_src2dst_req_delay (
+    .in_i  ( async_reset_src2dst_req_from_src ),
+    .out_o ( async_reset_src2dst_req_to_dst   )
   );
 
   cc_cdc_2phase_clearable_tb_bit_delay #(
     .MAX_DELAY_PS ( MAX_DELAY_PS )
-  ) i_src2dst_ack_delay (
-    .in_i  ( src2dst_ack_from_dst ),
-    .out_o ( src2dst_ack_to_src   )
+  ) i_async_reset_dst2src_ack_delay (
+    .in_i  ( async_reset_dst2src_ack_from_dst ),
+    .out_o ( async_reset_dst2src_ack_to_src   )
   );
 
   cc_cdc_2phase_clearable_tb_bus_delay #(
     .Width        ( ClearPhaseWidth ),
     .MAX_DELAY_PS ( MAX_DELAY_PS    )
-  ) i_dst2src_phase_delay (
-    .in_i  ( dst2src_phase_from_dst_bits ),
-    .out_o ( dst2src_phase_to_src_bits   )
+  ) i_async_reset_dst2src_next_phase_delay (
+    .in_i  ( async_reset_dst2src_next_phase_from_dst_bits ),
+    .out_o ( async_reset_dst2src_next_phase_to_src_bits   )
   );
 
   cc_cdc_2phase_clearable_tb_bit_delay #(
     .MAX_DELAY_PS ( MAX_DELAY_PS )
-  ) i_dst2src_req_delay (
-    .in_i  ( dst2src_req_from_dst ),
-    .out_o ( dst2src_req_to_src   )
+  ) i_async_reset_dst2src_req_delay (
+    .in_i  ( async_reset_dst2src_req_from_dst ),
+    .out_o ( async_reset_dst2src_req_to_src   )
   );
 
   cc_cdc_2phase_clearable_tb_bit_delay #(
     .MAX_DELAY_PS ( MAX_DELAY_PS )
-  ) i_dst2src_ack_delay (
-    .in_i  ( dst2src_ack_from_src ),
-    .out_o ( dst2src_ack_to_dst   )
+  ) i_async_reset_src2dst_ack_delay (
+    .in_i  ( async_reset_src2dst_ack_from_src ),
+    .out_o ( async_reset_src2dst_ack_to_dst   )
   );
 
-  cc_cdc_2phase_src_clearable #(
-    .data_t     ( logic [31:0] ),
-    .SyncStages ( SYNC_STAGES  )
-  ) i_src (
-    .rst_ni       ( src_rst_ni                     ),
-    .clk_i        ( src_clk_i                      ),
-    .clear_i      ( s_src_clear_req                ),
-    .data_i       ( src_data_i                     ),
-    .valid_i      ( src_valid_i & !s_src_isolate_req ),
-    .ready_o      ( s_src_ready                    ),
-    .async_req_o  ( payload_req_from_src           ),
-    .async_ack_i  ( payload_ack_to_src             ),
-    .async_data_o ( payload_data_from_src          )
-  );
-
-  assign src_ready_o = s_src_ready & !s_src_isolate_req;
-
-  cc_cdc_2phase_dst_clearable #(
-    .data_t     ( logic [31:0] ),
-    .SyncStages ( SYNC_STAGES  )
-  ) i_dst (
-    .rst_ni       ( dst_rst_ni                     ),
-    .clk_i        ( dst_clk_i                      ),
-    .clear_i      ( s_dst_clear_req                ),
-    .data_o       ( dst_data_o                     ),
-    .valid_o      ( s_dst_valid                    ),
-    .ready_i      ( dst_ready_i & !s_dst_isolate_req ),
-    .async_req_i  ( payload_req_to_dst             ),
-    .async_ack_o  ( payload_ack_from_dst           ),
-    .async_data_i ( payload_data_to_dst            )
-  );
-
-  assign dst_valid_o = s_dst_valid & !s_dst_isolate_req;
-
-  cc_cdc_reset_ctrlr_half #(
-    .SyncStages        ( SYNC_STAGES - 1 ),
+  // Reuse the production source and destination domain wrappers. The harness
+  // only inserts timing delays on the explicit async wires between them.
+  cc_cdc_2phase_src_domain_clearable #(
+    .data_t            ( logic [31:0]        ),
+    .SyncStages        ( SYNC_STAGES         ),
     .ClearOnAsyncReset ( CLEAR_ON_ASYNC_RESET )
-  ) i_cdc_reset_ctrlr_half_src (
-    .clk_i              ( src_clk_i                ),
-    .rst_ni             ( src_rst_ni               ),
-    .clear_i            ( src_clear_i              ),
-    .clear_o            ( s_src_clear_req          ),
-    .clear_ack_i        ( s_src_clear_ack_q        ),
-    .isolate_o          ( s_src_isolate_req        ),
-    .isolate_ack_i      ( s_src_isolate_ack_q      ),
-    .async_next_phase_o ( src2dst_phase_from_src   ),
-    .async_req_o        ( src2dst_req_from_src     ),
-    .async_ack_i        ( src2dst_ack_to_src       ),
-    .async_next_phase_i ( dst2src_phase_to_src     ),
-    .async_req_i        ( dst2src_req_to_src       ),
-    .async_ack_o        ( dst2src_ack_from_src     )
+  ) i_src_domain (
+    .src_rst_ni,
+    .src_clk_i,
+    .src_clear_i,
+    .src_clear_pending_o,
+    .src_data_i,
+    .src_valid_i,
+    .src_ready_o,
+    .async_payload_req_o       ( async_payload_req_from_src              ),
+    .async_payload_ack_i       ( async_payload_ack_to_src                ),
+    .async_payload_data_o      ( async_payload_data_from_src             ),
+    .async_reset_next_phase_o  ( async_reset_src2dst_next_phase_from_src ),
+    .async_reset_req_o         ( async_reset_src2dst_req_from_src        ),
+    .async_reset_ack_i         ( async_reset_dst2src_ack_to_src          ),
+    .async_reset_next_phase_i  ( async_reset_dst2src_next_phase_to_src   ),
+    .async_reset_req_i         ( async_reset_dst2src_req_to_src          ),
+    .async_reset_ack_o         ( async_reset_src2dst_ack_from_src        )
   );
 
-  cc_cdc_reset_ctrlr_half #(
-    .SyncStages        ( SYNC_STAGES - 1 ),
+  cc_cdc_2phase_dst_domain_clearable #(
+    .data_t            ( logic [31:0]        ),
+    .SyncStages        ( SYNC_STAGES         ),
     .ClearOnAsyncReset ( CLEAR_ON_ASYNC_RESET )
-  ) i_cdc_reset_ctrlr_half_dst (
-    .clk_i              ( dst_clk_i                ),
-    .rst_ni             ( dst_rst_ni               ),
-    .clear_i            ( dst_clear_i              ),
-    .clear_o            ( s_dst_clear_req          ),
-    .clear_ack_i        ( s_dst_clear_ack_q        ),
-    .isolate_o          ( s_dst_isolate_req        ),
-    .isolate_ack_i      ( s_dst_isolate_ack_q      ),
-    .async_next_phase_o ( dst2src_phase_from_dst   ),
-    .async_req_o        ( dst2src_req_from_dst     ),
-    .async_ack_i        ( dst2src_ack_to_dst       ),
-    .async_next_phase_i ( src2dst_phase_to_dst     ),
-    .async_req_i        ( src2dst_req_to_dst       ),
-    .async_ack_o        ( src2dst_ack_from_dst     )
+  ) i_dst_domain (
+    .dst_rst_ni,
+    .dst_clk_i,
+    .dst_clear_i,
+    .dst_clear_pending_o,
+    .dst_data_o,
+    .dst_valid_o,
+    .dst_ready_i,
+    .async_payload_req_i       ( async_payload_req_to_dst                ),
+    .async_payload_ack_o       ( async_payload_ack_from_dst              ),
+    .async_payload_data_i      ( async_payload_data_to_dst               ),
+    .async_reset_next_phase_o  ( async_reset_dst2src_next_phase_from_dst ),
+    .async_reset_req_o         ( async_reset_dst2src_req_from_dst        ),
+    .async_reset_ack_i         ( async_reset_src2dst_ack_to_dst          ),
+    .async_reset_next_phase_i  ( async_reset_src2dst_next_phase_to_dst   ),
+    .async_reset_req_i         ( async_reset_src2dst_req_to_dst          ),
+    .async_reset_ack_o         ( async_reset_dst2src_ack_from_dst        )
   );
-
-  always_ff @(posedge src_clk_i, negedge src_rst_ni) begin
-    if (!src_rst_ni) begin
-      s_src_isolate_ack_q <= 1'b0;
-      s_src_clear_ack_q   <= 1'b0;
-    end else begin
-      s_src_isolate_ack_q <= s_src_isolate_req;
-      s_src_clear_ack_q   <= s_src_clear_req;
-    end
-  end
-
-  always_ff @(posedge dst_clk_i, negedge dst_rst_ni) begin
-    if (!dst_rst_ni) begin
-      s_dst_isolate_ack_q <= 1'b0;
-      s_dst_clear_ack_q   <= 1'b0;
-    end else begin
-      s_dst_isolate_ack_q <= s_dst_isolate_req;
-      s_dst_clear_ack_q   <= s_dst_clear_req;
-    end
-  end
-
-  assign src_clear_pending_o = s_src_isolate_req;
-  assign dst_clear_pending_o = s_dst_isolate_req;
-
 endmodule
 
 
+// Lightweight checker for reset-controller half internals. This is deliberately
+// local-clock only and checks invariants that should hold after every edge.
 module cc_cdc_reset_ctrlr_half_monitor
   import cc_pkg::*;
 (


### PR DESCRIPTION
Requires #317, second part of the split #304.

Refactor the `cdc_2phase_clearable` using the new tests to check correctness, the goal was to cleanly separate it into a source and destination side and only have the async wires going between them in the top-level.  
Once #37 is merged this one should look more reasonable/scoped.