### PR TITLE
cdc_fifo_gray: split clock domains, configurable sync stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,9 @@ sg-lint:
   timeout: 10min
   script:
     - |
-      if [ "$TOPLEVEL" = "cc_cdc_2phase_clearable_tb" ]; then
+      if [ "$TOPLEVEL" = "cc_cdc_fifo_gray_tb" ]; then
+        ./test/simulate_cdc_fifo_gray.sh
+      elif [ "$TOPLEVEL" = "cc_cdc_2phase_clearable_tb" ]; then
         ./test/simulate_cdc_clearable.sh
       else
         bender checkout
@@ -64,6 +66,7 @@ tests:
           - cc_addr_decode_tb
           - cc_cb_filter_tb
           - cc_cdc_2phase_clearable_tb
+          - cc_cdc_fifo_gray_tb
           # - cc_cdc_fifo_clearable_tb
           - cc_clk_int_div_tb
           - cc_clk_int_div_static_tb

--- a/Bender.yml
+++ b/Bender.yml
@@ -128,6 +128,7 @@ sources:
       - test/cc_cb_filter_tb.sv
       - test/cc_cdc_2phase_tb.sv
       - test/cc_cdc_2phase_clearable_tb.sv
+      - test/cc_cdc_fifo_gray_tb.sv
       - test/cc_cdc_fifo_tb.sv
       - test/cc_cdc_fifo_clearable_tb.sv
       - test/cc_fifo_tb.sv

--- a/src/cc_cdc_fifo_gray.sv
+++ b/src/cc_cdc_fifo_gray.sv
@@ -128,8 +128,9 @@ module cc_cdc_fifo_gray #(
   logic [LogDepth:0]  async_rptr;
 
   cc_cdc_fifo_gray_src #(
-    .data_t   ( data_t   ),
-    .LogDepth ( LogDepth )
+    .data_t     ( data_t     ),
+    .LogDepth   ( LogDepth   ),
+    .SyncStages ( SyncStages )
   ) i_src (
     .src_rst_ni,
     .src_clk_i,
@@ -143,8 +144,9 @@ module cc_cdc_fifo_gray #(
   );
 
   cc_cdc_fifo_gray_dst #(
-    .data_t   ( data_t   ),
-    .LogDepth ( LogDepth )
+    .data_t     ( data_t     ),
+    .LogDepth   ( LogDepth   ),
+    .SyncStages ( SyncStages )
   ) i_dst (
     .dst_rst_ni,
     .dst_clk_i,
@@ -189,6 +191,10 @@ module cc_cdc_fifo_gray_src #(
 
   data_t [2**LogDepth-1:0] data_q, data_d;
   logic [PtrWidth-1:0] wptr_q, wptr_d, wptr_bin, wptr_next, rptr, rptr_bin;
+
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
 
   // Data FIFO.
   assign async_data_o = data_q;
@@ -250,6 +256,11 @@ module cc_cdc_fifo_gray_dst #(
   data_t dst_data;
   logic [PtrWidth-1:0] rptr_q, rptr_d, rptr_bin, rptr_bin_d, rptr_next, wptr, wptr_bin;
   logic dst_valid, dst_ready;
+
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
+
   // Data selector and register.
   assign dst_data = async_data_i[rptr_bin[LogDepth-1:0]];
 

--- a/src/cc_cdc_fifo_gray.sv
+++ b/src/cc_cdc_fifo_gray.sv
@@ -11,6 +11,7 @@
 //
 // Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 // Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+// Philippe Sauter <phsauter@iis.ee.ethz.ch> (source/destination split)
 
 /// A clock domain crossing FIFO, using gray counters.
 ///
@@ -186,48 +187,35 @@ module cc_cdc_fifo_gray_src #(
   input  logic  [LogDepth:0]      async_rptr_i
 );
 
-  localparam int unsigned PtrWidth = LogDepth+1;
-  localparam logic [PtrWidth-1:0] PtrFull = (1 << LogDepth);
+  logic [LogDepth-1:0] src_widx;
+  logic src_write;
 
-  data_t [2**LogDepth-1:0] data_q, data_d;
-  logic [PtrWidth-1:0] wptr_q, wptr_d, wptr_bin, wptr_next, rptr, rptr_bin;
+  assign src_write = src_valid_i & src_ready_o;
 
-  if (SyncStages < 2) begin : gen_sync_stage_assertion
-    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
-  end
+  cc_cdc_fifo_gray_src_data #(
+    .data_t   ( data_t   ),
+    .LogDepth ( LogDepth )
+  ) i_src_data (
+    .src_rst_ni,
+    .src_clk_i,
+    .src_data_i,
+    .src_widx_i  ( src_widx     ),
+    .src_write_i ( src_write    ),
+    .async_data_o
+  );
 
