### PR TITLE
rtl: use register macros for simple flops

### DIFF
--- a/src/cc_cdc_2phase.sv
+++ b/src/cc_cdc_2phase.sv
@@ -40,6 +40,8 @@
 /// CONSTRAINT: Requires max_delay of min_period(src_clk_i, dst_clk_i) through
 /// the paths async_req, async_ack, async_data.
 /* verilator lint_off DECLFILENAME */
+`include "common_cells/registers.svh"
+
 module cc_cdc_2phase #(
   parameter type data_t = logic
 )(
@@ -106,28 +108,17 @@ module cc_cdc_2phase_src #(
   logic req_src_q, ack_src_q, ack_q;
   (* dont_touch = "true" *)
   data_t data_src_q;
+  logic src_accept;
+
+  assign src_accept = valid_i && ready_o;
 
   // The req_src and data_src registers change when a new data item is accepted.
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      req_src_q  <= 0;
-      data_src_q <= data_t'('0);
-    end else if (valid_i && ready_o) begin
-      req_src_q  <= ~req_src_q;
-      data_src_q <= data_i;
-    end
-  end
+  `FFL(req_src_q,  ~req_src_q, src_accept, 1'b0,       clk_i, rst_ni)
+  `FFL(data_src_q, data_i,     src_accept, data_t'('0), clk_i, rst_ni)
 
   // The ack_src and ack registers act as synchronization stages.
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      ack_src_q <= 0;
-      ack_q     <= 0;
-    end else begin
-      ack_src_q <= async_ack_i;
-      ack_q     <= ack_src_q;
-    end
-  end
+  `FF(ack_src_q, async_ack_i, 1'b0, clk_i, rst_ni)
+  `FF(ack_q,     ack_src_q,   1'b0, clk_i, rst_ni)
 
   // Output assignments.
   assign ready_o = (req_src_q == ack_q);
@@ -157,38 +148,22 @@ module cc_cdc_2phase_dst #(
   logic req_dst_q, req_q0, req_q1, ack_dst_q;
   (* dont_touch = "true" *)
   data_t data_dst_q;
+  logic dst_accept, dst_data_load;
+
+  assign dst_accept   = valid_o && ready_i;
+  assign dst_data_load = req_q0 != req_q1 && !valid_o;
 
   // The ack_dst register changes when a new data item is accepted.
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      ack_dst_q  <= 0;
-    end else if (valid_o && ready_i) begin
-      ack_dst_q  <= ~ack_dst_q;
-    end
-  end
+  `FFL(ack_dst_q, ~ack_dst_q, dst_accept, 1'b0, clk_i, rst_ni)
 
   // The data_dst register changes when a new data item is presented. This is
   // indicated by the async_req line changing levels.
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      data_dst_q <= data_t'('0);
-    end else if (req_q0 != req_q1 && !valid_o) begin
-      data_dst_q <= async_data_i;
-    end
-  end
+  `FFL(data_dst_q, async_data_i, dst_data_load, data_t'('0), clk_i, rst_ni)
 
   // The req_dst and req registers act as synchronization stages.
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      req_dst_q <= 0;
-      req_q0    <= 0;
-      req_q1    <= 0;
-    end else begin
-      req_dst_q <= async_req_i;
-      req_q0    <= req_dst_q;
-      req_q1    <= req_q0;
-    end
-  end
+  `FF(req_dst_q, async_req_i, 1'b0, clk_i, rst_ni)
+  `FF(req_q0,    req_dst_q,   1'b0, clk_i, rst_ni)
+  `FF(req_q1,    req_q0,      1'b0, clk_i, rst_ni)
 
   // Output assignments.
   assign valid_o = (ack_dst_q != req_q1);

--- a/src/cc_cdc_2phase_clearable.sv
+++ b/src/cc_cdc_2phase_clearable.sv
@@ -257,15 +257,8 @@ module cc_cdc_2phase_dst_domain_clearable #(
   assign dst_valid_o = dst_valid & !dst_isolate_req;
 
   // Isolation and clear are acknowledged one cycle after the local request.
-  always_ff @(posedge dst_clk_i, negedge dst_rst_ni) begin
-    if (!dst_rst_ni) begin
-      dst_isolate_ack_q <= 1'b0;
-      dst_clear_ack_q   <= 1'b0;
-    end else begin
-      dst_isolate_ack_q <= dst_isolate_req;
-      dst_clear_ack_q   <= dst_clear_req;
-    end
-  end
+  `FF(dst_isolate_ack_q, dst_isolate_req, 1'b0, dst_clk_i, dst_rst_ni)
+  `FF(dst_clear_ack_q,   dst_clear_req,   1'b0, dst_clk_i, dst_rst_ni)
 
   assign dst_clear_pending_o = dst_isolate_req;
 
@@ -353,15 +346,8 @@ module cc_cdc_2phase_src_domain_clearable #(
   assign src_ready_o = src_ready & !src_isolate_req;
 
   // Isolation and clear are acknowledged one cycle after the local request.
-  always_ff @(posedge src_clk_i, negedge src_rst_ni) begin
-    if (!src_rst_ni) begin
-      src_isolate_ack_q <= 1'b0;
-      src_clear_ack_q   <= 1'b0;
-    end else begin
-      src_isolate_ack_q <= src_isolate_req;
-      src_clear_ack_q   <= src_clear_req;
-    end
-  end
+  `FF(src_isolate_ack_q, src_isolate_req, 1'b0, src_clk_i, src_rst_ni)
+  `FF(src_clear_ack_q,   src_clear_req,   1'b0, src_clk_i, src_rst_ni)
 
   assign src_clear_pending_o = src_isolate_req; // The isolate signal stays
                                                 // asserted during the whole
@@ -417,13 +403,7 @@ module cc_cdc_2phase_src_clearable #(
 
   `FFNR(data_src_q, data_src_d, clk_i)
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      req_src_q  <= 0;
-    end else begin
-      req_src_q  <= req_src_d;
-    end
-  end
+  `FF(req_src_q, req_src_d, 1'b0, clk_i, rst_ni)
 
   // Output assignments.
   assign ready_o = (req_src_q == ack_synced);
@@ -494,17 +474,10 @@ module cc_cdc_2phase_dst_clearable #(
 
   `FFNR(data_dst_q, data_dst_d, clk_i)
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      ack_dst_q     <= 0;
-      req_synced_q1 <= 1'b0;
-    end else begin
-      ack_dst_q     <= ack_dst_d;
-      // The req_synced_q1 is the delayed version of the synchronized req_synced
-      // used to detect transitions in the request.
-      req_synced_q1 <= req_synced;
-    end
-  end
+  `FF(ack_dst_q, ack_dst_d, 1'b0, clk_i, rst_ni)
+  // The req_synced_q1 is the delayed version of the synchronized req_synced
+  // used to detect transitions in the request.
+  `FF(req_synced_q1, req_synced, 1'b0, clk_i, rst_ni)
 
   // Output assignments.
   assign valid_o = (ack_dst_q != req_synced_q1);

--- a/src/cc_cdc_4phase.sv
+++ b/src/cc_cdc_4phase.sv
@@ -33,6 +33,8 @@
 /// CONSTRAINT: Requires max_delay of min_period(src_clk_i, dst_clk_i) through
 /// the paths async_req, async_ack, async_data.
 /* verilator lint_off DECLFILENAME */
+`include "common_cells/registers.svh"
+
 module cc_cdc_4phase #(
   parameter type data_t = logic,
   parameter bit Decoupled = 1'b1,
@@ -115,6 +117,8 @@ module cc_cdc_4phase_src #(
 
   typedef enum logic[1:0] {IDLE, WAIT_ACK_ASSERT, WAIT_ACK_DEASSERT} state_e;
   state_e state_d, state_q;
+  localparam logic ReqSrcResetValue = SendResetMsg ? 1'b1 : 1'b0;
+  localparam data_t DataSrcResetValue = SendResetMsg ? ResetMsg : data_t'('0);
 
   // Synchronize the async ACK
   tc_sync #(
@@ -169,29 +173,11 @@ module cc_cdc_4phase_src #(
     endcase
   end
 
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (!rst_ni) begin
-      state_q <= IDLE;
-    end else begin
-      state_q <= state_d;
-    end
-  end
+  `FF(state_q, state_d, IDLE, clk_i, rst_ni)
 
   // Sample the data and the request signal to filter combinational glitches
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      if (SendResetMsg) begin
-        req_src_q  <= 1'b1;
-        data_src_q <= ResetMsg;
-      end else begin
-        req_src_q  <= 1'b0;
-        data_src_q <= data_t'('0);
-      end
-    end else begin
-      req_src_q  <= req_src_d;
-      data_src_q <= data_src_d;
-    end
-  end
+  `FF(req_src_q,  req_src_d,  ReqSrcResetValue,  clk_i, rst_ni)
+  `FF(data_src_q, data_src_d, DataSrcResetValue, clk_i, rst_ni)
 
   // Async output assignments.
   assign async_req_o = req_src_q;
@@ -281,22 +267,10 @@ module cc_cdc_4phase_dst #(
     endcase
   end
 
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (!rst_ni) begin
-      state_q <= IDLE;
-    end else begin
-      state_q <= state_d;
-    end
-  end
+  `FF(state_q, state_d, IDLE, clk_i, rst_ni)
 
   // Filter glitches on ack signal before sending it through the asynchronous channel
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (!rst_ni) begin
-      ack_dst_q <= 1'b0;
-    end else begin
-      ack_dst_q <= ack_dst_d;
-    end
-  end
+  `FF(ack_dst_q, ack_dst_d, 1'b0, clk_i, rst_ni)
 
   if (Decoupled) begin : gen_decoupled
     // Decouple the output from the asynchronous data bus without introducing

--- a/src/cc_cdc_fifo_2phase.sv
+++ b/src/cc_cdc_fifo_2phase.sv
@@ -11,6 +11,7 @@
 //
 // Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 
+`include "common_cells/registers.svh"
 `include "common_cells/assertions.svh"
 
 /// A clock domain crossing FIFO, using 2-phase hand shakes.
@@ -81,7 +82,7 @@ module cc_cdc_fifo_2phase #(
   // - write: fifo_widx, fifo_wdata, fifo_write, src_clk_i
   // - read: fifo_ridx, fifo_rdata
   index_t fifo_widx, fifo_ridx;
-  logic fifo_write;
+  logic fifo_write, fifo_read;
   data_t fifo_wdata, fifo_rdata;
   data_t fifo_data_q [2**LogDepth];
 
@@ -99,19 +100,8 @@ module cc_cdc_fifo_2phase #(
   // Allocate the read and write pointers in the source and destination domain.
   pointer_t src_wptr_q, dst_wptr, src_rptr, dst_rptr_q;
 
-  always_ff @(posedge src_clk_i, negedge src_rst_ni) begin
-    if (!src_rst_ni)
-      src_wptr_q <= 0;
-    else if (src_valid_i && src_ready_o)
-      src_wptr_q <= src_wptr_q + 1;
-  end
-
-  always_ff @(posedge dst_clk_i, negedge dst_rst_ni) begin
-    if (!dst_rst_ni)
-      dst_rptr_q <= 0;
-    else if (dst_valid_o && dst_ready_i)
-      dst_rptr_q <= dst_rptr_q + 1;
-  end
+  `FFL(src_wptr_q, src_wptr_q + 1, fifo_write, '0, src_clk_i, src_rst_ni)
+  `FFL(dst_rptr_q, dst_rptr_q + 1, fifo_read,  '0, dst_clk_i, dst_rst_ni)
 
   // The pointers into the FIFO are one bit wider than the actual address into
   // the FIFO. This makes detecting critical states very simple: if all but the
@@ -151,6 +141,7 @@ module cc_cdc_fifo_2phase #(
   assign fifo_widx  = src_wptr_q;
   assign fifo_wdata = src_data_i;
   assign fifo_write = src_valid_i && src_ready_o;
+  assign fifo_read  = dst_valid_o && dst_ready_i;
   assign fifo_ridx  = dst_rptr_q;
   assign dst_data_o = fifo_rdata;
 

--- a/src/cc_cdc_fifo_gray_clearable.sv
+++ b/src/cc_cdc_fifo_gray_clearable.sv
@@ -228,25 +228,11 @@ module cc_cdc_fifo_gray_clearable #(
 
   // Just delay the isolate request by one cycle. We can ensure isolation within
   // one cycle by just deasserting valid and ready signals on both sides of the CDC.
-  always_ff @(posedge src_clk_i, negedge src_rst_ni) begin
-    if (!src_rst_ni) begin
-      s_src_isolate_ack_q <= 1'b0;
-      s_src_clear_ack_q   <= 1'b0;
-    end else begin
-      s_src_isolate_ack_q <= s_src_isolate_req;
-      s_src_clear_ack_q   <= s_src_clear_req;
-    end
-  end
+  `FF(s_src_isolate_ack_q, s_src_isolate_req, 1'b0, src_clk_i, src_rst_ni)
+  `FF(s_src_clear_ack_q,   s_src_clear_req,   1'b0, src_clk_i, src_rst_ni)
 
-  always_ff @(posedge dst_clk_i, negedge dst_rst_ni) begin
-    if (!dst_rst_ni) begin
-      s_dst_isolate_ack_q <= 1'b0;
-      s_dst_clear_ack_q   <= 1'b0;
-    end else begin
-      s_dst_isolate_ack_q <= s_dst_isolate_req;
-      s_dst_clear_ack_q   <= s_dst_clear_req;
-    end
-  end
+  `FF(s_dst_isolate_ack_q, s_dst_isolate_req, 1'b0, dst_clk_i, dst_rst_ni)
+  `FF(s_dst_clear_ack_q,   s_dst_clear_req,   1'b0, dst_clk_i, dst_rst_ni)
 
 
   assign src_clear_pending_o = s_src_isolate_req; // The isolate signal stays

--- a/src/cc_cdc_reset_ctrlr.sv
+++ b/src/cc_cdc_reset_ctrlr.sv
@@ -105,6 +105,8 @@
 // side is isolated (depending on protocol this might take several cycles),
 // assert the a/b_isolate_ack_i signal.
 //
+`include "common_cells/registers.svh"
+
 module cc_cdc_reset_ctrlr
   import cc_pkg::*;
  #(
@@ -252,6 +254,7 @@ module cc_cdc_reset_ctrlr_half
      FINISHED
   } initiator_state_e;
   initiator_state_e initiator_state_d, initiator_state_q;
+  localparam initiator_state_e InitiatorStateResetValue = ClearOnAsyncReset ? ISOLATE : IDLE;
 
   // The current phase of the clear sequence, sent to the other side using a
   // 4-phase CDC
@@ -371,18 +374,8 @@ module cc_cdc_reset_ctrlr_half
     endcase
   end
 
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (!rst_ni) begin
-      if (ClearOnAsyncReset) begin
-        initiator_state_q <= ISOLATE; // Start in the ISOLATE state which is
-                                        // the first state of a clear sequence.
-      end else begin
-        initiator_state_q <= IDLE;
-      end
-    end else begin
-      initiator_state_q <= initiator_state_d;
-    end
-  end
+  // Start in the ISOLATE state if asynchronous reset should launch a clear sequence.
+  `FF(initiator_state_q, initiator_state_d, InitiatorStateResetValue, clk_i, rst_ni)
 
   // Initiator CDC SRC
   // We use 4 phase handshaking. That way it doesn't matter if one side is
@@ -417,6 +410,7 @@ module cc_cdc_reset_ctrlr_half
   cdc_clear_seq_phase_e receiver_phase_q;
   cdc_clear_seq_phase_e receiver_next_phase;
   logic receiver_phase_req, receiver_phase_ack;
+  logic receiver_phase_accept;
 
   logic receiver_isolate_out;
   logic receiver_clear_out;
@@ -438,13 +432,10 @@ module cc_cdc_reset_ctrlr_half
     .async_data_i(async_next_phase_i)
   );
 
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (!rst_ni) begin
-      receiver_phase_q <= CDC_CLEAR_PHASE_IDLE;
-    end else if (receiver_phase_req && receiver_phase_ack) begin
-      receiver_phase_q <= receiver_next_phase;
-    end
-  end
+  assign receiver_phase_accept = receiver_phase_req && receiver_phase_ack;
+
+  `FFL(receiver_phase_q, receiver_next_phase, receiver_phase_accept, CDC_CLEAR_PHASE_IDLE,
+       clk_i, rst_ni)
 
   always_comb begin
     receiver_isolate_out = 1'b0;

--- a/src/cc_clk_int_div.sv
+++ b/src/cc_clk_int_div.sv
@@ -67,6 +67,8 @@
 // SPDX-License-Identifier: SHL-0.51
 // -----------------------------------------------------------------------------
 
+`include "common_cells/registers.svh"
+
 module cc_clk_int_div #(
   /// The with
   parameter int unsigned DivValueWidth = 4,
@@ -227,21 +229,11 @@ module cc_clk_int_div #(
   localparam logic UseOddDivisionResetValue = DefaultDivValue[0];
   localparam logic ClkDivBypassEnResetValue = (DefaultDivValue < 2)? 1'b1: 1'b0;
 
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (!rst_ni) begin
-      use_odd_division_q  <= UseOddDivisionResetValue;
-      clk_div_bypass_en_q <= ClkDivBypassEnResetValue;
-      div_q               <= DivResetValue;
-      clk_gate_state_q    <= IDLE;
-      gate_en_q           <= EnableClockInReset;
-    end else begin
-      use_odd_division_q  <= use_odd_division_d;
-      clk_div_bypass_en_q <= clk_div_bypass_en_d;
-      div_q               <= div_d;
-      clk_gate_state_q    <= clk_gate_state_d;
-      gate_en_q           <= gate_en_d;
-    end
-  end
+  `FF(use_odd_division_q,  use_odd_division_d,  UseOddDivisionResetValue,  clk_i, rst_ni)
+  `FF(clk_div_bypass_en_q, clk_div_bypass_en_d, ClkDivBypassEnResetValue, clk_i, rst_ni)
+  `FF(div_q,               div_d,               DivResetValue,            clk_i, rst_ni)
+  `FF(clk_gate_state_q,    clk_gate_state_d,    IDLE,                     clk_i, rst_ni)
+  `FF(gate_en_q,           gate_en_d,           EnableClockInReset,        clk_i, rst_ni)
 
   //---------------------- Cycle Counter ----------------------
 
@@ -265,13 +257,7 @@ module cc_clk_int_div #(
     end
   end
 
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (!rst_ni) begin
-      cycle_cntr_q <= '0;
-    end else begin
-      cycle_cntr_q <= cycle_cntr_d;
-    end
-  end
+  `FF(cycle_cntr_q, cycle_cntr_d, '0, clk_i, rst_ni)
 
   assign cycl_count_o = cycle_cntr_q;
 


### PR DESCRIPTION
As the title says, addresses #68.