### PR TITLE
cdc_reset_ctrlr: keep async phase inside CDC

### DIFF
--- a/formal/cc_cdc_reset_ctrlr_half_properties.sv
+++ b/formal/cc_cdc_reset_ctrlr_half_properties.sv
@@ -43,9 +43,11 @@ module cc_cdc_reset_ctrlr_half_properties #(
   input wire       initiator_isolate_out,
   input wire       initiator_clear_out,
   input wire [1:0] receiver_phase_q,
+  input wire [1:0] receiver_effective_phase,
   input wire [1:0] receiver_next_phase,
   input wire       receiver_phase_req,
   input wire       receiver_phase_ack,
+  input wire       receiver_phase_pending_q,
   input wire       receiver_isolate_out,
   input wire       receiver_clear_out
 );
@@ -108,6 +110,7 @@ module cc_cdc_reset_ctrlr_half_properties #(
         assert (initiator_state_q == InitIdle);
       end
       assert (receiver_phase_q == PhaseIdle);
+      assert (receiver_effective_phase == PhaseIdle);
     end
 
     if (rst_ni) begin
@@ -119,6 +122,7 @@ module cc_cdc_reset_ctrlr_half_properties #(
 
       assert (valid_initiator_state(initiator_state_q));
       assert (valid_phase(receiver_phase_q));
+      assert (valid_phase(receiver_effective_phase));
 
       if (async_req_o) begin
         assert (valid_phase(async_next_phase_o));
@@ -134,52 +138,42 @@ module cc_cdc_reset_ctrlr_half_properties #(
         end else begin
           assert (valid_phase(receiver_next_phase));
         end
+      end
 
-        case (receiver_next_phase)
-          PhaseIdle: begin
-            assert (!receiver_clear_out);
-            assert (!receiver_isolate_out);
-            assert (receiver_phase_ack);
-          end
-          PhaseIsolate: begin
-            assert (!receiver_clear_out);
-            assert (receiver_isolate_out);
-            assert (receiver_phase_ack == isolate_ack_i);
-          end
-          PhaseClear: begin
-            assert (receiver_clear_out);
-            assert (receiver_isolate_out);
-            assert (receiver_phase_ack == clear_ack_i);
-          end
-          PhasePostClear: begin
-            assert (!receiver_clear_out);
-            assert (receiver_isolate_out);
-            assert (receiver_phase_ack);
-          end
-          default: begin
-          end
-        endcase
-      end else begin
-        case (receiver_phase_q)
-          PhaseIdle: begin
-            assert (!receiver_clear_out);
-            assert (!receiver_isolate_out);
-          end
-          PhaseIsolate: begin
-            assert (!receiver_clear_out);
-            assert (receiver_isolate_out);
-          end
-          PhaseClear: begin
-            assert (receiver_clear_out);
-            assert (receiver_isolate_out);
-          end
-          PhasePostClear: begin
-            assert (!receiver_clear_out);
-            assert (receiver_isolate_out);
-          end
-          default: begin
-          end
-        endcase
+      case (receiver_effective_phase)
+        PhaseIdle: begin
+          assert (!receiver_clear_out);
+        end
+        PhaseIsolate: begin
+          assert (!receiver_clear_out);
+          assert (receiver_isolate_out);
+        end
+        PhaseClear: begin
+          assert (receiver_clear_out);
+          assert (receiver_isolate_out);
+        end
+        PhasePostClear: begin
+          assert (!receiver_clear_out);
+          assert (receiver_isolate_out);
+        end
+        default: begin
+        end
+      endcase
+
+      if (receiver_phase_ack) begin
+        assert (receiver_phase_pending_q);
+      end
+
+      if (receiver_clear_out) begin
+        assert (receiver_effective_phase == PhaseClear);
+      end
+
+      if (receiver_phase_ack && receiver_effective_phase == PhaseClear) begin
+        assert (clear_ack_i);
+      end
+
+      if (receiver_phase_ack && receiver_effective_phase == PhaseIsolate) begin
+        assert (isolate_ack_i);
       end
     end
   end
@@ -340,9 +334,11 @@ bind cc_cdc_reset_ctrlr_half cc_cdc_reset_ctrlr_half_properties #(
   .initiator_isolate_out,
   .initiator_clear_out,
   .receiver_phase_q,
+  .receiver_effective_phase,
   .receiver_next_phase,
   .receiver_phase_req,
   .receiver_phase_ack,
+  .receiver_phase_pending_q,
   .receiver_isolate_out,
   .receiver_clear_out
 );

--- a/src/cc_cdc_reset_ctrlr.sv
+++ b/src/cc_cdc_reset_ctrlr.sv
@@ -407,10 +407,16 @@ module cc_cdc_reset_ctrlr_half
   // This part of the circuit receives clear sequence state transitions from the
   // other side.
 
