### PR TITLE
Fix Verilator IMPLICIT, UNOPTFLAT and MULTIDRIVEN warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ $(VLT_ELAB_TARGETS): vlt-elab-%: .bender/.checkout
 	$(VERILATOR) --cc \
 		$(shell $(BENDER) script verilator) \
 		--top-module $* \
-		-Wno-UNSIGNED \
 		-Wno-WIDTHEXPAND \
 		-Wno-WIDTHTRUNC \
 		-j $(shell nproc)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ $(VLT_ELAB_TARGETS): vlt-elab-%: .bender/.checkout
 	$(VERILATOR) --cc \
 		$(shell $(BENDER) script verilator) \
 		--top-module $* \
-		-Wno-IMPLICIT \
 		-Wno-UNSIGNED \
 		-Wno-WIDTHEXPAND \
 		-Wno-WIDTHTRUNC \

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ $(VLT_ELAB_TARGETS): vlt-elab-%: .bender/.checkout
 		-Wno-UNSIGNED \
 		-Wno-WIDTHEXPAND \
 		-Wno-WIDTHTRUNC \
-		-Wno-UNOPTFLAT \
 		-j $(shell nproc)
 
 $(VSIM_BUILDDIR) $(VCS_BUILDDIR) $(SG_BUILDDIR):

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,12 @@ $(VLT_ELAB_TARGETS): vlt-elab-%: .bender/.checkout
 	$(VERILATOR) --cc \
 		$(shell $(BENDER) script verilator) \
 		--top-module $* \
-		-Wno-fatal \
+		-Wno-IMPLICIT \
+		-Wno-UNSIGNED \
+		-Wno-WIDTHEXPAND \
+		-Wno-WIDTHTRUNC \
+		-Wno-UNOPTFLAT \
+		-Wno-MULTIDRIVEN \
 		-j $(shell nproc)
 
 $(VSIM_BUILDDIR) $(VCS_BUILDDIR) $(SG_BUILDDIR):

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ $(VLT_ELAB_TARGETS): vlt-elab-%: .bender/.checkout
 		-Wno-WIDTHEXPAND \
 		-Wno-WIDTHTRUNC \
 		-Wno-UNOPTFLAT \
-		-Wno-MULTIDRIVEN \
 		-j $(shell nproc)
 
 $(VSIM_BUILDDIR) $(VCS_BUILDDIR) $(SG_BUILDDIR):

--- a/src/cc_cdc_2phase.sv
+++ b/src/cc_cdc_2phase.sv
@@ -39,7 +39,6 @@
 ///
 /// CONSTRAINT: Requires max_delay of min_period(src_clk_i, dst_clk_i) through
 /// the paths async_req, async_ack, async_data.
