### PR TITLE
cdc_2phase: make sync stages configurable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,12 +46,14 @@ sg-lint:
   timeout: 10min
   script:
     - |
-      if [ "$TOPLEVEL" = "cc_cdc_fifo_gray_tb" ]; then
-        ./test/simulate_cdc_fifo_gray.sh
+      if [ "$TOPLEVEL" = "cc_cdc_2phase_clearable_tb" ]; then
+        ./test/simulate_cdc_clearable.sh
+      elif [ "$TOPLEVEL" = "cc_cdc_2phase_tb" ]; then
+        ./test/simulate_cdc_2phase.sh
       elif [ "$TOPLEVEL" = "cc_cdc_4phase_tb" ]; then
         ./test/simulate_cdc_4phase.sh
-      elif [ "$TOPLEVEL" = "cc_cdc_2phase_clearable_tb" ]; then
-        ./test/simulate_cdc_clearable.sh
+      elif [ "$TOPLEVEL" = "cc_cdc_fifo_gray_tb" ]; then
+        ./test/simulate_cdc_fifo_gray.sh
       else
         bender checkout
         bender script vsim -t test > compile.tcl
@@ -68,6 +70,7 @@ tests:
           - cc_addr_decode_tb
           - cc_cb_filter_tb
           - cc_cdc_2phase_clearable_tb
+          - cc_cdc_2phase_tb
           - cc_cdc_4phase_tb
           - cc_cdc_fifo_gray_tb
           # - cc_cdc_fifo_clearable_tb

