### PR TITLE
passthrough_stream_fifo: gate ptr updates on full handshake (#264 #313)

### DIFF
--- a/src/cc_passthrough_stream_fifo.sv
+++ b/src/cc_passthrough_stream_fifo.sv
@@ -77,7 +77,7 @@ module cc_passthrough_stream_fifo #(
             // Read
             valid_o = read_ptr_q[PointerWidth-1] == write_ptr_q[PointerWidth-1]
                 ? read_ptr_q[PointerWidth-2:0] != write_ptr_q[PointerWidth-2:0] : 1'b1;
-            if (ready_i) begin
+            if (ready_i && valid_o) begin
                 if (read_ptr_q[PointerWidth-2:0] == (Depth-1)) begin
                     // On overflow reset pointer to zero and flip imaginary bit
                     read_ptr_d[PointerWidth-2:0] = '0;
@@ -93,7 +93,7 @@ module cc_passthrough_stream_fifo #(
                 ? 1'b1 : write_ptr_q[PointerWidth-2:0] != read_ptr_q[PointerWidth-2:0])
                 || (SameCycleRW && ready_i && valid_o);
 
-            if (valid_i) begin
+            if (valid_i && ready_o) begin
                 load_data = 1'b1;
                 data_d[write_ptr_q[PointerWidth-2:0]] = data_i;
 
@@ -114,12 +114,5 @@ module cc_passthrough_stream_fifo #(
     `FFARNC(write_ptr_q, write_ptr_d, clr_i, '0, clk_i, rst_ni)
 
     `FFLARNC(data_q, data_d, load_data, clr_i, '0, clk_i, rst_ni)
-
-    `ifndef COMMON_CELLS_ASSERTS_OFF
-    // no full push
-    `ASSERT_NEVER(CheckFullPush, (!ready_o & valid_i), clk_i, !rst_ni)
-    // empty pop
-    `ASSERT_NEVER(CheckEmptyPop, (!valid_o & ready_i), clk_i, !rst_ni)
-    `endif
 
 endmodule

--- a/test/cc_passthrough_stream_fifo_tb.sv
+++ b/test/cc_passthrough_stream_fifo_tb.sv
@@ -51,12 +51,12 @@ module cc_passthrough_stream_fifo_tb #(
         .flush_i    ( 1'b0 ),
 
         .data_i  ( (in_valid && in_ready) ? in_data : 'x ),
-        .valid_i ( in_valid && in_ready                  ),
+        .valid_i ( in_valid                              ),
         .ready_o ( in_ready                              ),
 
         .data_o  ( out_data               ),
         .valid_o ( out_valid              ),
-        .ready_i ( out_ready && out_valid )
+        .ready_i ( out_ready              )
     );
 
     // Application
@@ -121,7 +121,7 @@ module cc_passthrough_stream_fifo_tb #(
             acq_data = acq_queue.pop_front();
             app_data = app_queue.pop_front();
 
-            if (app_data != acq_data) begin
+            if (app_data !== acq_data) begin
                 $display("Missmatch! Applied: %d Acquired: %d", app_data, acq_data);
                 num_errors++;
             end else begin


### PR DESCRIPTION
Addresses https://github.com/pulp-platform/common_cells/issues/264 and https://github.com/pulp-platform/common_cells/issues/313.

The read and write pointer updates previously fired on valid_i/ready_i alone, without checking the other side of the handshake. With assertions disabled or in synthesized netlists this corrupted the FIFO pointers whenever a push happened while full, or a pop happened while empty.

Fix: gate read-pointer advance on (ready_i && valid_o) and write-pointer advance on (valid_i && ready_o).  The SameCycleRW mechanism is unaffected — ready_o already includes the (SameCycleRW && ready_i && valid_o) term, so simultaneous push+pop when full continues to work correctly.