-  cdc_clear_seq_phase_e receiver_phase_q;
+  cdc_clear_seq_phase_e receiver_phase_d, receiver_phase_q;
+  cdc_clear_seq_phase_e receiver_effective_phase;
   cdc_clear_seq_phase_e receiver_next_phase;
-  logic receiver_phase_req, receiver_phase_ack;
-  logic receiver_phase_accept;
+
+  logic receiver_phase_req;
+  logic receiver_phase_ack;
+  logic receiver_phase_pending_d, receiver_phase_pending_q;
+  logic receiver_phase_done_d, receiver_phase_done_q;
+
+  logic receiver_capture_phase;
 
   logic receiver_isolate_out;
   logic receiver_clear_out;
@@ -432,82 +438,75 @@ module cc_cdc_reset_ctrlr_half
     .async_data_i(async_next_phase_i)
   );
 
-  assign receiver_phase_accept = receiver_phase_req && receiver_phase_ack;
+  // Capture async phase payload after synchronized request
+  // Do not decode receiver_next_phase into clear/isolate
+  assign receiver_capture_phase =
+      receiver_phase_req
+   && !receiver_phase_pending_q
+   && !receiver_phase_done_q;
 
-  `FFL(receiver_phase_q, receiver_next_phase, receiver_phase_accept, CDC_CLEAR_PHASE_IDLE,
-       clk_i, rst_ni)
+  always_comb begin
+    receiver_phase_d         = receiver_phase_q;
+    receiver_phase_pending_d = receiver_phase_pending_q;
+    receiver_phase_done_d    = receiver_phase_done_q;
+
+    if (!receiver_phase_req) begin
+      receiver_phase_done_d = 1'b0;
+    end
+
+    if (receiver_capture_phase) begin
+      receiver_phase_d         = receiver_next_phase;
+      receiver_phase_pending_d = 1'b1;
+    end
+
+    if (receiver_phase_ack) begin
+      receiver_phase_pending_d = 1'b0;
+      receiver_phase_done_d    = 1'b1;
+    end
+  end
+
+  `FF(receiver_phase_q,         receiver_phase_d,         CDC_CLEAR_PHASE_IDLE, clk_i, rst_ni)
+  `FF(receiver_phase_pending_q, receiver_phase_pending_d, 1'b0,                 clk_i, rst_ni)
+  `FF(receiver_phase_done_q,    receiver_phase_done_d,    1'b0,                 clk_i, rst_ni)
+
+  assign receiver_effective_phase = receiver_phase_q;
 
   always_comb begin
     receiver_isolate_out = 1'b0;
     receiver_clear_out   = 1'b0;
     receiver_phase_ack   = 1'b0;
 
-    // If there is a new phase requestd, checkout which one it is and act accordingly
-    if (receiver_phase_req) begin
-      case (receiver_next_phase)
-        CDC_CLEAR_PHASE_IDLE: begin
-          receiver_clear_out   = 1'b0;
-          receiver_isolate_out = 1'b0;
-          receiver_phase_ack   = 1'b1;
-        end
+    unique case (receiver_effective_phase)
+      CDC_CLEAR_PHASE_IDLE: begin
+        receiver_clear_out   = 1'b0;
+        receiver_isolate_out = 1'b0;
+        receiver_phase_ack   = receiver_phase_req && receiver_phase_pending_q;
+      end
+      CDC_CLEAR_PHASE_ISOLATE: begin
+        receiver_clear_out   = 1'b0;
+        receiver_isolate_out = 1'b1;
+        receiver_phase_ack   = receiver_phase_req && receiver_phase_pending_q && isolate_ack_i;
+      end
+      CDC_CLEAR_PHASE_CLEAR: begin
+        receiver_clear_out   = 1'b1;
+        receiver_isolate_out = 1'b1;
+        receiver_phase_ack   = receiver_phase_req && receiver_phase_pending_q && clear_ack_i;
+      end
+      CDC_CLEAR_PHASE_POST_CLEAR: begin
+        receiver_clear_out   = 1'b0;
+        receiver_isolate_out = 1'b1;
+        receiver_phase_ack   = receiver_phase_req && receiver_phase_pending_q;
+      end
+      default: begin
+        receiver_clear_out   = 1'b0;
+        receiver_isolate_out = 1'b0;
+        receiver_phase_ack   = 1'b0;
+      end
+    endcase
 
-        CDC_CLEAR_PHASE_ISOLATE: begin
-          receiver_clear_out   = 1'b0;
-          receiver_isolate_out = 1'b1;
-          // Wait for the isolate to be acknowledged before ack'ing the phase
-          receiver_phase_ack = isolate_ack_i;
-        end
-
-        CDC_CLEAR_PHASE_CLEAR: begin
-          receiver_clear_out   = 1'b1;
-          receiver_isolate_out = 1'b1;
-          // Wait for the clear to be acknowledged before ack'ing the phase
-          receiver_phase_ack   = clear_ack_i;
-        end
-
-        CDC_CLEAR_PHASE_POST_CLEAR: begin
-          receiver_clear_out   = 1'b0;
-          receiver_isolate_out = 1'b1;
-          receiver_phase_ack   = 1'b1;
-        end
-
-        default: begin
-          receiver_clear_out   = 1'b0;
-          receiver_isolate_out = 1'b0;
-          receiver_phase_ack   = 1'b0;
-        end
-      endcase
-
-    end else begin
-      // No phase change is requested for the moment. Act according to the
-      // current phase signal
-      case (receiver_phase_q)
-        CDC_CLEAR_PHASE_IDLE: begin
-          receiver_clear_out   = 1'b0;
-          receiver_isolate_out = 1'b0;
-        end
-
-        CDC_CLEAR_PHASE_ISOLATE: begin
-          receiver_clear_out   = 1'b0;
-          receiver_isolate_out = 1'b1;
-        end
-
-        CDC_CLEAR_PHASE_CLEAR: begin
-          receiver_clear_out   = 1'b1;
-          receiver_isolate_out = 1'b1;
-        end
-
-        CDC_CLEAR_PHASE_POST_CLEAR: begin
-          receiver_clear_out   = 1'b0;
-          receiver_isolate_out = 1'b1;
-        end
-
-        default: begin
-          receiver_clear_out   = 1'b0;
-          receiver_isolate_out = 1'b0;
-          receiver_phase_ack   = 1'b0;
-        end
-      endcase
+    // Preserve async-reset ordering margin without async_next_phase_i decode
+    if (receiver_capture_phase) begin
+      receiver_isolate_out = 1'b1;
     end
   end
 

--- a/test/cc_cdc_2phase_clearable_tb.sv
+++ b/test/cc_cdc_2phase_clearable_tb.sv
@@ -769,9 +769,11 @@ module cc_cdc_2phase_clearable_tb;
     .initiator_isolate_out,
     .initiator_clear_out,
     .receiver_phase_q,
+    .receiver_effective_phase,
     .receiver_next_phase,
     .receiver_phase_req,
     .receiver_phase_ack,
+    .receiver_phase_pending_q,
     .receiver_isolate_out,
     .receiver_clear_out
   );