--- a/src/cc_cdc_2phase.sv
+++ b/src/cc_cdc_2phase.sv
@@ -42,7 +42,8 @@
 `include "common_cells/registers.svh"
 
 module cc_cdc_2phase #(
-  parameter type data_t = logic
+  parameter type data_t = logic,
+  parameter int unsigned SyncStages = 2
 )(
   input  logic  src_rst_ni,
   input  logic  src_clk_i,
@@ -62,8 +63,15 @@ module cc_cdc_2phase #(
   (* dont_touch = "true" *) logic  async_ack;
   (* dont_touch = "true" *) data_t async_data;
 
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
+
   // The sender in the source domain.
-  cc_cdc_2phase_src #(.data_t(data_t)) i_src (
+  cc_cdc_2phase_src #(
+    .data_t     ( data_t     ),
+    .SyncStages ( SyncStages )
+  ) i_src (
     .rst_ni       ( src_rst_ni  ),
     .clk_i        ( src_clk_i   ),
     .data_i       ( src_data_i  ),
@@ -75,7 +83,10 @@ module cc_cdc_2phase #(
   );
 
   // The receiver in the destination domain.
-  cc_cdc_2phase_dst #(.data_t(data_t)) i_dst (
+  cc_cdc_2phase_dst #(
+    .data_t     ( data_t     ),
+    .SyncStages ( SyncStages )
+  ) i_dst (
     .rst_ni       ( dst_rst_ni  ),
     .clk_i        ( dst_clk_i   ),
     .data_o       ( dst_data_o  ),
@@ -91,7 +102,8 @@ endmodule
 
 /// Half of the two-phase clock domain crossing located in the source domain.
 module cc_cdc_2phase_src #(
-  parameter type data_t = logic
+  parameter type data_t = logic,
+  parameter int unsigned SyncStages = 2
 )(
   input  logic  rst_ni,
   input  logic  clk_i,
@@ -104,23 +116,33 @@ module cc_cdc_2phase_src #(
 );
 
   (* dont_touch = "true" *)
-  logic req_src_q, ack_src_q, ack_q;
+  logic req_src_q, ack_synced;
   (* dont_touch = "true" *)
   data_t data_src_q;
   logic src_accept;
 
   assign src_accept = valid_i && ready_o;
 
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
+
+  // Synchronize the async ACK.
+  tc_sync #(
+    .Stages ( SyncStages )
+  ) i_sync (
+    .clk_i,
+    .rst_ni,
+    .serial_i ( async_ack_i ),
+    .serial_o ( ack_synced  )
+  );
+
   // The req_src and data_src registers change when a new data item is accepted.
   `FFL(req_src_q,  ~req_src_q, src_accept, 1'b0,       clk_i, rst_ni)
   `FFL(data_src_q, data_i,     src_accept, data_t'('0), clk_i, rst_ni)
 
-  // The ack_src and ack registers act as synchronization stages.
-  `FF(ack_src_q, async_ack_i, 1'b0, clk_i, rst_ni)
-  `FF(ack_q,     ack_src_q,   1'b0, clk_i, rst_ni)
-
   // Output assignments.
-  assign ready_o = (req_src_q == ack_q);
+  assign ready_o = (req_src_q == ack_synced);
   assign async_req_o = req_src_q;
   assign async_data_o = data_src_q;
 
@@ -130,7 +152,8 @@ endmodule
 /// Half of the two-phase clock domain crossing located in the destination
 /// domain.
 module cc_cdc_2phase_dst #(
-  parameter type data_t = logic
+  parameter type data_t = logic,
+  parameter int unsigned SyncStages = 2
 )(
   input  logic  rst_ni,
   input  logic  clk_i,
@@ -143,14 +166,27 @@ module cc_cdc_2phase_dst #(
 );
 
   (* dont_touch = "true" *)
-  (* async_reg = "true" *)
-  logic req_dst_q, req_q0, req_q1, ack_dst_q;
+  logic req_synced, req_synced_q1, ack_dst_q;
   (* dont_touch = "true" *)
   data_t data_dst_q;
   logic dst_accept, dst_data_load;
 
   assign dst_accept   = valid_o && ready_i;
-  assign dst_data_load = req_q0 != req_q1 && !valid_o;
+  assign dst_data_load = req_synced != req_synced_q1 && !valid_o;
+
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
+
+  // Synchronize the async request.
+  tc_sync #(
+    .Stages ( SyncStages )
+  ) i_sync (
+    .clk_i,
+    .rst_ni,
+    .serial_i ( async_req_i ),
+    .serial_o ( req_synced  )
+  );
 
   // The ack_dst register changes when a new data item is accepted.
   `FFL(ack_dst_q, ~ack_dst_q, dst_accept, 1'b0, clk_i, rst_ni)
@@ -159,13 +195,11 @@ module cc_cdc_2phase_dst #(
   // indicated by the async_req line changing levels.
   `FFL(data_dst_q, async_data_i, dst_data_load, data_t'('0), clk_i, rst_ni)
 
-  // The req_dst and req registers act as synchronization stages.
-  `FF(req_dst_q, async_req_i, 1'b0, clk_i, rst_ni)
-  `FF(req_q0,    req_dst_q,   1'b0, clk_i, rst_ni)
-  `FF(req_q1,    req_q0,      1'b0, clk_i, rst_ni)
+  // Delayed version of the synchronized request for transition detection.
+  `FF(req_synced_q1, req_synced, 1'b0, clk_i, rst_ni)
 
   // Output assignments.
-  assign valid_o = (ack_dst_q != req_q1);
+  assign valid_o = (ack_dst_q != req_synced_q1);
   assign data_o = data_dst_q;
   assign async_ack_o = ack_dst_q;
 

--- a/test/cc_cdc_2phase_tb.sv
+++ b/test/cc_cdc_2phase_tb.sv
@@ -9,192 +9,414 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 //
-// Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+// Authors:
+// - Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+//
+// Description: Two-Phase CDC Testbench
+// Exercise payload ordering, destination backpressure, and timed async-channel
+// delay sweeps for cc_cdc_2phase.
 
 module cc_cdc_2phase_tb;
 
-  parameter int UNTIL = 100000;
-  parameter bit INJECT_DELAYS = 1;
-  parameter bit POST_SYNTHESIS = 0;
+  timeunit 1ns;
+  timeprecision 1ps;
 
-  time tck_src = 10ns;
-  time tck_dst = 10ns;
-  bit src_done = 0;
-  bit dst_done = 0;
-  bit done;
-  assign done = src_done & dst_done;
+  // --------------------------------------------------------------------------
+  // Configuration
+  // --------------------------------------------------------------------------
+  parameter int unsigned UNTIL = 0;
+  parameter int unsigned NUM_RANDOM_TRANSFERS = 200;
+  parameter int unsigned TCK_SRC_PS = 10000;
+  parameter int unsigned TCK_DST_PS = 17000;
+  parameter int unsigned TIMEOUT_CYCLES = 20000;
+  parameter int unsigned SEED = 32'hcdc2_0001;
+  parameter bit          INJECT_DELAYS = 1'b0;
+  parameter int unsigned MAX_DELAY_PS = 0;
+  parameter int unsigned SRC_START_DELAY_PS = 0;
+  parameter int unsigned DST_START_DELAY_PS = 0;
+  parameter bit          POST_SYNTHESIS = 1'b0;
 
-  // Signals of the design under test.
-  logic        src_rst_ni  = 1;
-  logic        src_clk_i   = 0;
-  logic [31:0] src_data_i  = 0;
-  logic        src_valid_i = 0;
+  localparam int unsigned EffectiveRandomTransfers =
+      (UNTIL == 0) ? NUM_RANDOM_TRANSFERS : UNTIL;
+
+  typedef enum logic [1:0] {
+    DstReadyLow,
+    DstReadyHigh,
+    DstReadyRandom
+  } dst_ready_mode_e;
+
+  time tck_src = TCK_SRC_PS * 1ps;
+  time tck_dst = TCK_DST_PS * 1ps;
+
+  logic        src_rst_ni = 1'b1;
+  logic        src_clk_i = 1'b0;
+  logic [31:0] src_data_i = '0;
+  logic        src_valid_i = 1'b0;
   logic        src_ready_o;
 
-  logic        dst_rst_ni  = 1;
-  logic        dst_clk_i   = 0;
+  logic        dst_rst_ni = 1'b1;
+  logic        dst_clk_i = 1'b0;
   logic [31:0] dst_data_o;
   logic        dst_valid_o;
-  logic        dst_ready_i = 0;
+  logic        dst_ready_i = 1'b0;
 
-  // Instantiate the design under test.
-  if (POST_SYNTHESIS) begin : g_dut
-    cc_cdc_2phase_synth i_dut (.*);
-  end else if (INJECT_DELAYS) begin : g_dut
-    cc_cdc_2phase_tb_delay_injector #(0.8ns) i_dut (.*);
-  end else begin : g_dut
-    cc_cdc_2phase #(logic [31:0]) i_dut (.*);
+  logic [31:0] expected_q[$];
+  int unsigned num_src_handshakes = 0;
+  int unsigned num_dst_handshakes = 0;
+  int unsigned num_errors = 0;
+
+  dst_ready_mode_e dst_ready_mode = DstReadyLow;
+
+  // --------------------------------------------------------------------------
+  // DUT Selection
+  // --------------------------------------------------------------------------
+  // Instantiate either the plain DUT or the timed delay-injection harness used
+  // by sweeps to perturb every explicit asynchronous channel.
+  if (POST_SYNTHESIS) begin : gen_synth_dut
+    cc_cdc_2phase_synth i_dut (
+      .src_rst_ni,
+      .src_clk_i,
+      .src_data_i,
+      .src_valid_i,
+      .src_ready_o,
+      .dst_rst_ni,
+      .dst_clk_i,
+      .dst_data_o,
+      .dst_valid_o,
+      .dst_ready_i
+    );
+  end else if (INJECT_DELAYS) begin : gen_delayed_dut
+    cc_cdc_2phase_tb_delay_injector #(
+      .MAX_DELAY_PS ( MAX_DELAY_PS )
+    ) i_dut (
+      .src_rst_ni,
+      .src_clk_i,
+      .src_data_i,
+      .src_valid_i,
+      .src_ready_o,
+      .dst_rst_ni,
+      .dst_clk_i,
+      .dst_data_o,
+      .dst_valid_o,
+      .dst_ready_i
+    );
+  end else begin : gen_dut
+    cc_cdc_2phase #(
+      .data_t ( logic [31:0] )
+    ) i_dut (
+      .src_rst_ni,
+      .src_clk_i,
+      .src_data_i,
+      .src_valid_i,
+      .src_ready_o,
+      .dst_rst_ni,
+      .dst_clk_i,
+      .dst_data_o,
+      .dst_valid_o,
+      .dst_ready_i
+    );
   end
 
-  // Mailbox with expected items on destination side.
-  mailbox #(integer) dst_mbox = new();
-  int num_sent = 0;
-  int num_received = 0;
-  int num_failed = 0;
+  // --------------------------------------------------------------------------
+  // Clock And Ready Generation
+  // --------------------------------------------------------------------------
+  initial begin : gen_src_clk
+    #(SRC_START_DELAY_PS * 1ps);
+    forever #(tck_src / 2) src_clk_i = ~src_clk_i;
+  end
 
-  // Clock generators.
-  initial begin
-    static int num_items, num_clks;
-    num_items = 10;
-    num_clks = 0;
-    #10ns;
-    src_rst_ni = 0;
-    #10ns;
-    src_rst_ni = 1;
-    #10ns;
-    while (!done) begin
-      src_clk_i = 1;
-      #(tck_src/2);
-      src_clk_i = 0;
-      #(tck_src/2);
+  initial begin : gen_dst_clk
+    #(DST_START_DELAY_PS * 1ps);
+    forever #(tck_dst / 2) dst_clk_i = ~dst_clk_i;
+  end
 
-      // Modulate the clock frequency.
-      num_clks++;
-      if (num_sent >= num_items && num_clks > 10) begin
-        num_items = num_sent + 10;
-        num_clks = 0;
-        tck_src = $urandom_range(1000, 10000) * 1ps;
-        assert(tck_src > 0);
+  always @(negedge dst_clk_i) begin
+    case (dst_ready_mode)
+      DstReadyLow:    dst_ready_i <= 1'b0;
+      DstReadyHigh:   dst_ready_i <= 1'b1;
+      DstReadyRandom: dst_ready_i <= ($urandom_range(0, 99) < 70);
+      default:        dst_ready_i <= 1'b0;
+    endcase
+  end
+
+  // --------------------------------------------------------------------------
+  // Scoreboard And Protocol Checks
+  // --------------------------------------------------------------------------
+  // Scoreboard source and destination handshakes.
+  always @(posedge src_clk_i) begin
+    if (src_rst_ni) begin
+      if ($isunknown(src_ready_o)) begin
+        report_error("src_ready_o is unknown");
+      end
+      if ($isunknown(src_valid_i)) begin
+        report_error("src_valid_i is unknown");
+      end
+      if (src_valid_i && $isunknown(src_data_i)) begin
+        report_error("src_data_i is unknown while valid");
+      end
+      if (src_valid_i && src_ready_o) begin
+        num_src_handshakes++;
+        expected_q.push_back(src_data_i);
       end
     end
   end
 
-  initial begin
-    static int num_items, num_clks;
-    num_items = 10;
-    num_clks = 0;
-    #10ns;
-    dst_rst_ni = 0;
-    #10ns;
-    dst_rst_ni = 1;
-    #10ns;
-    while (!done) begin
-      dst_clk_i = 1;
-      #(tck_dst/2);
-      dst_clk_i = 0;
-      #(tck_dst/2);
+  always @(posedge dst_clk_i) begin
+    logic [31:0] expected;
 
-      // Modulate the clock frequency.
-      num_clks++;
-      if (num_received >= num_items && num_clks > 10) begin
-        num_items = num_received + 10;
-        num_clks = 0;
-        tck_dst = $urandom_range(1000, 10000) * 1ps;
-        assert(tck_dst > 0);
+    if (dst_rst_ni) begin
+      if ($isunknown(dst_valid_o)) begin
+        report_error("dst_valid_o is unknown");
       end
-    end
-  end
-
-  // Source side sender.
-  task src_cycle_start;
-    #(tck_src*0.8);
-  endtask
-
-  task src_cycle_end;
-    @(posedge src_clk_i);
-  endtask
-
-  initial begin
-    @(negedge src_rst_ni);
-    @(posedge src_rst_ni);
-    repeat(3) @(posedge src_clk_i);
-    for (int i = 0; i < UNTIL; i++) begin
-      static integer stimulus;
-      stimulus = $random();
-      src_data_i  <= #(tck_src*0.2) stimulus;
-      src_valid_i <= #(tck_src*0.2) 1;
-      dst_mbox.put(stimulus);
-      num_sent++;
-      src_cycle_start();
-      while (!src_ready_o) begin
-        src_cycle_end();
-        src_cycle_start();
+      if ($isunknown(dst_ready_i)) begin
+        report_error("dst_ready_i is unknown");
       end
-      src_cycle_end();
-      src_valid_i <= #(tck_src*0.2) 0;
-    end
-    src_done = 1;
-  end
-
-  // Destination side receiver.
-  task dst_cycle_start;
-    #(tck_dst*0.8);
-  endtask
-
-  task dst_cycle_end;
-    @(posedge dst_clk_i);
-  endtask
-
-  initial begin
-    @(negedge dst_rst_ni);
-    @(posedge dst_rst_ni);
-    repeat(3) @(posedge dst_clk_i);
-    while (!src_done || dst_mbox.num() > 0) begin
-      static integer expected, actual;
-      static int cooldown;
-      dst_ready_i <= #(tck_dst*0.2) 1;
-      dst_cycle_start();
-      while (!dst_valid_o) begin
-        dst_cycle_end();
-        dst_cycle_start();
+      if (dst_valid_o && $isunknown(dst_data_o)) begin
+        report_error("dst_data_o is unknown while valid");
       end
-      actual = dst_data_o;
-      num_received++;
-      if (dst_mbox.num() == 0) begin
-        $error("unexpected transaction: data=%0h", actual);
-        num_failed++;
-      end else begin
-        dst_mbox.get(expected);
-        if (actual != expected) begin
-          $error("transaction mismatch: exp=%0h, act=%0h", expected, actual);
-          num_failed++;
+      if (dst_valid_o && dst_ready_i) begin
+        num_dst_handshakes++;
+        if (expected_q.size() == 0) begin
+          report_error($sformatf("unexpected destination transaction: data=0x%08h",
+                                 dst_data_o));
+        end else begin
+          expected = expected_q.pop_front();
+          if (dst_data_o !== expected) begin
+            report_error($sformatf("transaction mismatch: expected=0x%08h actual=0x%08h",
+                                   expected, dst_data_o));
+          end
         end
       end
-      dst_cycle_end();
-      dst_ready_i <= #(tck_dst*0.2) 0;
+    end
+  end
 
-      // Insert a random cooldown period.
-      cooldown = $urandom_range(0, 40);
-      if (cooldown < 20) repeat(cooldown) @(posedge dst_clk_i);
+  // --------------------------------------------------------------------------
+  // Test Helpers
+  // --------------------------------------------------------------------------
+  task automatic report_error(input string msg);
+    num_errors++;
+    $error("%s", msg);
+  endtask
+
+  task automatic wait_src_cycles(input int unsigned cycles);
+    repeat (cycles) begin
+      @(posedge src_clk_i);
+    end
+    #1ps;
+  endtask
+
+  task automatic wait_dst_cycles(input int unsigned cycles);
+    repeat (cycles) begin
+      @(posedge dst_clk_i);
+    end
+    #1ps;
+  endtask
+
+  task automatic reset_both_domains;
+    expected_q.delete();
+    src_data_i = '0;
+    src_valid_i = 1'b0;
+    dst_ready_mode = DstReadyLow;
+    src_rst_ni = 1'b0;
+    dst_rst_ni = 1'b0;
+
+    fork
+      wait_src_cycles(4);
+      wait_dst_cycles(4);
+    join
+
+    src_rst_ni = 1'b1;
+    dst_rst_ni = 1'b1;
+
+    fork
+      wait_src_cycles(6);
+      wait_dst_cycles(6);
+    join
+  endtask
+
+  task automatic send_word(input logic [31:0] data);
+    @(negedge src_clk_i);
+    #1ps;
+    src_data_i = data;
+    src_valid_i = 1'b1;
+
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_ready_o) begin
+        @(posedge src_clk_i);
+        @(negedge src_clk_i);
+        src_valid_i = 1'b0;
+        src_data_i = '0;
+        return;
+      end
+      @(negedge src_clk_i);
     end
 
-    if (num_sent != num_received) begin
-      $error("%0d items sent, but %0d items received", num_sent, num_received);
-    end
-    if (num_failed > 0) begin
-      $error("%0d/%0d items mismatched", num_failed, num_sent);
-    end else begin
-      $info("%0d items passed", num_sent);
+    report_error($sformatf("timeout sending data=0x%08h", data));
+    src_valid_i = 1'b0;
+  endtask
+
+  task automatic wait_scoreboard_empty(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (expected_q.size() == 0) begin
+        return;
+      end
+      @(posedge dst_clk_i or posedge src_clk_i);
     end
 
-    dst_done = 1;
+    report_error($sformatf("timeout waiting for scoreboard to drain in %s, pending=%0d",
+                           test_name, expected_q.size()));
+  endtask
+
+  task automatic wait_src_ready(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_ready_o) begin
+        return;
+      end
+      @(posedge src_clk_i or posedge dst_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for source ready in %s", test_name));
+  endtask
+
+  task automatic wait_dst_valid(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (dst_valid_o) begin
+        return;
+      end
+      @(posedge dst_clk_i or posedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for destination valid in %s", test_name));
+  endtask
+
+  task automatic send_sequence(input int unsigned num_words, input logic [31:0] base);
+    for (int unsigned i = 0; i < num_words; i++) begin
+      send_word(base + i);
+      if ($urandom_range(0, 3) == 0) begin
+        wait_src_cycles($urandom_range(1, 3));
+      end
+    end
+  endtask
+
+  task automatic run_transfer_check(input string test_name, input int unsigned num_words,
+                                    input logic [31:0] base,
+                                    input dst_ready_mode_e ready_mode);
+    $display("%m: %s", test_name);
+    dst_ready_mode = ready_mode;
+    send_sequence(num_words, base);
+    wait_scoreboard_empty(test_name);
+    wait_src_ready(test_name);
+    dst_ready_mode = DstReadyLow;
+    wait_dst_cycles(2);
+  endtask
+
+  task automatic run_backpressure_check(input string test_name, input logic [31:0] data,
+                                        input logic [31:0] post_base);
+    $display("%m: %s", test_name);
+    dst_ready_mode = DstReadyLow;
+    wait_src_ready(test_name);
+    send_word(data);
+    wait_dst_valid(test_name);
+    wait_dst_cycles($urandom_range(4, 12));
+    dst_ready_mode = DstReadyHigh;
+    wait_scoreboard_empty(test_name);
+    wait_src_ready(test_name);
+    run_transfer_check({test_name, " recovery transfer"}, 8, post_base, DstReadyHigh);
+  endtask
+
+  // --------------------------------------------------------------------------
+  // Test Sequence
+  // --------------------------------------------------------------------------
+  initial begin : run_tests
+    int unsigned seed;
+
+    seed = SEED;
+    seed = $urandom(seed);
+    $display("%m: SEED=0x%08h derived=0x%08h", SEED, seed);
+
+    reset_both_domains();
+
+    run_transfer_check("basic fixed-ready transfer", 32, 32'h1000_0000, DstReadyHigh);
+    run_backpressure_check("destination backpressure", 32'h2000_0001, 32'h2000_1000);
+    run_transfer_check("randomized ready transfer", EffectiveRandomTransfers, 32'h3000_0000,
+                       DstReadyRandom);
+
+    if ((num_errors != 0) || (expected_q.size() != 0)) begin
+      $fatal(1, "%m: failed with %0d errors and %0d pending scoreboard items",
+             num_errors, expected_q.size());
+    end
+
+    $display("%m: passed: src_handshakes=%0d dst_handshakes=%0d",
+             num_src_handshakes, num_dst_handshakes);
+    $finish;
   end
 
 endmodule
 
 
+// ----------------------------------------------------------------------------
+// Delay Model Helpers
+// ----------------------------------------------------------------------------
+
+// Per-bit inertial delay model used to sweep relative async channel timing in
+// simulation without changing the production DUT hierarchy.
+module cc_cdc_2phase_tb_bit_delay #(
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic in_i,
+  output logic out_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  initial begin
+    out_o = 1'b0;
+  end
+
+  always @(in_i) begin
+    automatic int unsigned delay_ps;
+    delay_ps = (MAX_DELAY_PS == 0) ? 0 : $urandom_range(0, MAX_DELAY_PS);
+    out_o <= #(delay_ps * 1ps) in_i;
+  end
+
+endmodule
+
+
+// Bus delay wrapper that applies independent random per-bit delay. This stresses
+// bundled payload under the same async timing assumptions as the control wires.
+module cc_cdc_2phase_tb_bus_delay #(
+  parameter int unsigned Width = 1,
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  for (genvar i = 0; i < Width; i++) begin : gen_bit_delay
+    cc_cdc_2phase_tb_bit_delay #(
+      .MAX_DELAY_PS ( MAX_DELAY_PS )
+    ) i_delay (
+      .in_i  ( in_i[i]  ),
+      .out_o ( out_o[i] )
+    );
+  end
+
+endmodule
+
+
+// ----------------------------------------------------------------------------
+// Timed Delay-Injection Harness
+// ----------------------------------------------------------------------------
+
+// Timed test harness equivalent to the DUT, but with explicit delay elements
+// inserted on all payload async wires.
 module cc_cdc_2phase_tb_delay_injector #(
-  parameter time MaxDelay = 0ns
+  parameter int unsigned MAX_DELAY_PS = 0
 )(
   input  logic        src_rst_ni,
   input  logic        src_clk_i,
@@ -209,47 +431,62 @@ module cc_cdc_2phase_tb_delay_injector #(
   input  logic        dst_ready_i
 );
 
-  logic async_req_o, async_req_i;
-  logic async_ack_o, async_ack_i;
-  logic [31:0] async_data_o, async_data_i;
+  timeunit 1ns;
+  timeprecision 1ps;
 
-  always @(async_req_o) begin
-    automatic time d = $urandom_range(0, MaxDelay);
-    async_req_i <= #d async_req_o;
-  end
+  logic        async_req_from_src;
+  logic        async_req_to_dst;
+  logic        async_ack_from_dst;
+  logic        async_ack_to_src;
+  logic [31:0] async_data_from_src;
+  logic [31:0] async_data_to_dst;
 
-  always @(async_ack_o) begin
-    automatic time d = $urandom_range(0, MaxDelay);
-    async_ack_i <= #d async_ack_o;
-  end
-
-  for (genvar i = 0; i < 32; i++) begin
-    always @(async_data_o[i]) begin
-      automatic time d = $urandom_range(0, MaxDelay);
-      async_data_i[i] <= #d async_data_o[i];
-    end
-  end
-
-  cc_cdc_2phase_src #(logic [31:0]) i_src (
-    .rst_ni       ( src_rst_ni   ),
-    .clk_i        ( src_clk_i    ),
-    .data_i       ( src_data_i   ),
-    .valid_i      ( src_valid_i  ),
-    .ready_o      ( src_ready_o  ),
-    .async_req_o  ( async_req_o  ),
-    .async_ack_i  ( async_ack_i  ),
-    .async_data_o ( async_data_o )
+  cc_cdc_2phase_tb_bit_delay #(
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_async_req_delay (
+    .in_i  ( async_req_from_src ),
+    .out_o ( async_req_to_dst   )
   );
 
-  cc_cdc_2phase_dst #(logic [31:0]) i_dst (
-    .rst_ni       ( dst_rst_ni   ),
-    .clk_i        ( dst_clk_i    ),
-    .data_o       ( dst_data_o   ),
-    .valid_o      ( dst_valid_o  ),
-    .ready_i      ( dst_ready_i  ),
-    .async_req_i  ( async_req_i  ),
-    .async_ack_o  ( async_ack_o  ),
-    .async_data_i ( async_data_i )
+  cc_cdc_2phase_tb_bit_delay #(
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_async_ack_delay (
+    .in_i  ( async_ack_from_dst ),
+    .out_o ( async_ack_to_src   )
+  );
+
+  cc_cdc_2phase_tb_bus_delay #(
+    .Width        ( 32           ),
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_async_data_delay (
+    .in_i  ( async_data_from_src ),
+    .out_o ( async_data_to_dst   )
+  );
+
+  cc_cdc_2phase_src #(
+    .data_t ( logic [31:0] )
+  ) i_src (
+    .rst_ni       ( src_rst_ni          ),
+    .clk_i        ( src_clk_i           ),
+    .data_i       ( src_data_i          ),
+    .valid_i      ( src_valid_i         ),
+    .ready_o      ( src_ready_o         ),
+    .async_req_o  ( async_req_from_src  ),
+    .async_ack_i  ( async_ack_to_src    ),
+    .async_data_o ( async_data_from_src )
+  );
+
+  cc_cdc_2phase_dst #(
+    .data_t ( logic [31:0] )
+  ) i_dst (
+    .rst_ni       ( dst_rst_ni        ),
+    .clk_i        ( dst_clk_i         ),
+    .data_o       ( dst_data_o        ),
+    .valid_o      ( dst_valid_o       ),
+    .ready_i      ( dst_ready_i       ),
+    .async_req_i  ( async_req_to_dst  ),
+    .async_ack_o  ( async_ack_from_dst ),
+    .async_data_i ( async_data_to_dst )
   );
 
 endmodule

--- a/test/simulate_cdc_2phase.sh
+++ b/test/simulate_cdc_2phase.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Copyright 2026 ETH Zurich and University of Bologna.
+#
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 0.51 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Authors:
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+#
+# Description: Two-Phase CDC Simulation Sweep
+# Compile the test target and run plain plus timed-delay Questa regressions for
+# cc_cdc_2phase.
+
+set -euo pipefail
+
+: "${BENDER:=bender}"
+: "${VSIM:=vsim}"
+
+read -r -a bender_cmd <<< "${BENDER}"
+read -r -a vsim_cmd <<< "${VSIM}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+build_dir="${CDC_2PHASE_BUILDDIR:-${repo_root}/build/vsim/cdc_2phase}"
+compile_tcl="${build_dir}/compile.tcl"
+
+mkdir -p "${build_dir}"
+
+cd "${repo_root}"
+"${bender_cmd[@]}" checkout
+"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+
+cd "${build_dir}"
+"${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"
+
+call_vsim() {
+  local name="$1"
+  local log_file="vsim.${name}.log"
+  shift
+  echo "== ${name} =="
+  "${vsim_cmd[@]}" -c -quiet cc_cdc_2phase_tb "$@" -do 'run -all; quit -f' |
+    tee "${log_file}"
+  grep "Errors: 0," "${log_file}"
+}
+
+call_vsim smoke_default \
+  -gSEED=1 \
+  -gNUM_RANDOM_TRANSFERS=100
+
+call_vsim src_fast \
+  -gSEED=2 \
+  -gNUM_RANDOM_TRANSFERS=100 \
+  -gTCK_SRC_PS=5000 \
+  -gTCK_DST_PS=17000
+
+call_vsim dst_fast \
+  -gSEED=3 \
+  -gNUM_RANDOM_TRANSFERS=100 \
+  -gTCK_SRC_PS=17000 \
+  -gTCK_DST_PS=5000
+
+call_vsim timed_balanced_250ps \
+  -gSEED=11 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=250 \
+  -gTCK_SRC_PS=10000 \
+  -gTCK_DST_PS=10000
+
+call_vsim timed_src_fast_800ps \
+  -gSEED=12 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=800 \
+  -gTCK_SRC_PS=5000 \
+  -gTCK_DST_PS=17000
+
+call_vsim timed_dst_fast_800ps \
+  -gSEED=13 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=800 \
+  -gTCK_SRC_PS=17000 \
+  -gTCK_DST_PS=5000
+
+call_vsim timed_balanced_offset_1800ps \
+  -gSEED=14 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=1800 \
+  -gTCK_SRC_PS=10000 \
+  -gTCK_DST_PS=10000 \
+  -gDST_START_DELAY_PS=2500
+
+call_vsim timed_relprime_offset_2200ps \
+  -gSEED=15 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=2200 \
+  -gTCK_SRC_PS=7000 \
+  -gTCK_DST_PS=11000 \
+  -gSRC_START_DELAY_PS=1500 \
+  -gDST_START_DELAY_PS=3300
+
+call_vsim timed_src_fast_near_bound \
+  -gSEED=16 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=4500 \
+  -gTCK_SRC_PS=5000 \
+  -gTCK_DST_PS=17000 \
+  -gSRC_START_DELAY_PS=1000 \
+  -gDST_START_DELAY_PS=2500
+
+call_vsim timed_dst_fast_near_bound \
+  -gSEED=17 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=4500 \
+  -gTCK_SRC_PS=17000 \
+  -gTCK_DST_PS=5000 \
+  -gSRC_START_DELAY_PS=2500 \
+  -gDST_START_DELAY_PS=1000


### PR DESCRIPTION
Makes SyncStages configurable for cc_cdc_2phase and forwards it into the source and destination synchronizers. Adds timed async-boundary test coverage for the 2-phase CDC.