-  // Data FIFO.
-  assign async_data_o = data_q;
-
-  always_comb begin
-    data_d                          = data_q;
-    data_d[wptr_bin[LogDepth-1:0]] = src_data_i;
-  end
-  `FFL(data_q, data_d, src_valid_i & src_ready_o, '0, src_clk_i, src_rst_ni)
-
-  // Read pointer.
-  for (genvar i = 0; i < PtrWidth; i++) begin : gen_sync
-    tc_sync #(.Stages(SyncStages)) i_sync (
-      .clk_i    ( src_clk_i       ),
-      .rst_ni   ( src_rst_ni      ),
-      .serial_i ( async_rptr_i[i] ),
-      .serial_o ( rptr[i]         )
-    );
-  end
-  cc_gray_to_binary #(PtrWidth) i_rptr_g2b (.a_i(rptr), .z_o(rptr_bin));
-
-  // Write pointer.
-  assign wptr_next = wptr_bin+1;
-  cc_gray_to_binary #(PtrWidth) i_wptr_g2b (.a_i(wptr_q), .z_o(wptr_bin));
-  cc_binary_to_gray #(PtrWidth) i_wptr_b2g (.a_i(wptr_next), .z_o(wptr_d));
-  `FFL(wptr_q, wptr_d, src_valid_i & src_ready_o, '0, src_clk_i, src_rst_ni)
-  assign async_wptr_o = wptr_q;
-
-  // The pointers into the FIFO are one bit wider than the actual address into
-  // the FIFO. This makes detecting critical states very simple: if all but the
-  // topmost bit of rptr and wptr agree, the FIFO is in a critical state. If the
-  // topmost bit is equal, the FIFO is empty, otherwise it is full.
-  assign src_ready_o = ((wptr_bin ^ rptr_bin) != PtrFull);
+  cc_cdc_fifo_gray_src_ptr #(
+    .LogDepth   ( LogDepth   ),
+    .SyncStages ( SyncStages )
+  ) i_src_ptr (
+    .src_rst_ni,
+    .src_clk_i,
+    .src_valid_i,
+    .src_ready_o,
+    .src_widx_o  ( src_widx     ),
+    .async_wptr_o,
+    .async_rptr_i
+  );
 
 endmodule
 
@@ -250,28 +238,157 @@ module cc_cdc_fifo_gray_dst #(
   output logic  [LogDepth:0]      async_rptr_o
 );
 
-  localparam int unsigned PtrWidth = LogDepth+1;
-  localparam logic [PtrWidth-1:0] PtrEmpty = '0;
-
-  data_t dst_data;
-  logic [PtrWidth-1:0] rptr_q, rptr_d, rptr_bin, rptr_bin_d, rptr_next, wptr, wptr_bin;
   logic dst_valid, dst_ready;