@@ -1028,9 +1030,11 @@ module cc_cdc_reset_ctrlr_half_monitor
   input logic                 initiator_isolate_out,
   input logic                 initiator_clear_out,
   input cdc_clear_seq_phase_e receiver_phase_q,
+  input cdc_clear_seq_phase_e receiver_effective_phase,
   input cdc_clear_seq_phase_e receiver_next_phase,
   input logic                 receiver_phase_req,
   input logic                 receiver_phase_ack,
+  input logic                 receiver_phase_pending_q,
   input logic                 receiver_isolate_out,
   input logic                 receiver_clear_out
 );
@@ -1103,38 +1107,61 @@ module cc_cdc_reset_ctrlr_half_monitor
       report_monitor_error($sformatf("%m: initiator requested an illegal clear phase"));
     end
 
+    if (!valid_phase(receiver_effective_phase)) begin
+      report_monitor_error($sformatf("%m: illegal effective receiver phase 0x%0h",
+                                     receiver_effective_phase));
+    end
+
     if (receiver_phase_req) begin
-      unique case (receiver_next_phase)
-        CDC_CLEAR_PHASE_IDLE: begin
-          if (receiver_clear_out || receiver_isolate_out || !receiver_phase_ack) begin
-            report_monitor_error($sformatf("%m: receiver IDLE phase outputs are inconsistent"));
-          end
+      if (!valid_phase(receiver_next_phase)) begin
+        report_monitor_error($sformatf("%m: incoming receiver phase is illegal"));
+      end
+    end
+
+    unique case (receiver_effective_phase)
+      CDC_CLEAR_PHASE_IDLE: begin
+        if (receiver_clear_out) begin
+          report_monitor_error($sformatf("%m: receiver IDLE phase outputs are inconsistent"));
         end
-        CDC_CLEAR_PHASE_ISOLATE: begin
-          if (receiver_clear_out || !receiver_isolate_out ||
-              (receiver_phase_ack !== isolate_ack_i)) begin
-            report_monitor_error($sformatf("%m: receiver ISOLATE phase outputs are inconsistent"));
-          end
+      end
+      CDC_CLEAR_PHASE_ISOLATE: begin
+        if (receiver_clear_out || !receiver_isolate_out) begin
+          report_monitor_error($sformatf("%m: receiver ISOLATE phase outputs are inconsistent"));
         end