-/* verilator lint_off DECLFILENAME */
 `include "common_cells/registers.svh"
 
 module cc_cdc_2phase #(
@@ -171,4 +170,3 @@ module cc_cdc_2phase_dst #(
   assign async_ack_o = ack_dst_q;
 
 endmodule
-/* verilator lint_on DECLFILENAME */

--- a/src/cc_cdc_2phase_clearable.sv
+++ b/src/cc_cdc_2phase_clearable.sv
@@ -57,8 +57,6 @@
 ///    why).
 ///
 ///
-/* verilator lint_off DECLFILENAME */
-
 `include "common_cells/registers.svh"
 `include "common_cells/assertions.svh"
 
@@ -485,4 +483,3 @@ module cc_cdc_2phase_dst_clearable #(
   assign async_ack_o = ack_dst_q;
 
 endmodule
-/* verilator lint_on DECLFILENAME */

--- a/src/cc_cdc_4phase.sv
+++ b/src/cc_cdc_4phase.sv
@@ -130,21 +130,29 @@ module cc_cdc_4phase_src #(
     .serial_o( ack_synced  )
   );
 
-  // FSM for the 4-phase handshake
+  // Output logic derived from registered local state only.
+  always_comb begin
+    ready_o = 1'b0;
+    case (state_q)
+      IDLE: begin
+        ready_o = Decoupled;
+      end
+      WAIT_ACK_DEASSERT: begin
+        ready_o = !Decoupled && (ack_synced == 1'b0);
+      end
+      default: begin
+        ready_o = 1'b0;
+      end
+    endcase
+  end
+
+  // FSM for the 4-phase handshake; calculates next state from inputs and local state.
   always_comb begin
     state_d    = state_q;
     req_src_d  = 1'b0;
     data_src_d = data_src_q;
-    ready_o    = 1'b0;
     case (state_q)
       IDLE: begin
-        // If decoupling is disabled, defer assertion of ready until the
-        // handshake with the dst is completed
-        if (Decoupled) begin
-          ready_o = 1'b1;
-        end else begin
-          ready_o = 1'b0;
-        end
         // Sample a new item when the valid signal is asserted.
         if (valid_i) begin
           data_src_d = data_i;
@@ -162,9 +170,6 @@ module cc_cdc_4phase_src #(
       WAIT_ACK_DEASSERT: begin
         if (ack_synced == 1'b0) begin
           state_d = IDLE;
-          if (!Decoupled) begin
-            ready_o = 1'b1;
-          end
         end
       end
       default: begin
@@ -226,17 +231,31 @@ module cc_cdc_4phase_dst #(
     .serial_o( req_synced  )
   );
 
-  // FSM for the 4-phase handshake
+  // Output logic derived from registered local state only.
+  always_comb begin
+    data_valid = 1'b0;
+    case (state_q)
+      IDLE: begin
+        data_valid = req_synced;
+      end
+      WAIT_DOWNSTREAM_ACK: begin
+        data_valid = 1'b1;
+      end
+      default: begin
+        data_valid = 1'b0;
+      end
+    endcase
+  end
+
+  // FSM for the 4-phase handshake; calculates next state from inputs and local state.
   always_comb begin
     state_d    = state_q;
-    data_valid = 1'b0;
     ack_dst_d  = 1'b0;
 
     case (state_q)
       IDLE: begin
         // Sample the data upon a new request and transition to the next state
         if (req_synced == 1'b1) begin
-          data_valid = 1'b1;
           if (output_ready == 1'b1) begin
             state_d = WAIT_REQ_DEASSERT;
           end else begin
@@ -246,7 +265,6 @@ module cc_cdc_4phase_dst #(
       end
 
       WAIT_DOWNSTREAM_ACK: begin
-        data_valid       = 1'b1;
         if (output_ready == 1'b1) begin
           state_d    = WAIT_REQ_DEASSERT;
           ack_dst_d  = 1'b1;

--- a/src/cc_cdc_4phase.sv
+++ b/src/cc_cdc_4phase.sv
@@ -32,7 +32,6 @@
 ///
 /// CONSTRAINT: Requires max_delay of min_period(src_clk_i, dst_clk_i) through
 /// the paths async_req, async_ack, async_data.
-/* verilator lint_off DECLFILENAME */
 `include "common_cells/registers.svh"
 
 module cc_cdc_4phase #(
@@ -317,4 +316,3 @@ module cc_cdc_4phase_dst #(
   assign async_ack_o = ack_dst_q;
 
 endmodule
-/* verilator lint_on DECLFILENAME */

--- a/src/cc_clk_mux_glitch_free.sv
+++ b/src/cc_clk_mux_glitch_free.sv
@@ -69,6 +69,7 @@
 // specific language governing permissions and limitations under the License.
 //-----------------------------------------------------------------------------
 
