### PR TITLE
Undefine lowRISC macros, move UVM report to source file

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -23,6 +23,7 @@ sources:
   # etc. Files within a level are ordered alphabetically.
 
   # Level 0
+  - src/assert_rpt_pkg.sv
   - src/cc_binary_to_gray.sv
 
   - target: not(all(xilinx,vivado_ipx))

--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -39,6 +39,34 @@
 `endif
 `endif
 
+// detect and resolve potential collision with lowRISC's prim_assert macros by undefining all of
+// their macros (the variants in here should be backwards compatible with lowRISC's macros)
+`ifdef PRIM_ASSERT_SV
+  `ifdef INC_ASSERT
+    `undef ASSERT_I
+    `undef ASSERT_INIT
+    `undef ASSERT_FINAL
+    `undef ASSERT
+    `undef ASSERT_NEVER
+    `undef ASSERT_KNOWN
+    `undef COVER
+    `undef ASSERT_PULSE
+    `undef ASSERT_IF
+    `ifndef FPV_ON
+      `undef ASSERT_KNOWN_IF
+    `endif
+    `undef ASSUME
+    `undef ASSUME_I
+  `endif
+  `ifdef FPV_ON
+    `undef ASSUME_FPV
+    `undef ASSUME_I_FPV
+    `undef COVER_FPV
+  `endif
+`endif
+// define PRIM_ASSERT_SV to anticipate a later inclusion of lowRISC's prim_assert macros
+`define PRIM_ASSERT_SV
+
 // Converts an arbitrary block of code into a Verilog string
 `define ASSERT_STRINGIFY(__x) `"__x`"
 

--- a/include/common_cells/assertions.svh
+++ b/include/common_cells/assertions.svh
@@ -9,17 +9,6 @@
 `ifndef COMMON_CELLS_ASSERTIONS_SVH
 `define COMMON_CELLS_ASSERTIONS_SVH
 
-`ifdef UVM
-  // report assertion error with UVM if compiled
-  package assert_rpt_pkg;
-    import uvm_pkg::*;
-    `include "uvm_macros.svh"
-    function void assert_rpt(string msg);
-      `uvm_error("ASSERT FAILED", msg)
-    endfunction
-  endpackage
-`endif
-
 ///////////////////
 // Helper macros //
 ///////////////////

--- a/src/assert_rpt_pkg.sv
+++ b/src/assert_rpt_pkg.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifdef UVM
+package assert_rpt_pkg;
+
+  import uvm_pkg::*;
+
+  `include "uvm_macros.svh"
+
+  function automatic void assert_rpt(string msg);
+    `uvm_error("ASSERT FAILED", msg)
+  endfunction
+
+endpackage
+`endif


### PR DESCRIPTION
This addresses #238 and #250 and replaces #241.  

- Solves lowRISC prim_assert macro collisions by undefining existing lowRISC assertion macros before common_cells redefines them.
- Moves the UVM assertion reporting helper package out of assertions.svh into a dedicated source file, avoiding repeated package definitions across translation units.