### PR TITLE
cdc_4phase: forward sync stages parameter

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,8 @@ sg-lint:
     - |
       if [ "$TOPLEVEL" = "cc_cdc_fifo_gray_tb" ]; then
         ./test/simulate_cdc_fifo_gray.sh
+      elif [ "$TOPLEVEL" = "cc_cdc_4phase_tb" ]; then
+        ./test/simulate_cdc_4phase.sh
       elif [ "$TOPLEVEL" = "cc_cdc_2phase_clearable_tb" ]; then
         ./test/simulate_cdc_clearable.sh
       else
@@ -66,6 +68,7 @@ tests:
           - cc_addr_decode_tb
           - cc_cb_filter_tb
           - cc_cdc_2phase_clearable_tb
+          - cc_cdc_4phase_tb
           - cc_cdc_fifo_gray_tb
           # - cc_cdc_fifo_clearable_tb
           - cc_clk_int_div_tb

--- a/Bender.yml
+++ b/Bender.yml
@@ -128,6 +128,7 @@ sources:
       - test/cc_cb_filter_tb.sv
       - test/cc_cdc_2phase_tb.sv
       - test/cc_cdc_2phase_clearable_tb.sv
+      - test/cc_cdc_4phase_tb.sv
       - test/cc_cdc_fifo_gray_tb.sv
       - test/cc_cdc_fifo_tb.sv
       - test/cc_cdc_fifo_clearable_tb.sv

--- a/src/cc_cdc_4phase.sv
+++ b/src/cc_cdc_4phase.sv
@@ -30,6 +30,8 @@
 /// during an async reset even if there is no clock available. This mode is
 /// required for proper functionality of the cc_cdc_reset_ctrlr module.
 ///