+`include "common_cells/registers.svh"
 
 module cc_clk_mux_glitch_free #(
   parameter int unsigned NumInputs = 2,
@@ -120,12 +121,12 @@ module cc_clk_mux_glitch_free #(
   logic [NumInputs-1:0]        s_sel_onehot;
   (*dont_touch*)
   (*async_reg*)
-  logic [NumInputs-1:0][1:0]   glitch_filter_d, glitch_filter_q;
+  logic [NumInputs-1:0][1:0]   glitch_filter_arr_d, glitch_filter_arr_q;
   logic [NumInputs-1:0]        s_gate_enable_unfiltered_async;
   logic [NumInputs-1:0]        s_glitch_filter_output_async;
   logic [NumInputs-1:0]        s_gate_enable_sync;
   logic [NumInputs-1:0]        s_gate_enable;
-  logic [NumInputs-1:0]        clock_has_been_disabled_q;
+  logic [NumInputs-1:0]        clock_has_been_disabled_arr_q;
   logic [NumInputs-1:0]        s_gated_clock;
   logic                         s_output_clock;
 
@@ -141,6 +142,17 @@ module cc_clk_mux_glitch_free #(
 
   // Input stages
   for (genvar i = 0; i < NumInputs; i++) begin : gen_input_stages
+
+    // Slice the glitch_filter and clock_has_been_disabled arrays
+    // to avoid Verilator MULTIDRIVEN warnings.
+    (*dont_touch*)
+    (*async_reg*)
+    logic [1:0] glitch_filter_d, glitch_filter_q;
+    logic       clock_has_been_disabled_q;
+    assign glitch_filter_arr_d[i]           = glitch_filter_d;
+    assign glitch_filter_arr_q[i]           = glitch_filter_q;
+    assign clock_has_been_disabled_arr_q[i] = clock_has_been_disabled_q;
+
     // Synchronize the reset into each clock domain
     cc_rstgen i_rstgen(
       .clk_i       ( clks_i[i]         ),
@@ -157,23 +169,17 @@ module cc_clk_mux_glitch_free #(
         if (i==j) begin
           s_gate_enable_unfiltered_async[i] &= s_sel_onehot[j];
         end else begin
-          s_gate_enable_unfiltered_async[i] &= clock_has_been_disabled_q[j];
+          s_gate_enable_unfiltered_async[i] &= clock_has_been_disabled_arr_q[j];
         end
       end
     end
-    assign glitch_filter_d[i][0] = s_gate_enable_unfiltered_async[i];
-    assign glitch_filter_d[i][1] = glitch_filter_q[i][0];
+    assign glitch_filter_d[0] = s_gate_enable_unfiltered_async[i];
+    assign glitch_filter_d[1] = glitch_filter_q[0];
 
     // Filter HIGH-pulse glitches
-    always_ff @(posedge clks_i[i], negedge s_reset_synced[i]) begin
-      if (!s_reset_synced[i]) begin
-        glitch_filter_q[i] <= '0;
-      end else begin
-        glitch_filter_q[i] <= glitch_filter_d[i];
-      end
-    end
-    assign s_glitch_filter_output_async[i] = glitch_filter_q[i][1] &
-                                       glitch_filter_q[i][0] &
+    `FF(glitch_filter_q, glitch_filter_d, '0, clks_i[i], s_reset_synced[i])
+    assign s_glitch_filter_output_async[i] = glitch_filter_q[1] &
+                                       glitch_filter_q[0] &
                                        s_gate_enable_unfiltered_async[i];
 
     // Synchronize to current clock
@@ -223,14 +229,7 @@ module cc_clk_mux_glitch_free #(
     // enable signal one more cycle, we ensure that the clock stays low for at
     // least one clock period of the original clock input before any other clock
     // even has the chance to become active.
-
-    always_ff @(posedge clks_i[i], negedge s_reset_synced[i]) begin
-      if (!s_reset_synced[i]) begin
-        clock_has_been_disabled_q[i] <= 1'b1;
-      end else begin
-        clock_has_been_disabled_q[i] <= ~s_gate_enable[i];
-      end
-    end
+    `FF(clock_has_been_disabled_q, ~s_gate_enable[i], 1'b1, clks_i[i], s_reset_synced[i])
   end
 
   // Output OR-gate. At this stage, we should be already sure that the clocks

--- a/src/cc_id_queue.sv
+++ b/src/cc_id_queue.sv
@@ -116,7 +116,8 @@ module cc_id_queue #(
 
     linked_data_t [Capacity-1:0]    linked_data_d,  linked_data_q;
 
-    logic                           full,
+    logic                           empty,
+                                    full,
                                     match_in_id_valid,
                                     match_out_id_valid,
                                     no_in_id_match,

--- a/src/cc_rr_arb_tree.sv
+++ b/src/cc_rr_arb_tree.sv
@@ -172,8 +172,13 @@ module cc_rr_arb_tree #(
         logic             upper_empty, lower_empty;
 
         for (genvar i = 0; i < NumIn; i++) begin : gen_mask
-          assign upper_mask[i] = (i >  rr_q) ? req_d[i] : 1'b0;
-          assign lower_mask[i] = (i <= rr_q) ? req_d[i] : 1'b0;
+          if (i == 0) begin : gen_first_mask
+            assign upper_mask[i] = 1'b0;
+            assign lower_mask[i] = req_d[i];
+          end else begin : gen_other_mask
+            assign upper_mask[i] = (idx_t'(i) >  rr_q) ? req_d[i] : 1'b0;
+            assign lower_mask[i] = (idx_t'(i) <= rr_q) ? req_d[i] : 1'b0;
+          end
         end
 
         cc_lzc #(

--- a/src/cc_rr_arb_tree.sv
+++ b/src/cc_rr_arb_tree.sv
@@ -96,10 +96,8 @@ module cc_rr_arb_tree #(
   input  idx_t                rr_i,
   /// Input requests arbitration.
   input  logic    [NumIn-1:0] req_i,
-  /* verilator lint_off UNOPTFLAT */
   /// Input request is granted.
   output logic    [NumIn-1:0] gnt_o,
-  /* verilator lint_on UNOPTFLAT */
   /// Input data for arbitration.
   input  data_t   [NumIn-1:0] data_i,
   /// Output request is valid.
@@ -122,12 +120,10 @@ module cc_rr_arb_tree #(
   end else begin : gen_arbiter
     localparam int unsigned NumLevels = unsigned'($clog2(NumIn));
 
-    /* verilator lint_off SPLITVAR */  // disable warning that is issued if bitwidth is 1
     idx_t    [2**NumLevels-2:0] index_nodes /* verilator split_var */; // propagates indices
     data_t   [2**NumLevels-2:0] data_nodes  /* verilator split_var */; // propagates data
     logic    [2**NumLevels-2:0] gnt_nodes   /* verilator split_var */; // propagates gnt to masters
     logic    [2**NumLevels-2:0] req_nodes   /* verilator split_var */; // propagates reqs to slave
-    /* verilator lint_on SPLITVAR */
 
     /* lint_off */
     idx_t                       rr_q;

--- a/src/cc_unread.sv
+++ b/src/cc_unread.sv
@@ -12,7 +12,6 @@
 // Date: 29.10.2018
 // Description: Dummy circuit to mitigate Open Pin warnings
 
-/* verilator lint_off UNUSED */
 module cc_unread (
     input logic d_i
 );
@@ -22,4 +21,3 @@ module cc_unread (
     assign d_i = x;
 `endif
 endmodule
-/* verilator lint_on UNUSED */


### PR DESCRIPTION
Addresses https://github.com/pulp-platform/common_cells/issues/323 as discussed therein.

**TODO**
- [x] Fix [UNOPTFLAT](https://verilator.org/guide/latest/warnings.html#cmdoption-arg-UNOPTFLAT) warnings. @phsauter could you have a look at this since you're more familiar with the CDC modules? My feeling is we might have to waive the warning within those files.