-        CDC_CLEAR_PHASE_CLEAR: begin
-          if (!receiver_clear_out || !receiver_isolate_out ||
-              (receiver_phase_ack !== clear_ack_i)) begin
-            report_monitor_error($sformatf("%m: receiver CLEAR phase outputs are inconsistent"));
-          end
+      end
+      CDC_CLEAR_PHASE_CLEAR: begin
+        if (!receiver_clear_out || !receiver_isolate_out) begin
+          report_monitor_error($sformatf("%m: receiver CLEAR phase outputs are inconsistent"));
         end
-        CDC_CLEAR_PHASE_POST_CLEAR: begin
-          if (receiver_clear_out || !receiver_isolate_out || !receiver_phase_ack) begin
-            report_monitor_error(
-                $sformatf("%m: receiver POST_CLEAR phase outputs are inconsistent"));
-          end
+      end
+      CDC_CLEAR_PHASE_POST_CLEAR: begin
+        if (receiver_clear_out || !receiver_isolate_out) begin
+          report_monitor_error(
+              $sformatf("%m: receiver POST_CLEAR phase outputs are inconsistent"));
         end
-        default: begin
-          if (receiver_clear_out || receiver_isolate_out || receiver_phase_ack) begin
-            report_monitor_error(
-                $sformatf("%m: receiver illegal phase was acknowledged or exposed"));
-          end
+      end
+      default: begin
+        if (receiver_clear_out || receiver_phase_ack) begin
+          report_monitor_error(
+              $sformatf("%m: receiver illegal phase was acknowledged or exposed"));
         end
-      endcase
+      end
+    endcase
+
+    if (receiver_phase_ack && !receiver_phase_pending_q) begin
+      report_monitor_error($sformatf("%m: receiver phase acknowledged before capture"));
+    end
+
+    if (receiver_phase_ack &&
+        receiver_effective_phase == CDC_CLEAR_PHASE_CLEAR &&
+        !clear_ack_i) begin
+      report_monitor_error($sformatf("%m: receiver clear phase acknowledged before local ack"));
+    end
+
+    if (receiver_phase_ack &&
+        receiver_effective_phase == CDC_CLEAR_PHASE_ISOLATE &&
+        !isolate_ack_i) begin
+      report_monitor_error($sformatf("%m: receiver isolate phase acknowledged before local ack"));
     end
   endtask
 


### PR DESCRIPTION
This is a much better solution to #243 that I have been working on for a while.

The current receiver side of `cdc_reset_ctrlr_half` decodes the 4-phase CDC payload directly into clear_o/isolate_o while a phase request is active.  
This is functionally intended as a bundled-data CDC, but it creates awkward async-data fanouts into reset-control logic and is especially fragile for open-source timing engines and OpenROADs flattening of modules when reading in.

This change keeps the 4-phase handshake and DECOUPLED=0 semantics unchanged, but captures the received phase into the destination clock domain before decoding it.  
To preserve the async-reset ordering margin, the receiver conservatively asserts isolate_o as soon as a synchronized phase request is observed, then drives clear_o only from the registered phase and acknowledges the phase only after the corresponding local effect has been acknowledged.

Informal ordering proof (with help from ChatGPT to express it):

Before the change, receiver side roughly does:
```
  async phase payload visible
      ↓
  decode phase combinationally
      ↓
  drive isolate_o / clear_o / phase_ack
```
The intended handshake makes this functionally valid but the phase payload still fans out into local reset-control logic as async-looking data.

After the change, the receiver side does:
```
  synchronized phase request visible
      ↓
  cycle N:
      isolate_o asserted conservatively
      phase payload captured into a local register
      no clear_o yet from the raw payload
      no phase ack yet

  cycle N+1:
      registered phase is decoded
      if phase == CLEAR: clear_o asserts
      if phase == ISOLATE/CLEAR: isolation remains asserted

  later / same cycle if already acknowledged:
      phase_ack is allowed only after the registered phase's
      local effect has been acknowledged
```
Importantly the ordering remains:
```
  request seen
      → isolate first
      → decode registered phase
      → clear only after isolation has started
      → acknowledge only after local isolate/clear acknowledgement
      → sender may advance to the next phase
```
This does not depend on the clock ratio. If the receiver is slow, the sender is held by the 4-phase handshake. If the receiver is fast, it may finish the local phase quickly, but the sender still cannot observe completion until the acknowledgement returns through its synchronizer. If the clocks are similar or arbitrarily phased, the normal synchronizer uncertainty is absorbed by the existing request/ack protocol.

For legal async-reset configurations, the important invariant is unchanged:
```
  reset-control request path reaches the receiver
      before
  the protected CDC's reset-induced state change can escape
```
The patch preserves that because the first-cycle isolation is still driven immediately from the synchronized phase request (thats why the new conservative nature there is necessary). Only the clear/decode action is delayed by one receiver clock, and that is safe because the side is already isolated before clear is asserted.