### PR TITLE
rr_arb_tree: fix inconsistent gnt for NumIn==1 (#248)

### DIFF
--- a/src/cc_rr_arb_tree.sv
+++ b/src/cc_rr_arb_tree.sv
@@ -114,7 +114,7 @@ module cc_rr_arb_tree #(
   // just pass through in this corner case
   if (NumIn == unsigned'(1)) begin : gen_pass_through
     assign req_o    = req_i[0];
-    assign gnt_o[0] = gnt_i;
+    assign gnt_o[0] = gnt_i & (AxiVldRdy | req_i[0]);
     assign data_o   = data_i[0];
     assign idx_o    = '0;
   // non-degenerate cases


### PR DESCRIPTION
Addresses https://github.com/pulp-platform/common_cells/issues/248.

When `NumIn==1` and `AxiVldRdy==0`, `gnt_o[0]` was passed through unconditionally from `gnt_i`, ignoring `req_i[0]`. The multi-input path correctly gates with (`AxiVldRdy | req_i[0]`). Align the single-input corner case to the same logic.