+  logic [LogDepth-1:0] dst_ridx;
+
+  cc_cdc_fifo_gray_dst_ptr #(
+    .LogDepth   ( LogDepth   ),
+    .SyncStages ( SyncStages )
+  ) i_dst_ptr (
+    .dst_rst_ni,
+    .dst_clk_i,
+    .dst_ready_i ( dst_ready    ),
+    .dst_valid_o ( dst_valid    ),
+    .dst_ridx_o  ( dst_ridx     ),
+    .async_wptr_i,
+    .async_rptr_o
+  );
+
+  cc_cdc_fifo_gray_dst_data #(
+    .data_t   ( data_t   ),
+    .LogDepth ( LogDepth )
+  ) i_dst_data (
+    .dst_rst_ni,
+    .dst_clk_i,
+    .dst_data_o,
+    .dst_valid_o,
+    .dst_ready_i,
+    .dst_valid_i ( dst_valid    ),
+    .dst_ready_o ( dst_ready    ),
+    .dst_ridx_i  ( dst_ridx     ),
+    .async_data_i
+  );
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_src_data #(
+  parameter type data_t = logic,
+  parameter int unsigned LogDepth = 3
+)(
+  input  logic  src_rst_ni,
+  input  logic  src_clk_i,
+  input  data_t src_data_i,
+  input  logic [LogDepth-1:0] src_widx_i,
+  input  logic  src_write_i,
+  output data_t [2**LogDepth-1:0] async_data_o
+);
+
+  data_t [2**LogDepth-1:0] data_d, data_q;
+
+  always_comb begin
+    data_d = data_q;
+    data_d[src_widx_i] = src_data_i;
+  end
+
+  `FFL(data_q, data_d, src_write_i, '0, src_clk_i, src_rst_ni)
+
+  assign async_data_o = data_q;
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_src_ptr #(
+  parameter int unsigned LogDepth = 3,
+  parameter int unsigned SyncStages = 2
+)(
+  input  logic src_rst_ni,
+  input  logic src_clk_i,
+  input  logic src_valid_i,
+  output logic src_ready_o,
+  output logic [LogDepth-1:0] src_widx_o,
+  output logic [LogDepth:0]   async_wptr_o,
+  input  logic [LogDepth:0]   async_rptr_i
+);
+
+  localparam int unsigned PtrWidth = LogDepth+1;
+  localparam logic [PtrWidth-1:0] PtrFull = (1 << LogDepth);
+
+  logic [PtrWidth-1:0] wptr_q, wptr_d, wptr_bin, wptr_next, rptr, rptr_bin;
 
   if (SyncStages < 2) begin : gen_sync_stage_assertion
     $error("A minimum of 2 synchronizer stages is required for proper functionality.");
   end
 
-  // Data selector and register.
-  assign dst_data = async_data_i[rptr_bin[LogDepth-1:0]];
+  // Read pointer from the destination domain, synchronized into the source
+  // domain for the full check.
+  for (genvar i = 0; i < PtrWidth; i++) begin : gen_sync
+    tc_sync #(.Stages(SyncStages)) i_sync (
+      .clk_i    ( src_clk_i       ),
+      .rst_ni   ( src_rst_ni      ),
+      .serial_i ( async_rptr_i[i] ),
+      .serial_o ( rptr[i]         )
+    );
+  end
+  cc_gray_to_binary #(PtrWidth) i_rptr_g2b (.a_i(rptr), .z_o(rptr_bin));
 
-  // Read pointer.
+  // Local write pointer.
+  assign wptr_next = wptr_bin+1;
+  cc_gray_to_binary #(PtrWidth) i_wptr_g2b (.a_i(wptr_q), .z_o(wptr_bin));
+  cc_binary_to_gray #(PtrWidth) i_wptr_b2g (.a_i(wptr_next), .z_o(wptr_d));
+  `FFL(wptr_q, wptr_d, src_valid_i & src_ready_o, '0, src_clk_i, src_rst_ni)
+
+  assign src_widx_o   = wptr_bin[LogDepth-1:0];
+  assign async_wptr_o = wptr_q;
+
+  // The pointers into the FIFO are one bit wider than the actual address into
+  // the FIFO. This makes detecting critical states very simple: if all but the
+  // topmost bit of rptr and wptr agree, the FIFO is in a critical state. If the
+  // topmost bit is equal, the FIFO is empty, otherwise it is full.
+  assign src_ready_o = ((wptr_bin ^ rptr_bin) != PtrFull);
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_dst_ptr #(
+  parameter int unsigned LogDepth = 3,
+  parameter int unsigned SyncStages = 2
+)(
+  input  logic dst_rst_ni,
+  input  logic dst_clk_i,
+  input  logic dst_ready_i,
+  output logic dst_valid_o,
+  output logic [LogDepth-1:0] dst_ridx_o,
+  input  logic [LogDepth:0]   async_wptr_i,
+  output logic [LogDepth:0]   async_rptr_o
+);
+
+  localparam int unsigned PtrWidth = LogDepth+1;
+  localparam logic [PtrWidth-1:0] PtrEmpty = '0;
+
+  logic [PtrWidth-1:0] rptr_q, rptr_d, rptr_bin, rptr_next, wptr, wptr_bin;
+
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
+
+  // Local read pointer.
   assign rptr_next = rptr_bin+1;
   cc_gray_to_binary #(PtrWidth) i_rptr_g2b (.a_i(rptr_q), .z_o(rptr_bin));
   cc_binary_to_gray #(PtrWidth) i_rptr_b2g (.a_i(rptr_next), .z_o(rptr_d));
-  `FFL(rptr_q, rptr_d, dst_valid & dst_ready, '0, dst_clk_i, dst_rst_ni)
+  `FFL(rptr_q, rptr_d, dst_valid_o & dst_ready_i, '0, dst_clk_i, dst_rst_ni)
+
+  assign dst_ridx_o   = rptr_bin[LogDepth-1:0];
   assign async_rptr_o = rptr_q;
 
-  // Write pointer.
+  // Write pointer from the source domain, synchronized into the destination
+  // domain for the empty check.
   for (genvar i = 0; i < PtrWidth; i++) begin : gen_sync
     tc_sync #(.Stages(SyncStages)) i_sync (
       .clk_i    ( dst_clk_i       ),
@@ -286,7 +403,31 @@ module cc_cdc_fifo_gray_dst #(
   // the FIFO. This makes detecting critical states very simple: if all but the
   // topmost bit of rptr and wptr agree, the FIFO is in a critical state. If the
   // topmost bit is equal, the FIFO is empty, otherwise it is full.
-  assign dst_valid = ((wptr_bin ^ rptr_bin) != PtrEmpty);
+  assign dst_valid_o = ((wptr_bin ^ rptr_bin) != PtrEmpty);
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_dst_data #(
+  parameter type data_t = logic,
+  parameter int unsigned LogDepth = 3
+)(
+  input  logic  dst_rst_ni,
+  input  logic  dst_clk_i,
+  output data_t dst_data_o,
+  output logic  dst_valid_o,
+  input  logic  dst_ready_i,
+  input  logic  dst_valid_i,
+  output logic  dst_ready_o,
+  input  logic [LogDepth-1:0] dst_ridx_i,
+  input  data_t [2**LogDepth-1:0] async_data_i
+);
+
+  data_t dst_data;
+
+  assign dst_data = async_data_i[dst_ridx_i];
 
   // Cut the combinatorial path with a spill register.
   cc_spill_register #(