+/// SyncStages - Number of synchronization stages for async_req and async_ack.
+///
 /// CONSTRAINT: Requires max_delay of min_period(src_clk_i, dst_clk_i) through
 /// the paths async_req, async_ack, async_data.
 `include "common_cells/registers.svh"
@@ -38,7 +40,8 @@ module cc_cdc_4phase #(
   parameter type data_t = logic,
   parameter bit Decoupled = 1'b1,
   parameter bit SendResetMsg = 1'b0,
-  parameter data_t ResetMsg = data_t'('0)
+  parameter data_t ResetMsg = data_t'('0),
+  parameter int unsigned SyncStages = 2
 )(
   input  logic  src_rst_ni,
   input  logic  src_clk_i,
@@ -58,9 +61,14 @@ module cc_cdc_4phase #(
   (* dont_touch = "true" *) logic  async_ack;
   (* dont_touch = "true" *) data_t async_data;
 
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
+
   // The sender in the source domain.
   cc_cdc_4phase_src #(
     .data_t(data_t),
+    .SyncStages(SyncStages),
     .Decoupled(Decoupled),
     .SendResetMsg(SendResetMsg),
     .ResetMsg(ResetMsg)
@@ -76,7 +84,11 @@ module cc_cdc_4phase #(
   );
 
   // The receiver in the destination domain.
-  cc_cdc_4phase_dst #(.data_t(data_t), .Decoupled(Decoupled)) i_dst (
+  cc_cdc_4phase_dst #(
+    .data_t(data_t),
+    .SyncStages(SyncStages),
+    .Decoupled(Decoupled)
+  ) i_dst (
     .rst_ni       ( dst_rst_ni  ),
     .clk_i        ( dst_clk_i   ),
     .data_o       ( dst_data_o  ),
@@ -118,6 +130,10 @@ module cc_cdc_4phase_src #(
   state_e state_d, state_q;
   localparam logic ReqSrcResetValue = SendResetMsg ? 1'b1 : 1'b0;
   localparam data_t DataSrcResetValue = SendResetMsg ? ResetMsg : data_t'('0);
+
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
 
   // Synchronize the async ACK
   tc_sync #(
@@ -195,7 +211,7 @@ endmodule
 module cc_cdc_4phase_dst #(
   parameter type data_t = logic,
   parameter int unsigned SyncStages = 2,
-  parameter bit Decoupled = 1
+  parameter bit Decoupled = 1'b1
 )(
   input  logic  rst_ni,
   input  logic  clk_i,
@@ -219,6 +235,10 @@ module cc_cdc_4phase_dst #(
 
   typedef enum logic[1:0] {IDLE, WAIT_DOWNSTREAM_ACK, WAIT_REQ_DEASSERT} state_e;
   state_e state_d, state_q;
+
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
 
   //Synchronize the request
   tc_sync #(

--- a/test/cc_cdc_4phase_tb.sv
+++ b/test/cc_cdc_4phase_tb.sv
@@ -1,0 +1,561 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Authors:
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+//
+// Description: Four-Phase CDC Testbench
+// Exercise payload ordering, coupled/decoupled source handshakes, reset-message
+// behavior, and timed async-channel delay sweeps for cc_cdc_4phase.
+
+module cc_cdc_4phase_tb;
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  // --------------------------------------------------------------------------
+  // Configuration
+  // --------------------------------------------------------------------------
+  parameter int unsigned NUM_RANDOM_TRANSFERS = 200;
+  parameter int unsigned SYNC_STAGES = 2;
+  parameter int unsigned TCK_SRC_PS = 10000;
+  parameter int unsigned TCK_DST_PS = 17000;
+  parameter int unsigned TIMEOUT_CYCLES = 20000;
+  parameter int unsigned SEED = 32'hcdc4_0001;
+  parameter bit          DECOUPLED = 1'b1;
+  parameter bit          SEND_RESET_MSG = 1'b0;
+  parameter logic [31:0] RESET_MSG = 32'hcdc4_4e57;
+  parameter bit          INJECT_DELAYS = 1'b0;
+  parameter int unsigned MAX_DELAY_PS = 0;
+  parameter int unsigned SRC_START_DELAY_PS = 0;
+  parameter int unsigned DST_START_DELAY_PS = 0;
+
+  typedef enum logic [1:0] {
+    DstReadyLow,
+    DstReadyHigh,
+    DstReadyRandom
+  } dst_ready_mode_e;
+
+  time tck_src = TCK_SRC_PS * 1ps;
+  time tck_dst = TCK_DST_PS * 1ps;
+
+  logic        src_rst_ni = 1'b1;
+  logic        src_clk_i = 1'b0;
+  logic [31:0] src_data_i = '0;
+  logic        src_valid_i = 1'b0;
+  logic        src_ready_o;
+
+  logic        dst_rst_ni = 1'b1;
+  logic        dst_clk_i = 1'b0;
+  logic [31:0] dst_data_o;
+  logic        dst_valid_o;
+  logic        dst_ready_i = 1'b0;
+
+  logic [31:0] expected_q[$];
+  int unsigned num_src_handshakes = 0;
+  int unsigned num_dst_handshakes = 0;
+  int unsigned num_words_expected = 0;
+  int unsigned num_reset_messages = 0;
+  int unsigned optional_reset_messages = 0;
+  int unsigned num_errors = 0;
+
+  dst_ready_mode_e dst_ready_mode = DstReadyLow;
+
+  // --------------------------------------------------------------------------
+  // DUT Selection
+  // --------------------------------------------------------------------------
+  // Instantiate either the plain DUT or the timed delay-injection harness used
+  // by sweeps to perturb every explicit asynchronous channel.
+  if (INJECT_DELAYS) begin : gen_delayed_dut
+    cc_cdc_4phase_tb_delay_injector #(
+      .SYNC_STAGES    ( SYNC_STAGES    ),
+      .DECOUPLED      ( DECOUPLED      ),
+      .SEND_RESET_MSG ( SEND_RESET_MSG ),
+      .RESET_MSG      ( RESET_MSG      ),
+      .MAX_DELAY_PS   ( MAX_DELAY_PS   )
+    ) i_dut (
+      .src_rst_ni,
+      .src_clk_i,
+      .src_data_i,
+      .src_valid_i,
+      .src_ready_o,
+      .dst_rst_ni,
+      .dst_clk_i,
+      .dst_data_o,
+      .dst_valid_o,
+      .dst_ready_i
+    );
+  end else begin : gen_dut
+    cc_cdc_4phase #(
+      .data_t       ( logic [31:0]  ),
+      .Decoupled    ( DECOUPLED     ),
+      .SendResetMsg ( SEND_RESET_MSG ),
+      .ResetMsg     ( RESET_MSG     ),
+      .SyncStages   ( SYNC_STAGES   )
+    ) i_dut (
+      .src_rst_ni,
+      .src_clk_i,
+      .src_data_i,
+      .src_valid_i,
+      .src_ready_o,
+      .dst_rst_ni,
+      .dst_clk_i,
+      .dst_data_o,
+      .dst_valid_o,
+      .dst_ready_i
+    );
+  end
+
+  // --------------------------------------------------------------------------
+  // Clock And Ready Generation
+  // --------------------------------------------------------------------------
+  initial begin : gen_src_clk
+    #(SRC_START_DELAY_PS * 1ps);
+    forever #(tck_src / 2) src_clk_i = ~src_clk_i;
+  end
+
+  initial begin : gen_dst_clk
+    #(DST_START_DELAY_PS * 1ps);
+    forever #(tck_dst / 2) dst_clk_i = ~dst_clk_i;
+  end
+
+  always @(negedge dst_clk_i) begin
+    case (dst_ready_mode)
+      DstReadyLow:    dst_ready_i <= 1'b0;
+      DstReadyHigh:   dst_ready_i <= 1'b1;
+      DstReadyRandom: dst_ready_i <= ($urandom_range(0, 99) < 70);
+      default:        dst_ready_i <= 1'b0;
+    endcase
+  end
+
+  // --------------------------------------------------------------------------
+  // Scoreboard And Protocol Checks
+  // --------------------------------------------------------------------------
+  always @(posedge src_clk_i) begin
+    if (src_rst_ni) begin
+      if ($isunknown(src_ready_o)) begin
+        report_error("src_ready_o is unknown");
+      end
+      if ($isunknown(src_valid_i)) begin
+        report_error("src_valid_i is unknown");
+      end
+      if (src_valid_i && $isunknown(src_data_i)) begin
+        report_error("src_data_i is unknown while valid");
+      end
+      if (src_valid_i && src_ready_o) begin
+        num_src_handshakes++;
+      end
+    end
+  end
+
+  always @(posedge dst_clk_i) begin
+    logic [31:0] expected;
+
+    if (dst_rst_ni) begin
+      if ($isunknown(dst_valid_o)) begin
+        report_error("dst_valid_o is unknown");
+      end
+      if ($isunknown(dst_ready_i)) begin
+        report_error("dst_ready_i is unknown");
+      end
+      if (dst_valid_o && $isunknown(dst_data_o)) begin
+        report_error("dst_data_o is unknown while valid");
+      end
+      if (dst_valid_o && dst_ready_i) begin
+        num_dst_handshakes++;
+        if (expected_q.size() == 0) begin
+          if ((optional_reset_messages != 0) && SEND_RESET_MSG && (dst_data_o === RESET_MSG)) begin
+            optional_reset_messages--;
+            num_reset_messages++;
+          end else begin
+            report_error($sformatf("unexpected destination transaction: data=0x%08h",
+                                   dst_data_o));
+          end
+        end else begin
+          expected = expected_q.pop_front();
+          if (dst_data_o !== expected) begin
+            report_error($sformatf("transaction mismatch: expected=0x%08h actual=0x%08h",
+                                   expected, dst_data_o));
+          end
+        end
+      end
+    end
+  end
+
+  // --------------------------------------------------------------------------
+  // Test Helpers
+  // --------------------------------------------------------------------------
+  task automatic report_error(input string msg);
+    num_errors++;
+    $error("%s", msg);
+  endtask
+
+  task automatic wait_src_cycles(input int unsigned cycles);
+    repeat (cycles) begin
+      @(posedge src_clk_i);
+    end
+    #1ps;
+  endtask
+
+  task automatic wait_dst_cycles(input int unsigned cycles);
+    repeat (cycles) begin
+      @(posedge dst_clk_i);
+    end
+    #1ps;
+  endtask
+
+  task automatic expect_word(input logic [31:0] data);
+    expected_q.push_back(data);
+    num_words_expected++;
+  endtask
+
+  task automatic reset_both_domains;
+    expected_q.delete();
+    src_data_i = '0;
+    src_valid_i = 1'b0;
+    dst_ready_mode = DstReadyLow;
+    optional_reset_messages = SEND_RESET_MSG ? 1 : 0;
+    src_rst_ni = 1'b0;
+    dst_rst_ni = 1'b0;
+
+    fork
+      wait_src_cycles(4);
+      wait_dst_cycles(4);
+    join
+
+    src_rst_ni = 1'b1;
+    dst_rst_ni = 1'b1;
+
+    fork
+      wait_src_cycles(6);
+      wait_dst_cycles(6);
+    join
+
+    wait_source_available("power-on reset");
+    if (SEND_RESET_MSG) begin
+      dst_ready_mode = DstReadyHigh;
+      fork
+        wait_src_cycles(SYNC_STAGES + 4);
+        wait_dst_cycles(SYNC_STAGES + 4);
+      join
+      dst_ready_mode = DstReadyLow;
+      wait_dst_cycles(2);
+    end
+  endtask
+
+  task automatic send_word(input logic [31:0] data);
+    @(negedge src_clk_i);
+    #1ps;
+    src_data_i = data;
+    src_valid_i = 1'b1;
+    expect_word(data);
+
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_ready_o) begin
+        @(posedge src_clk_i);
+        @(negedge src_clk_i);
+        src_valid_i = 1'b0;
+        src_data_i = '0;
+        return;
+      end
+      @(negedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout sending data=0x%08h", data));
+    src_valid_i = 1'b0;
+  endtask
+
+  task automatic wait_scoreboard_empty(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (expected_q.size() == 0) begin
+        return;
+      end
+      @(posedge dst_clk_i or posedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for scoreboard to drain in %s, pending=%0d",
+                           test_name, expected_q.size()));
+  endtask
+
+  task automatic wait_src_ready(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_ready_o) begin
+        return;
+      end
+      @(posedge src_clk_i or posedge dst_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for source ready in %s", test_name));
+  endtask
+
+  task automatic wait_source_available(input string test_name);
+    if (DECOUPLED) begin
+      wait_src_ready(test_name);
+    end else begin
+      wait_src_cycles(2);
+    end
+  endtask
+
+  task automatic wait_dst_valid(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (dst_valid_o) begin
+        return;
+      end
+      @(posedge dst_clk_i or posedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for destination valid in %s", test_name));
+  endtask
+
+  task automatic send_sequence(input int unsigned num_words, input logic [31:0] base);
+    for (int unsigned i = 0; i < num_words; i++) begin
+      send_word(base + i);
+      if ($urandom_range(0, 3) == 0) begin
+        wait_src_cycles($urandom_range(1, 3));
+      end
+    end
+  endtask
+
+  task automatic run_transfer_check(input string test_name, input int unsigned num_words,
+                                    input logic [31:0] base,
+                                    input dst_ready_mode_e ready_mode);
+    $display("%m: %s", test_name);
+    dst_ready_mode = ready_mode;
+    send_sequence(num_words, base);
+    wait_scoreboard_empty(test_name);
+    wait_source_available(test_name);
+    dst_ready_mode = DstReadyLow;
+    wait_dst_cycles(2);
+  endtask
+
+  task automatic run_backpressure_check(input string test_name, input logic [31:0] data,
+                                        input logic [31:0] post_base);
+    $display("%m: %s", test_name);
+    dst_ready_mode = DstReadyLow;
+    wait_source_available(test_name);
+    fork
+      send_word(data);
+      begin
+        wait_dst_valid(test_name);
+        wait_dst_cycles($urandom_range(4, 12));
+        dst_ready_mode = DstReadyHigh;
+        wait_scoreboard_empty(test_name);
+      end
+    join
+    wait_scoreboard_empty(test_name);
+    wait_source_available(test_name);
+    run_transfer_check({test_name, " recovery transfer"}, 8, post_base, DstReadyHigh);
+  endtask
+
+  task automatic run_source_reset_message_check;
+    if (!SEND_RESET_MSG) begin
+      return;
+    end
+
+    $display("%m: source reset message");
+    dst_ready_mode = DstReadyHigh;
+    wait_scoreboard_empty("pre-source-reset-message");
+    wait_source_available("pre-source-reset-message");
+    optional_reset_messages = 0;
+    expect_word(RESET_MSG);
+    num_reset_messages++;
+
+    #(tck_src / 3);
+    src_rst_ni = 1'b0;
+    fork
+      wait_src_cycles(SYNC_STAGES + 6);
+      wait_dst_cycles(SYNC_STAGES + 6);
+    join
+    src_rst_ni = 1'b1;
+
+    wait_scoreboard_empty("source reset message");
+    wait_source_available("source reset message");
+    dst_ready_mode = DstReadyLow;
+    wait_dst_cycles(2);
+  endtask
+
+  // --------------------------------------------------------------------------
+  // Test Sequence
+  // --------------------------------------------------------------------------
+  initial begin : run_tests
+    int unsigned seed;
+
+    seed = SEED;
+    seed = $urandom(seed);
+    $display("%m: SEED=0x%08h derived=0x%08h DECOUPLED=%0d SEND_RESET_MSG=%0d",
+             SEED, seed, DECOUPLED, SEND_RESET_MSG);
+
+    reset_both_domains();
+
+    run_source_reset_message_check();
+    run_transfer_check("basic fixed-ready transfer", 32, 32'h1000_0000, DstReadyHigh);
+    run_backpressure_check("destination backpressure", 32'h2000_0001, 32'h2000_1000);
+    run_transfer_check("randomized ready transfer", NUM_RANDOM_TRANSFERS, 32'h3000_0000,
+                       DstReadyRandom);
+
+    if ((num_errors != 0) || (expected_q.size() != 0)) begin
+      $fatal(1, "%m: failed with %0d errors and %0d pending scoreboard items",
+             num_errors, expected_q.size());
+    end
+
+    $display("%m: passed: expected=%0d dst_handshakes=%0d src_handshakes=%0d reset_msgs=%0d",
+             num_words_expected, num_dst_handshakes, num_src_handshakes, num_reset_messages);
+    $finish;
+  end
+
+endmodule
+
+
+// ----------------------------------------------------------------------------
+// Delay Model Helpers
+// ----------------------------------------------------------------------------
+
+// Per-bit inertial delay model used to sweep relative async channel timing in
+// simulation without changing the production DUT hierarchy.
+module cc_cdc_4phase_tb_bit_delay #(
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic in_i,
+  output logic out_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  initial begin
+    out_o = 1'b0;
+  end
+
+  always @(in_i) begin
+    automatic int unsigned delay_ps;
+    delay_ps = (MAX_DELAY_PS == 0) ? 0 : $urandom_range(0, MAX_DELAY_PS);
+    out_o <= #(delay_ps * 1ps) in_i;
+  end
+
+endmodule
+
+
+// Bus delay wrapper that applies independent random per-bit delay. This stresses
+// bundled payload under the same async timing assumptions as the control wires.
+module cc_cdc_4phase_tb_bus_delay #(
+  parameter int unsigned Width = 1,
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  for (genvar i = 0; i < Width; i++) begin : gen_bit_delay
+    cc_cdc_4phase_tb_bit_delay #(
+      .MAX_DELAY_PS ( MAX_DELAY_PS )
+    ) i_delay (
+      .in_i  ( in_i[i]  ),
+      .out_o ( out_o[i] )
+    );
+  end
+
+endmodule
+
+
+// ----------------------------------------------------------------------------
+// Timed Delay-Injection Harness
+// ----------------------------------------------------------------------------
+
+// Timed test harness equivalent to the DUT, but with explicit delay elements
+// inserted on all payload async wires.
+module cc_cdc_4phase_tb_delay_injector #(
+  parameter int unsigned SYNC_STAGES = 2,
+  parameter bit          DECOUPLED = 1'b1,
+  parameter bit          SEND_RESET_MSG = 1'b0,
+  parameter logic [31:0] RESET_MSG = 32'hcdc4_4e57,
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic        src_rst_ni,
+  input  logic        src_clk_i,
+  input  logic [31:0] src_data_i,
+  input  logic        src_valid_i,
+  output logic        src_ready_o,
+
+  input  logic        dst_rst_ni,
+  input  logic        dst_clk_i,
+  output logic [31:0] dst_data_o,
+  output logic        dst_valid_o,
+  input  logic        dst_ready_i
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  logic        async_req_from_src;
+  logic        async_req_to_dst;
+  logic        async_ack_from_dst;
+  logic        async_ack_to_src;
+  logic [31:0] async_data_from_src;
+  logic [31:0] async_data_to_dst;
+
+  cc_cdc_4phase_tb_bit_delay #(
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_async_req_delay (
+    .in_i  ( async_req_from_src ),
+    .out_o ( async_req_to_dst   )
+  );
+
+  cc_cdc_4phase_tb_bit_delay #(
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_async_ack_delay (
+    .in_i  ( async_ack_from_dst ),
+    .out_o ( async_ack_to_src   )
+  );
+
+  cc_cdc_4phase_tb_bus_delay #(
+    .Width        ( 32           ),
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_async_data_delay (
+    .in_i  ( async_data_from_src ),
+    .out_o ( async_data_to_dst   )
+  );
+
+  cc_cdc_4phase_src #(
+    .data_t       ( logic [31:0]  ),
+    .SyncStages   ( SYNC_STAGES   ),
+    .Decoupled    ( DECOUPLED     ),
+    .SendResetMsg ( SEND_RESET_MSG ),
+    .ResetMsg     ( RESET_MSG     )
+  ) i_src (
+    .rst_ni       ( src_rst_ni          ),
+    .clk_i        ( src_clk_i           ),
+    .data_i       ( src_data_i          ),
+    .valid_i      ( src_valid_i         ),
+    .ready_o      ( src_ready_o         ),
+    .async_req_o  ( async_req_from_src  ),
+    .async_ack_i  ( async_ack_to_src    ),
+    .async_data_o ( async_data_from_src )
+  );
+
+  cc_cdc_4phase_dst #(
+    .data_t     ( logic [31:0] ),
+    .SyncStages ( SYNC_STAGES  ),
+    .Decoupled  ( DECOUPLED    )
+  ) i_dst (
+    .rst_ni       ( dst_rst_ni        ),
+    .clk_i        ( dst_clk_i         ),
+    .data_o       ( dst_data_o        ),
+    .valid_o      ( dst_valid_o       ),
+    .ready_i      ( dst_ready_i       ),
+    .async_req_i  ( async_req_to_dst  ),
+    .async_ack_o  ( async_ack_from_dst ),
+    .async_data_i ( async_data_to_dst )
+  );
+
+endmodule

--- a/test/simulate_cdc_4phase.sh
+++ b/test/simulate_cdc_4phase.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Copyright 2026 ETH Zurich and University of Bologna.
+#
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 0.51 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Authors:
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+#
+# Description: Four-Phase CDC Simulation Sweep
+# Compile the test target and run plain plus timed-delay Questa regressions for
+# cc_cdc_4phase.
+
+set -euo pipefail
+
+: "${BENDER:=bender}"
+: "${VSIM:=vsim}"
+
+read -r -a bender_cmd <<< "${BENDER}"
+read -r -a vsim_cmd <<< "${VSIM}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+build_dir="${CDC_4PHASE_BUILDDIR:-${repo_root}/build/vsim/cdc_4phase}"
+compile_tcl="${build_dir}/compile.tcl"
+
+mkdir -p "${build_dir}"
+
+cd "${repo_root}"
+"${bender_cmd[@]}" checkout
+"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+
+cd "${build_dir}"
+"${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"
+
+call_vsim() {
+  local name="$1"
+  local log_file="vsim.${name}.log"
+  shift
+  echo "== ${name} =="
+  # Questa 10.7 reports the enum-typed RESET_MSG parameter default in
+  # cc_cdc_4phase_src as a suppressible elaboration error, even though the
+  # reset controller overrides it with an enum value.
+  "${vsim_cmd[@]}" -c -quiet cc_cdc_4phase_tb -suppress 8386 "$@" -do 'run -all; quit -f' |
+    tee "${log_file}"
+  grep "Errors: 0," "${log_file}"
+}
+
+call_vsim decoupled_default \
+  -gSEED=1 \
+  -gNUM_RANDOM_TRANSFERS=100
+
+call_vsim coupled_default \
+  -gSEED=2 \
+  -gDECOUPLED=0 \
+  -gNUM_RANDOM_TRANSFERS=100
+
+call_vsim reset_message \
+  -gSEED=3 \
+  -gSEND_RESET_MSG=1 \
+  -gNUM_RANDOM_TRANSFERS=80
+
+call_vsim src_fast \
+  -gSEED=4 \
+  -gNUM_RANDOM_TRANSFERS=100 \
+  -gTCK_SRC_PS=5000 \
+  -gTCK_DST_PS=17000
+
+call_vsim dst_fast \
+  -gSEED=5 \
+  -gNUM_RANDOM_TRANSFERS=100 \
+  -gTCK_SRC_PS=17000 \
+  -gTCK_DST_PS=5000
+
+call_vsim timed_decoupled_800ps \
+  -gSEED=11 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=800 \
+  -gTCK_SRC_PS=10000 \
+  -gTCK_DST_PS=10000
+
+call_vsim timed_coupled_800ps \
+  -gSEED=12 \
+  -gDECOUPLED=0 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=800 \
+  -gTCK_SRC_PS=10000 \
+  -gTCK_DST_PS=10000
+
+call_vsim timed_reset_message_800ps \
+  -gSEED=13 \
+  -gSEND_RESET_MSG=1 \
+  -gNUM_RANDOM_TRANSFERS=60 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=800 \
+  -gTCK_SRC_PS=10000 \
+  -gTCK_DST_PS=10000
+
+call_vsim timed_relprime_offset_2200ps \
+  -gSEED=14 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=2200 \
+  -gTCK_SRC_PS=7000 \
+  -gTCK_DST_PS=11000 \
+  -gSRC_START_DELAY_PS=1500 \
+  -gDST_START_DELAY_PS=3300
+
+call_vsim timed_src_fast_near_bound \
+  -gSEED=15 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=4500 \
+  -gTCK_SRC_PS=5000 \
+  -gTCK_DST_PS=17000 \
+  -gSRC_START_DELAY_PS=1000 \
+  -gDST_START_DELAY_PS=2500
+
+call_vsim timed_dst_fast_near_bound \
+  -gSEED=16 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=4500 \
+  -gTCK_SRC_PS=17000 \
+  -gTCK_DST_PS=5000 \
+  -gSRC_START_DELAY_PS=2500 \
+  -gDST_START_DELAY_PS=1000


### PR DESCRIPTION
Forwards the top-level SyncStages parameter into the 4-phase source and destination halves. Adds timed async-boundary test coverage for the 4-phase CDC.