@@ -295,8 +436,8 @@ module cc_cdc_fifo_gray_dst #(
     .clk_i   ( dst_clk_i   ),
     .rst_ni  ( dst_rst_ni  ),
     .clr_i   ( '0          ),
-    .valid_i ( dst_valid   ),
-    .ready_o ( dst_ready   ),
+    .valid_i ( dst_valid_i ),
+    .ready_o ( dst_ready_o ),
     .data_i  ( dst_data    ),
     .valid_o ( dst_valid_o ),
     .ready_i ( dst_ready_i ),

--- a/test/cc_cdc_fifo_gray_tb.sv
+++ b/test/cc_cdc_fifo_gray_tb.sv
@@ -1,0 +1,568 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Authors:
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+//
+// Description: Gray-Counter CDC FIFO Testbench
+// Exercise FIFO ordering, full/empty transitions, backpressure, gray pointer
+// transitions, and timed async data/pointer delay sweeps for cc_cdc_fifo_gray.
+
+module cc_cdc_fifo_gray_tb;
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  // --------------------------------------------------------------------------
+  // Configuration
+  // --------------------------------------------------------------------------
+  parameter int unsigned NUM_RANDOM_TRANSFERS = 200;
+  parameter int unsigned DEPTH = 3;
+  parameter int unsigned SYNC_STAGES = 2;
+  parameter int unsigned TCK_SRC_PS = 10000;
+  parameter int unsigned TCK_DST_PS = 17000;
+  parameter int unsigned TIMEOUT_CYCLES = 40000;
+  parameter int unsigned SEED = 32'hf109_0001;
+  parameter bit          INJECT_DELAYS = 1'b0;
+  parameter int unsigned MAX_DELAY_PS = 0;
+  parameter int unsigned SRC_START_DELAY_PS = 0;
+  parameter int unsigned DST_START_DELAY_PS = 0;
+
+  localparam int unsigned FifoDepth = 2**DEPTH;
+  localparam int unsigned PtrWidth = DEPTH + 1;
+
+  typedef enum logic [1:0] {
+    DstReadyLow,
+    DstReadyHigh,
+    DstReadyRandom
+  } dst_ready_mode_e;
+
+  time tck_src = TCK_SRC_PS * 1ps;
+  time tck_dst = TCK_DST_PS * 1ps;
+
+  logic        src_rst_ni = 1'b1;
+  logic        src_clk_i = 1'b0;
+  logic [31:0] src_data_i = '0;
+  logic        src_valid_i = 1'b0;
+  logic        src_ready_o;
+
+  logic        dst_rst_ni = 1'b1;
+  logic        dst_clk_i = 1'b0;
+  logic [31:0] dst_data_o;
+  logic        dst_valid_o;
+  logic        dst_ready_i = 1'b0;
+
+  logic [PtrWidth-1:0] async_wptr_mon;
+  logic [PtrWidth-1:0] async_rptr_mon;
+  logic [PtrWidth-1:0] async_wptr_q = '0;
+  logic [PtrWidth-1:0] async_rptr_q = '0;
+
+  logic [31:0] expected_q[$];
+  int unsigned num_src_handshakes = 0;
+  int unsigned num_dst_handshakes = 0;
+  int unsigned num_errors = 0;
+
+  dst_ready_mode_e dst_ready_mode = DstReadyLow;
+
+  // --------------------------------------------------------------------------
+  // DUT Selection
+  // --------------------------------------------------------------------------
+  if (INJECT_DELAYS) begin : gen_delayed_dut
+    cc_cdc_fifo_gray_tb_delay_injector #(
+      .LOG_DEPTH    ( DEPTH        ),
+      .SYNC_STAGES  ( SYNC_STAGES  ),
+      .MAX_DELAY_PS ( MAX_DELAY_PS )
+    ) i_dut (
+      .src_rst_ni,
+      .src_clk_i,
+      .src_data_i,
+      .src_valid_i,
+      .src_ready_o,
+      .dst_rst_ni,
+      .dst_clk_i,
+      .dst_data_o,
+      .dst_valid_o,
+      .dst_ready_i,
+      .async_wptr_mon_o ( async_wptr_mon ),
+      .async_rptr_mon_o ( async_rptr_mon )
+    );
+  end else begin : gen_dut
+    cc_cdc_fifo_gray #(
+      .data_t     ( logic [31:0] ),
+      .LogDepth   ( DEPTH        ),
+      .SyncStages ( SYNC_STAGES  )
+    ) i_dut (
+      .src_rst_ni,
+      .src_clk_i,
+      .src_data_i,
+      .src_valid_i,
+      .src_ready_o,
+      .dst_rst_ni,
+      .dst_clk_i,
+      .dst_data_o,
+      .dst_valid_o,
+      .dst_ready_i
+    );
+
+    assign async_wptr_mon = i_dut.async_wptr;
+    assign async_rptr_mon = i_dut.async_rptr;
+  end
+
+  // --------------------------------------------------------------------------
+  // Clock And Ready Generation
+  // --------------------------------------------------------------------------
+  initial begin : gen_src_clk
+    #(SRC_START_DELAY_PS * 1ps);
+    forever #(tck_src / 2) src_clk_i = ~src_clk_i;
+  end
+
+  initial begin : gen_dst_clk
+    #(DST_START_DELAY_PS * 1ps);
+    forever #(tck_dst / 2) dst_clk_i = ~dst_clk_i;
+  end
+
+  always @(negedge dst_clk_i) begin
+    case (dst_ready_mode)
+      DstReadyLow:    dst_ready_i <= 1'b0;
+      DstReadyHigh:   dst_ready_i <= 1'b1;
+      DstReadyRandom: dst_ready_i <= ($urandom_range(0, 99) < 70);
+      default:        dst_ready_i <= 1'b0;
+    endcase
+  end
+
+  // --------------------------------------------------------------------------
+  // Scoreboard And Protocol Checks
+  // --------------------------------------------------------------------------
+  always @(posedge src_clk_i) begin
+    if (src_rst_ni) begin
+      if ($isunknown(src_ready_o)) begin
+        report_error("src_ready_o is unknown");
+      end
+      if ($isunknown(src_valid_i)) begin
+        report_error("src_valid_i is unknown");
+      end
+      if (src_valid_i && $isunknown(src_data_i)) begin
+        report_error("src_data_i is unknown while valid");
+      end
+      if (src_valid_i && src_ready_o) begin
+        num_src_handshakes++;
+        expected_q.push_back(src_data_i);
+      end
+    end
+  end
+
+  always @(posedge dst_clk_i) begin
+    logic [31:0] expected;
+
+    if (dst_rst_ni) begin
+      if ($isunknown(dst_valid_o)) begin
+        report_error("dst_valid_o is unknown");
+      end
+      if ($isunknown(dst_ready_i)) begin
+        report_error("dst_ready_i is unknown");
+      end
+      if (dst_valid_o && $isunknown(dst_data_o)) begin
+        report_error("dst_data_o is unknown while valid");
+      end
+      if (dst_valid_o && dst_ready_i) begin
+        num_dst_handshakes++;
+        if (expected_q.size() == 0) begin
+          report_error($sformatf("unexpected destination transaction: data=0x%08h",
+                                 dst_data_o));
+        end else begin
+          expected = expected_q.pop_front();
+          if (dst_data_o !== expected) begin
+            report_error($sformatf("transaction mismatch: expected=0x%08h actual=0x%08h",
+                                   expected, dst_data_o));
+          end
+        end
+      end
+    end
+  end
+
+  // --------------------------------------------------------------------------
+  // Gray Pointer Monitors
+  // --------------------------------------------------------------------------
+  always @(posedge src_clk_i) begin
+    if (!src_rst_ni) begin
+      async_wptr_q <= '0;
+    end else begin
+      check_gray_transition("async_wptr_o", async_wptr_q, async_wptr_mon);
+      async_wptr_q <= async_wptr_mon;
+    end
+  end
+
+  always @(posedge dst_clk_i) begin
+    if (!dst_rst_ni) begin
+      async_rptr_q <= '0;
+    end else begin
+      check_gray_transition("async_rptr_o", async_rptr_q, async_rptr_mon);
+      async_rptr_q <= async_rptr_mon;
+    end
+  end
+
+  // --------------------------------------------------------------------------
+  // Test Helpers
+  // --------------------------------------------------------------------------
+  function automatic int unsigned count_set_bits(input logic [PtrWidth-1:0] value);
+    int unsigned count;
+
+    count = 0;
+    for (int unsigned i = 0; i < PtrWidth; i++) begin
+      if (value[i]) begin
+        count++;
+      end
+    end
+    return count;
+  endfunction
+
+  task automatic check_gray_transition(input string signal_name,
+                                       input logic [PtrWidth-1:0] previous,
+                                       input logic [PtrWidth-1:0] current);
+    if (!$isunknown(previous) && !$isunknown(current) &&
+        (count_set_bits(previous ^ current) > 1)) begin
+      report_error($sformatf("%s changed more than one bit: previous=0x%0h current=0x%0h",
+                             signal_name, previous, current));
+    end
+  endtask
+
+  task automatic report_error(input string msg);
+    num_errors++;
+    $error("%s", msg);
+  endtask
+
+  task automatic wait_src_cycles(input int unsigned cycles);
+    repeat (cycles) begin
+      @(posedge src_clk_i);
+    end
+    #1ps;
+  endtask
+
+  task automatic wait_dst_cycles(input int unsigned cycles);
+    repeat (cycles) begin
+      @(posedge dst_clk_i);
+    end
+    #1ps;
+  endtask
+
+  task automatic reset_both_domains;
+    expected_q.delete();
+    async_wptr_q = '0;
+    async_rptr_q = '0;
+    src_data_i = '0;
+    src_valid_i = 1'b0;
+    dst_ready_mode = DstReadyLow;
+    src_rst_ni = 1'b0;
+    dst_rst_ni = 1'b0;
+
+    fork
+      wait_src_cycles(4);
+      wait_dst_cycles(4);
+    join
+
+    src_rst_ni = 1'b1;
+    dst_rst_ni = 1'b1;
+
+    fork
+      wait_src_cycles(8);
+      wait_dst_cycles(8);
+    join
+  endtask
+
+  task automatic send_word(input logic [31:0] data);
+    @(negedge src_clk_i);
+    #1ps;
+    src_data_i = data;
+    src_valid_i = 1'b1;
+
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_ready_o) begin
+        @(posedge src_clk_i);
+        @(negedge src_clk_i);
+        src_valid_i = 1'b0;
+        src_data_i = '0;
+        return;
+      end
+      @(negedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout sending data=0x%08h", data));
+    src_valid_i = 1'b0;
+  endtask
+
+  task automatic wait_scoreboard_empty(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (expected_q.size() == 0) begin
+        return;
+      end
+      @(posedge dst_clk_i or posedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for scoreboard to drain in %s, pending=%0d",
+                           test_name, expected_q.size()));
+  endtask
+
+  task automatic wait_src_ready(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_ready_o) begin
+        return;
+      end
+      @(posedge src_clk_i or posedge dst_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for source ready in %s", test_name));
+  endtask
+
+  task automatic wait_src_not_ready(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (!src_ready_o) begin
+        return;
+      end
+      @(posedge src_clk_i or posedge dst_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for source not-ready in %s", test_name));
+  endtask
+
+  task automatic wait_dst_not_valid(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (!dst_valid_o) begin
+        return;
+      end
+      @(posedge dst_clk_i or posedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for destination not-valid in %s", test_name));
+  endtask
+
+  task automatic send_sequence(input int unsigned num_words, input logic [31:0] base);
+    for (int unsigned i = 0; i < num_words; i++) begin
+      send_word(base + i);
+      if ($urandom_range(0, 3) == 0) begin
+        wait_src_cycles($urandom_range(1, 3));
+      end
+    end
+  endtask
+
+  task automatic run_transfer_check(input string test_name, input int unsigned num_words,
+                                    input logic [31:0] base,
+                                    input dst_ready_mode_e ready_mode);
+    $display("%m: %s", test_name);
+    dst_ready_mode = ready_mode;
+    send_sequence(num_words, base);
+    wait_scoreboard_empty(test_name);
+    wait_src_ready(test_name);
+    dst_ready_mode = DstReadyLow;
+    wait_dst_cycles(2);
+  endtask
+
+  task automatic run_fill_drain_check(input string test_name, input logic [31:0] base);
+    int unsigned max_fill_words;
+
+    $display("%m: %s", test_name);
+    max_fill_words = FifoDepth + 2;
+    dst_ready_mode = DstReadyLow;
+    wait_src_ready(test_name);
+    for (int unsigned i = 0; i < max_fill_words; i++) begin
+      send_word(base + i);
+      if (!src_ready_o) begin
+        break;
+      end
+    end
+    wait_src_not_ready(test_name);
+    dst_ready_mode = DstReadyHigh;
+    wait_scoreboard_empty(test_name);
+    wait_src_ready(test_name);
+    wait_dst_not_valid(test_name);
+    dst_ready_mode = DstReadyLow;
+    wait_dst_cycles(2);
+  endtask
+
+  // --------------------------------------------------------------------------
+  // Test Sequence
+  // --------------------------------------------------------------------------
+  initial begin : run_tests
+    int unsigned seed;
+
+    seed = SEED;
+    seed = $urandom(seed);
+    $display("%m: SEED=0x%08h derived=0x%08h DEPTH=%0d SYNC_STAGES=%0d",
+             SEED, seed, DEPTH, SYNC_STAGES);
+
+    reset_both_domains();
+
+    run_transfer_check("basic fixed-ready transfer", FifoDepth + 8, 32'h1000_0000,
+                       DstReadyHigh);
+    run_fill_drain_check("fill and drain", 32'h2000_0000);
+    run_transfer_check("randomized ready transfer", NUM_RANDOM_TRANSFERS, 32'h3000_0000,
+                       DstReadyRandom);
+
+    if ((num_errors != 0) || (expected_q.size() != 0)) begin
+      $fatal(1, "%m: failed with %0d errors and %0d pending scoreboard items",
+             num_errors, expected_q.size());
+    end
+
+    $display("%m: passed: src_handshakes=%0d dst_handshakes=%0d",
+             num_src_handshakes, num_dst_handshakes);
+    $finish;
+  end
+
+endmodule
+
+
+// ----------------------------------------------------------------------------
+// Delay Model Helpers
+// ----------------------------------------------------------------------------
+
+module cc_cdc_fifo_gray_tb_bit_delay #(
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic in_i,
+  output logic out_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  initial begin
+    out_o = 1'b0;
+  end
+
+  always @(in_i) begin
+    automatic int unsigned delay_ps;
+    delay_ps = (MAX_DELAY_PS == 0) ? 0 : $urandom_range(0, MAX_DELAY_PS);
+    out_o <= #(delay_ps * 1ps) in_i;
+  end
+
+endmodule
+
+
+module cc_cdc_fifo_gray_tb_bus_delay #(
+  parameter int unsigned Width = 1,
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  for (genvar i = 0; i < Width; i++) begin : gen_bit_delay
+    cc_cdc_fifo_gray_tb_bit_delay #(
+      .MAX_DELAY_PS ( MAX_DELAY_PS )
+    ) i_delay (
+      .in_i  ( in_i[i]  ),
+      .out_o ( out_o[i] )
+    );
+  end
+
+endmodule
+
+
+// ----------------------------------------------------------------------------
+// Timed Delay-Injection Harness
+// ----------------------------------------------------------------------------
+
+module cc_cdc_fifo_gray_tb_delay_injector #(
+  parameter int unsigned LOG_DEPTH = 3,
+  parameter int unsigned SYNC_STAGES = 2,
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic        src_rst_ni,
+  input  logic        src_clk_i,
+  input  logic [31:0] src_data_i,
+  input  logic        src_valid_i,
+  output logic        src_ready_o,
+
+  input  logic        dst_rst_ni,
+  input  logic        dst_clk_i,
+  output logic [31:0] dst_data_o,
+  output logic        dst_valid_o,
+  input  logic        dst_ready_i,
+
+  output logic [LOG_DEPTH:0] async_wptr_mon_o,
+  output logic [LOG_DEPTH:0] async_rptr_mon_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  localparam int unsigned PtrWidth = LOG_DEPTH + 1;
+  typedef logic [31:0] data_t;
+
+  data_t [2**LOG_DEPTH-1:0] async_data_from_src;
+  data_t [2**LOG_DEPTH-1:0] async_data_to_dst;
+  logic [PtrWidth-1:0] async_wptr_from_src;
+  logic [PtrWidth-1:0] async_wptr_to_dst;
+  logic [PtrWidth-1:0] async_rptr_from_dst;
+  logic [PtrWidth-1:0] async_rptr_to_src;
+
+  assign async_wptr_mon_o = async_wptr_from_src;
+  assign async_rptr_mon_o = async_rptr_from_dst;
+
+  cc_cdc_fifo_gray_src #(
+    .data_t     ( data_t       ),
+    .LogDepth   ( LOG_DEPTH    ),
+    .SyncStages ( SYNC_STAGES  )
+  ) i_src (
+    .src_rst_ni,
+    .src_clk_i,
+    .src_data_i,
+    .src_valid_i,
+    .src_ready_o,
+    .async_data_o ( async_data_from_src ),
+    .async_wptr_o ( async_wptr_from_src ),
+    .async_rptr_i ( async_rptr_to_src   )
+  );
+
+  for (genvar i = 0; i < 2**LOG_DEPTH; i++) begin : gen_data_delay
+    cc_cdc_fifo_gray_tb_bus_delay #(
+      .Width        ( 32           ),
+      .MAX_DELAY_PS ( MAX_DELAY_PS )
+    ) i_data_delay (
+      .in_i  ( async_data_from_src[i] ),
+      .out_o ( async_data_to_dst[i]   )
+    );
+  end
+
+  cc_cdc_fifo_gray_tb_bus_delay #(
+    .Width        ( PtrWidth     ),
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_wptr_delay (
+    .in_i  ( async_wptr_from_src ),
+    .out_o ( async_wptr_to_dst   )
+  );
+
+  cc_cdc_fifo_gray_tb_bus_delay #(
+    .Width        ( PtrWidth     ),
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_rptr_delay (
+    .in_i  ( async_rptr_from_dst ),
+    .out_o ( async_rptr_to_src   )
+  );
+
+  cc_cdc_fifo_gray_dst #(
+    .data_t     ( data_t       ),
+    .LogDepth   ( LOG_DEPTH    ),
+    .SyncStages ( SYNC_STAGES  )
+  ) i_dst (
+    .dst_rst_ni,
+    .dst_clk_i,
+    .dst_data_o,
+    .dst_valid_o,
+    .dst_ready_i,
+    .async_data_i ( async_data_to_dst   ),
+    .async_wptr_i ( async_wptr_to_dst   ),
+    .async_rptr_o ( async_rptr_from_dst )
+  );
+
+endmodule

--- a/test/simulate_cdc_fifo_gray.sh
+++ b/test/simulate_cdc_fifo_gray.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Copyright 2026 ETH Zurich and University of Bologna.
+#
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 0.51 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Authors:
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+#
+# Description: Gray-Counter CDC FIFO Simulation Sweep
+# Compile the test target and run plain plus timed-delay Questa regressions for
+# cc_cdc_fifo_gray.
+
+set -euo pipefail
+
+: "${BENDER:=bender}"
+: "${VSIM:=vsim}"
+
+read -r -a bender_cmd <<< "${BENDER}"
+read -r -a vsim_cmd <<< "${VSIM}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+build_dir="${CDC_FIFO_GRAY_BUILDDIR:-${repo_root}/build/vsim/cdc_fifo_gray}"
+compile_tcl="${build_dir}/compile.tcl"
+
+mkdir -p "${build_dir}"
+
+cd "${repo_root}"
+"${bender_cmd[@]}" checkout
+"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+
+cd "${build_dir}"
+"${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"
+
+call_vsim() {
+  local name="$1"
+  local log_file="vsim.${name}.log"
+  shift
+  echo "== ${name} =="
+  "${vsim_cmd[@]}" -c -quiet cc_cdc_fifo_gray_tb "$@" -do 'run -all; quit -f' |
+    tee "${log_file}"
+  grep "Errors: 0," "${log_file}"
+}
+
+call_vsim depth1_default \
+  -gSEED=1 \
+  -gDEPTH=1 \
+  -gNUM_RANDOM_TRANSFERS=80
+
+call_vsim depth2_default \
+  -gSEED=2 \
+  -gDEPTH=2 \
+  -gNUM_RANDOM_TRANSFERS=100
+
+call_vsim depth3_default \
+  -gSEED=3 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=120
+
+call_vsim src_fast \
+  -gSEED=4 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=100 \
+  -gTCK_SRC_PS=5000 \
+  -gTCK_DST_PS=17000
+
+call_vsim dst_fast \
+  -gSEED=5 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=100 \
+  -gTCK_SRC_PS=17000 \
+  -gTCK_DST_PS=5000
+
+call_vsim timed_depth2_800ps \
+  -gSEED=11 \
+  -gDEPTH=2 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=800 \
+  -gTCK_SRC_PS=10000 \
+  -gTCK_DST_PS=10000
+
+call_vsim timed_relprime_offset_1800ps \
+  -gSEED=12 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=1800 \
+  -gTCK_SRC_PS=7000 \
+  -gTCK_DST_PS=11000 \
+  -gSRC_START_DELAY_PS=1500 \
+  -gDST_START_DELAY_PS=3300
+
+call_vsim timed_src_fast_near_bound \
+  -gSEED=13 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=4500 \
+  -gTCK_SRC_PS=5000 \
+  -gTCK_DST_PS=17000 \
+  -gSRC_START_DELAY_PS=1000 \
+  -gDST_START_DELAY_PS=2500
+
+call_vsim timed_dst_fast_near_bound \
+  -gSEED=14 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=4500 \
+  -gTCK_SRC_PS=17000 \
+  -gTCK_DST_PS=5000 \
+  -gSRC_START_DELAY_PS=2500 \
+  -gDST_START_DELAY_PS=1000


### PR DESCRIPTION
Forwards SyncStages into the gray FIFO sides and splits pointer/data handling into clearer source and destination path modules. Adds timed gray FIFO test coverage with async delay injection.