### PR TITLE
cdc_fifo_gray_clearable: split clock domains, preserve reset timing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,9 @@ sg-lint:
   timeout: 10min
   script:
     - |
-      if [ "$TOPLEVEL" = "cc_cdc_2phase_clearable_tb" ]; then
+      if [ "$TOPLEVEL" = "cc_cdc_fifo_clearable_tb" ]; then
+        ./test/simulate_cdc_fifo_gray_clearable.sh
+      elif [ "$TOPLEVEL" = "cc_cdc_2phase_clearable_tb" ]; then
         ./test/simulate_cdc_clearable.sh
       elif [ "$TOPLEVEL" = "cc_cdc_2phase_tb" ]; then
         ./test/simulate_cdc_2phase.sh
@@ -75,8 +77,8 @@ tests:
           - cc_cdc_2phase_tb
           - cc_cdc_4phase_tb
           - cc_cdc_fifo_2phase_tb
+          - cc_cdc_fifo_clearable_tb
           - cc_cdc_fifo_gray_tb
-          # - cc_cdc_fifo_clearable_tb
           - cc_clk_int_div_tb
           - cc_clk_int_div_static_tb
           - cc_clk_mux_glitch_free_tb

--- a/src/cc_cdc_fifo_gray_clearable.sv
+++ b/src/cc_cdc_fifo_gray_clearable.sv
@@ -108,9 +108,9 @@ module cc_cdc_fifo_gray_clearable #(
   /// The FIFO's depth given as 2**LogDepth.
   parameter int unsigned LogDepth = 3,
   /// The number of synchronization registers to insert on the async pointers
-  /// between the FIFOs. If ClearOnAsyncReset is enabled, we need at least 4
+  /// between the FIFOs. If ClearOnAsyncReset is enabled, we need at least 3
   /// synchronizer stages to provide the clear synchronizer lower latency than
-  /// the async reset. I.e. if ClearOnAsyncReset==1 -> SyncStages >= 4 else
+  /// the async reset. I.e. if ClearOnAsyncReset==1 -> SyncStages >= 3 else
   /// SyncStages >= 2.
   parameter int unsigned SyncStages = 3,
   parameter bit ClearOnAsyncReset = 1
@@ -208,7 +208,8 @@ module cc_cdc_fifo_gray_clearable #(
   // Synchronize the clear and reset signaling in both directions (see header of
   // the cc_cdc_reset_ctrlr module for more details.)
   cc_cdc_reset_ctrlr #(
-    .SyncStages(SyncStages-1)
+    .SyncStages        ( SyncStages-1      ),
+    .ClearOnAsyncReset ( ClearOnAsyncReset )
   ) i_cdc_reset_ctrlr (
     .a_clk_i         ( src_clk_i           ),
     .a_rst_ni        ( src_rst_ni          ),

--- a/src/cc_cdc_fifo_gray_clearable.sv
+++ b/src/cc_cdc_fifo_gray_clearable.sv
@@ -207,8 +207,10 @@ module cc_cdc_fifo_gray_clearable #(
 
   // Synchronize the clear and reset signaling in both directions (see header of
   // the cc_cdc_reset_ctrlr module for more details.)
+  localparam int unsigned ResetSyncStages = (SyncStages > 2) ? SyncStages - 1 : 2;
+
   cc_cdc_reset_ctrlr #(
-    .SyncStages        ( SyncStages-1      ),
+    .SyncStages        ( ResetSyncStages   ),
     .ClearOnAsyncReset ( ClearOnAsyncReset )
   ) i_cdc_reset_ctrlr (
     .a_clk_i         ( src_clk_i           ),

--- a/src/cc_cdc_fifo_gray_clearable.sv
+++ b/src/cc_cdc_fifo_gray_clearable.sv
@@ -12,6 +12,7 @@
 // Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
 // Florian Zaruba <zarubaf@iis.ee.ethz.ch>
 // Manuel Eggimann <meggimann@iis.ee.ethz.ch> (clearability feature)
+// Philippe Sauter <phsauter@iis.ee.ethz.ch> (source/destination split)
 
 /// A clock domain crossing FIFO, using gray counters.
 ///
@@ -88,6 +89,12 @@
 /// one bit of the read/write pointer have an excessive delay). Furthermore, we
 /// should deactivate setup and hold checks on the asynchronous signals.
 ///
+/// async_data, async_wptr, and async_rptr are the FIFO storage and pointer CDCs
+/// for the actual data path. async_reset_src2dst_req,
+/// async_reset_dst2src_ack, async_reset_src2dst_next_phase,
+/// async_reset_dst2src_req, async_reset_src2dst_ack, and
+/// async_reset_dst2src_next_phase are the CDCs for the clearing state machines.
+///
 /// ``` set_ungroup [get_designs cc_cdc_fifo_gray*] false set_boundary_optimization
 /// [get_designs cc_cdc_fifo_gray*] false set_max_delay min(T_src, T_dst) \
 /// -through [get_pins -hierarchical -filter async] \ -through [get_pins
@@ -132,21 +139,15 @@ module cc_cdc_fifo_gray_clearable #(
   input  logic  dst_ready_i
 );
 
-  logic        s_src_clear_req;
-  logic        s_src_clear_ack_q;
-  logic        s_src_ready;
-  logic        s_src_isolate_req;
-  logic        s_src_isolate_ack_q;
-  logic        s_dst_clear_req;
-  logic        s_dst_clear_ack_q;
-  logic        s_dst_valid;
-  logic        s_dst_isolate_req;
-  logic        s_dst_isolate_ack_q;
-
-
   data_t [2**LogDepth-1:0] async_data;
   logic [LogDepth:0]  async_wptr;
   logic [LogDepth:0]  async_rptr;
+  cc_pkg::cdc_clear_seq_phase_e async_reset_src2dst_next_phase;
+  logic async_reset_src2dst_req;
+  logic async_reset_dst2src_ack;
+  cc_pkg::cdc_clear_seq_phase_e async_reset_dst2src_next_phase;
+  logic async_reset_dst2src_req;
+  logic async_reset_src2dst_ack;
 
   if (ClearOnAsyncReset) begin : gen_elaboration_assertion
     if (SyncStages < 3)
@@ -167,6 +168,129 @@ module cc_cdc_fifo_gray_clearable #(
 
 
 
+  cc_cdc_fifo_gray_clearable_src #(
+    .data_t            ( data_t            ),
+    .LogDepth          ( LogDepth          ),
+    .SyncStages        ( SyncStages        ),
+    .ClearOnAsyncReset ( ClearOnAsyncReset )
+  ) i_src (
+    .src_rst_ni,
+    .src_clk_i,
+    .src_clear_i,
+    .src_clear_pending_o,
+    .src_data_i,
+    .src_valid_i,
+    .src_ready_o,
+
+    (* async *) .async_data_o              ( async_data                   ),
+    (* async *) .async_wptr_o              ( async_wptr                   ),
+    (* async *) .async_rptr_i              ( async_rptr                   ),
+    (* async *) .async_reset_next_phase_o  ( async_reset_src2dst_next_phase ),
+    (* async *) .async_reset_req_o         ( async_reset_src2dst_req        ),
+    (* async *) .async_reset_ack_i         ( async_reset_dst2src_ack        ),
+    (* async *) .async_reset_next_phase_i  ( async_reset_dst2src_next_phase ),
+    (* async *) .async_reset_req_i         ( async_reset_dst2src_req        ),
+    (* async *) .async_reset_ack_o         ( async_reset_src2dst_ack        )
+  );
+
+  cc_cdc_fifo_gray_clearable_dst #(
+    .data_t            ( data_t            ),
+    .LogDepth          ( LogDepth          ),
+    .SyncStages        ( SyncStages        ),
+    .ClearOnAsyncReset ( ClearOnAsyncReset )
+  ) i_dst (
+    .dst_rst_ni,
+    .dst_clk_i,
+    .dst_clear_i,
+    .dst_clear_pending_o,
+    .dst_data_o,
+    .dst_valid_o,
+    .dst_ready_i,
+
+    (* async *) .async_data_i              ( async_data                   ),
+    (* async *) .async_wptr_i              ( async_wptr                   ),
+    (* async *) .async_rptr_o              ( async_rptr                   ),
+    (* async *) .async_reset_next_phase_o  ( async_reset_dst2src_next_phase ),
+    (* async *) .async_reset_req_o         ( async_reset_dst2src_req        ),
+    (* async *) .async_reset_ack_i         ( async_reset_src2dst_ack        ),
+    (* async *) .async_reset_next_phase_i  ( async_reset_src2dst_next_phase ),
+    (* async *) .async_reset_req_i         ( async_reset_src2dst_req        ),
+    (* async *) .async_reset_ack_o         ( async_reset_dst2src_ack        )
+  );
+
+  // Check the invariants.
+  `ifndef COMMON_CELLS_ASSERTS_OFF
+  `ASSERT_INIT(log_depth_0, LogDepth > 0)
+  `ASSERT_INIT(sync_stages_lt_2, SyncStages >= 2)
+  `endif
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_clearable_src #(
+  parameter type data_t = logic,
+  parameter int unsigned LogDepth = 3,
+  parameter int unsigned SyncStages = 2,
+  parameter bit ClearOnAsyncReset = 1
+)(
+  input  logic  src_rst_ni,
+  input  logic  src_clk_i,
+  input  logic  src_clear_i,
+  output logic  src_clear_pending_o,
+  input  data_t src_data_i,
+  input  logic  src_valid_i,
+  output logic  src_ready_o,
+
+  output data_t [2**LogDepth-1:0] async_data_o,
+  output logic  [LogDepth:0]      async_wptr_o,
+  input  logic  [LogDepth:0]      async_rptr_i,
+  output cc_pkg::cdc_clear_seq_phase_e async_reset_next_phase_o,
+  output logic async_reset_req_o,
+  input  logic async_reset_ack_i,
+  input  cc_pkg::cdc_clear_seq_phase_e async_reset_next_phase_i,
+  input  logic async_reset_req_i,
+  output logic async_reset_ack_o
+);
+
+  logic src_clear_req;
+  logic src_clear_ack_q;
+  logic src_ready;
+  logic src_isolate_req;
+  logic src_isolate_ack_q;
+
+  if (ClearOnAsyncReset) begin : gen_elaboration_assertion
+    if (SyncStages < 3)
+      $error("The clearable CDC FIFO with async reset synchronization requires at least",
+             "3 synchronizer stages for the FIFO.");
+  end else begin : gen_elaboration_assertion
+    if (SyncStages < 2) begin : gen_sync_stage_assertion
+      $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+    end
+  end
+
+  localparam int unsigned ResetSyncStages = (SyncStages > 2) ? SyncStages - 1 : 2;
+
+  cc_cdc_reset_ctrlr_half #(
+    .SyncStages        ( ResetSyncStages    ),
+    .ClearOnAsyncReset ( ClearOnAsyncReset )
+  ) i_cdc_reset_ctrlr_half (
+    .clk_i              ( src_clk_i                  ),
+    .rst_ni             ( src_rst_ni                 ),
+    .clear_i            ( src_clear_i                ),
+    .clear_o            ( src_clear_req              ),
+    .clear_ack_i        ( src_clear_ack_q            ),
+    .isolate_o          ( src_isolate_req            ),
+    .isolate_ack_i      ( src_isolate_ack_q          ),
+    (* async *) .async_next_phase_o ( async_reset_next_phase_o ),
+    (* async *) .async_req_o        ( async_reset_req_o        ),
+    (* async *) .async_ack_i        ( async_reset_ack_i        ),
+    (* async *) .async_next_phase_i ( async_reset_next_phase_i ),
+    (* async *) .async_req_i        ( async_reset_req_i        ),
+    (* async *) .async_ack_o        ( async_reset_ack_o        )
+  );
+
   cc_cdc_fifo_gray_src_clearable #(
     .data_t     ( data_t     ),
     .LogDepth   ( LogDepth   ),
@@ -174,17 +298,90 @@ module cc_cdc_fifo_gray_clearable #(
   ) i_src (
     .src_rst_ni,
     .src_clk_i,
-    .src_clear_i ( s_src_clear_req                  ),
+    .src_clear_i ( src_clear_req                  ),
     .src_data_i,
-    .src_valid_i ( src_valid_i & !s_src_isolate_req ),
-    .src_ready_o ( s_src_ready                      ),
+    .src_valid_i ( src_valid_i & !src_isolate_req ),
+    .src_ready_o ( src_ready                      ),
 
-    (* async *) .async_data_o ( async_data ),
-    (* async *) .async_wptr_o ( async_wptr ),
-    (* async *) .async_rptr_i ( async_rptr )
+    (* async *) .async_data_o ( async_data_o ),
+    (* async *) .async_wptr_o ( async_wptr_o ),
+    (* async *) .async_rptr_i ( async_rptr_i )
   );
 
-  assign src_ready_o = s_src_ready & !s_src_isolate_req;
+  assign src_ready_o = src_ready & !src_isolate_req;
+
+  // Isolation and clear are acknowledged one cycle after the local request.
+  `FF(src_isolate_ack_q, src_isolate_req, 1'b0, src_clk_i, src_rst_ni)
+  `FF(src_clear_ack_q,   src_clear_req,   1'b0, src_clk_i, src_rst_ni)
+
+  assign src_clear_pending_o = src_isolate_req;
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_clearable_dst #(
+  parameter type data_t = logic,
+  parameter int unsigned LogDepth = 3,
+  parameter int unsigned SyncStages = 2,
+  parameter bit ClearOnAsyncReset = 1
+)(
+  input  logic  dst_rst_ni,
+  input  logic  dst_clk_i,
+  input  logic  dst_clear_i,
+  output logic  dst_clear_pending_o,
+  output data_t dst_data_o,
+  output logic  dst_valid_o,
+  input  logic  dst_ready_i,
+
+  input  data_t [2**LogDepth-1:0] async_data_i,
+  input  logic  [LogDepth:0]      async_wptr_i,
+  output logic  [LogDepth:0]      async_rptr_o,
+  output cc_pkg::cdc_clear_seq_phase_e async_reset_next_phase_o,
+  output logic async_reset_req_o,
+  input  logic async_reset_ack_i,
+  input  cc_pkg::cdc_clear_seq_phase_e async_reset_next_phase_i,
+  input  logic async_reset_req_i,
+  output logic async_reset_ack_o
+);
+
+  logic dst_clear_req;
+  logic dst_clear_ack_q;
+  logic dst_valid;
+  logic dst_isolate_req;
+  logic dst_isolate_ack_q;
+
+  if (ClearOnAsyncReset) begin : gen_elaboration_assertion
+    if (SyncStages < 3)
+      $error("The clearable CDC FIFO with async reset synchronization requires at least",
+             "3 synchronizer stages for the FIFO.");
+  end else begin : gen_elaboration_assertion
+    if (SyncStages < 2) begin : gen_sync_stage_assertion
+      $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+    end
+  end
+
+  localparam int unsigned ResetSyncStages = (SyncStages > 2) ? SyncStages - 1 : 2;
+
+  cc_cdc_reset_ctrlr_half #(
+    .SyncStages        ( ResetSyncStages    ),
+    .ClearOnAsyncReset ( ClearOnAsyncReset )
+  ) i_cdc_reset_ctrlr_half (
+    .clk_i              ( dst_clk_i                  ),
+    .rst_ni             ( dst_rst_ni                 ),
+    .clear_i            ( dst_clear_i                ),
+    .clear_o            ( dst_clear_req              ),
+    .clear_ack_i        ( dst_clear_ack_q            ),
+    .isolate_o          ( dst_isolate_req            ),
+    .isolate_ack_i      ( dst_isolate_ack_q          ),
+    (* async *) .async_next_phase_o ( async_reset_next_phase_o ),
+    (* async *) .async_req_o        ( async_reset_req_o        ),
+    (* async *) .async_ack_i        ( async_reset_ack_i        ),
+    (* async *) .async_next_phase_i ( async_reset_next_phase_i ),
+    (* async *) .async_req_i        ( async_reset_req_i        ),
+    (* async *) .async_ack_o        ( async_reset_ack_o        )
+  );
 
   cc_cdc_fifo_gray_dst_clearable #(
     .data_t     ( data_t     ),
@@ -193,61 +390,23 @@ module cc_cdc_fifo_gray_clearable #(
   ) i_dst (
     .dst_rst_ni,
     .dst_clk_i,
-    .dst_clear_i ( s_dst_clear_req                  ),
+    .dst_clear_i ( dst_clear_req                  ),
     .dst_data_o,
-    .dst_valid_o ( s_dst_valid                      ),
-    .dst_ready_i ( dst_ready_i & !s_dst_isolate_req ),
+    .dst_valid_o ( dst_valid                      ),
+    .dst_ready_i ( dst_ready_i & !dst_isolate_req ),
 
-    (* async *) .async_data_i ( async_data ),
-    (* async *) .async_wptr_i ( async_wptr ),
-    (* async *) .async_rptr_o ( async_rptr )
+    (* async *) .async_data_i ( async_data_i ),
+    (* async *) .async_wptr_i ( async_wptr_i ),
+    (* async *) .async_rptr_o ( async_rptr_o )
   );
 
-  assign dst_valid_o = s_dst_valid & !s_dst_isolate_req;
+  assign dst_valid_o = dst_valid & !dst_isolate_req;
 
-  // Synchronize the clear and reset signaling in both directions (see header of
-  // the cc_cdc_reset_ctrlr module for more details.)
-  localparam int unsigned ResetSyncStages = (SyncStages > 2) ? SyncStages - 1 : 2;
+  // Isolation and clear are acknowledged one cycle after the local request.
+  `FF(dst_isolate_ack_q, dst_isolate_req, 1'b0, dst_clk_i, dst_rst_ni)
+  `FF(dst_clear_ack_q,   dst_clear_req,   1'b0, dst_clk_i, dst_rst_ni)
 
-  cc_cdc_reset_ctrlr #(
-    .SyncStages        ( ResetSyncStages   ),
-    .ClearOnAsyncReset ( ClearOnAsyncReset )
-  ) i_cdc_reset_ctrlr (
-    .a_clk_i         ( src_clk_i           ),
-    .a_rst_ni        ( src_rst_ni          ),
-    .a_clear_i       ( src_clear_i         ),
-    .a_clear_o       ( s_src_clear_req     ),
-    .a_clear_ack_i   ( s_src_clear_ack_q   ),
-    .a_isolate_o     ( s_src_isolate_req   ),
-    .a_isolate_ack_i ( s_src_isolate_ack_q ),
-    .b_clk_i         ( dst_clk_i           ),
-    .b_rst_ni        ( dst_rst_ni          ),
-    .b_clear_i       ( dst_clear_i         ),
-    .b_clear_o       ( s_dst_clear_req     ),
-    .b_clear_ack_i   ( s_dst_clear_ack_q   ),
-    .b_isolate_o     ( s_dst_isolate_req   ),
-    .b_isolate_ack_i ( s_dst_isolate_ack_q )
-  );
-
-  // Just delay the isolate request by one cycle. We can ensure isolation within
-  // one cycle by just deasserting valid and ready signals on both sides of the CDC.
-  `FF(s_src_isolate_ack_q, s_src_isolate_req, 1'b0, src_clk_i, src_rst_ni)
-  `FF(s_src_clear_ack_q,   s_src_clear_req,   1'b0, src_clk_i, src_rst_ni)
-
-  `FF(s_dst_isolate_ack_q, s_dst_isolate_req, 1'b0, dst_clk_i, dst_rst_ni)
-  `FF(s_dst_clear_ack_q,   s_dst_clear_req,   1'b0, dst_clk_i, dst_rst_ni)
-
-
-  assign src_clear_pending_o = s_src_isolate_req; // The isolate signal stays
-                                                  // asserted during the whole
-                                                  // clear sequence.
-  assign dst_clear_pending_o = s_dst_isolate_req;
-
-  // Check the invariants.
-  `ifndef COMMON_CELLS_ASSERTS_OFF
-  `ASSERT_INIT(log_depth_0, LogDepth > 0)
-  `ASSERT_INIT(sync_stages_lt_2, SyncStages >= 2)
-  `endif
+  assign dst_clear_pending_o = dst_isolate_req;
 
 endmodule
 
@@ -271,43 +430,36 @@ module cc_cdc_fifo_gray_src_clearable #(
   input  logic  [LogDepth:0]      async_rptr_i
 );
 
-  localparam int unsigned PtrWidth = LogDepth+1;
-  localparam logic [PtrWidth-1:0] PtrFull = (1 << LogDepth);
+  logic [LogDepth-1:0] src_widx;
+  logic src_write;
 
-  data_t [2**LogDepth-1:0] data_q, data_d;
-  logic [PtrWidth-1:0] wptr_q, wptr_d, wptr_bin, wptr_next, rptr, rptr_bin;
+  assign src_write = src_valid_i & src_ready_o;
 
-  // Data FIFO.
-  assign async_data_o = data_q;
-  always_comb begin
-    data_d                          = data_q;
-    data_d[wptr_bin[LogDepth-1:0]] = src_data_i;
-  end
-  `FFL(data_q, data_d, src_valid_i & src_ready_o, '0, src_clk_i, src_rst_ni)
+  cc_cdc_fifo_gray_src_data_clearable #(
+    .data_t   ( data_t   ),
+    .LogDepth ( LogDepth )
+  ) i_src_data (
+    .src_rst_ni,
+    .src_clk_i,
+    .src_data_i,
+    .src_widx_i  ( src_widx     ),
+    .src_write_i ( src_write    ),
+    .async_data_o
+  );
 
-  // Read pointer.
-  for (genvar i = 0; i < PtrWidth; i++) begin : gen_sync
-    tc_sync #(.Stages(SyncStages)) i_sync (
-      .clk_i    ( src_clk_i       ),
-      .rst_ni   ( src_rst_ni      ),
-      .serial_i ( async_rptr_i[i] ),
-      .serial_o ( rptr[i]         )
-    );
-  end
-  cc_gray_to_binary #(PtrWidth) i_rptr_g2b (.a_i(rptr), .z_o(rptr_bin));
-
-  // Write pointer.
-  assign wptr_next = wptr_bin+1;
-  cc_gray_to_binary #(PtrWidth) i_wptr_g2b (.a_i(wptr_q), .z_o(wptr_bin));
-  cc_binary_to_gray #(PtrWidth) i_wptr_b2g (.a_i(wptr_next), .z_o(wptr_d));
-  `FFLARNC(wptr_q, wptr_d, src_valid_i & src_ready_o, src_clear_i, '0, src_clk_i, src_rst_ni)
-  assign async_wptr_o = wptr_q;
-
-  // The pointers into the FIFO are one bit wider than the actual address into
-  // the FIFO. This makes detecting critical states very simple: if all but the
-  // topmost bit of rptr and wptr agree, the FIFO is in a critical state. If the
-  // topmost bit is equal, the FIFO is empty, otherwise it is full.
-  assign src_ready_o = ((wptr_bin ^ rptr_bin) != PtrFull);
+  cc_cdc_fifo_gray_src_ptr_clearable #(
+    .LogDepth   ( LogDepth   ),
+    .SyncStages ( SyncStages )
+  ) i_src_ptr (
+    .src_rst_ni,
+    .src_clk_i,
+    .src_clear_i,
+    .src_valid_i,
+    .src_ready_o,
+    .src_widx_o  ( src_widx     ),
+    .async_wptr_o,
+    .async_rptr_i
+  );
 
 endmodule
 
@@ -331,23 +483,161 @@ module cc_cdc_fifo_gray_dst_clearable #(
   output logic  [LogDepth:0]      async_rptr_o
 );
 
+  logic dst_valid, dst_ready;
+  logic [LogDepth-1:0] dst_ridx;
+
+  cc_cdc_fifo_gray_dst_ptr_clearable #(
+    .LogDepth   ( LogDepth   ),
+    .SyncStages ( SyncStages )
+  ) i_dst_ptr (
+    .dst_rst_ni,
+    .dst_clk_i,
+    .dst_clear_i,
+    .dst_ready_i ( dst_ready    ),
+    .dst_valid_o ( dst_valid    ),
+    .dst_ridx_o  ( dst_ridx     ),
+    .async_wptr_i,
+    .async_rptr_o
+  );
+
+  cc_cdc_fifo_gray_dst_data_clearable #(
+    .data_t   ( data_t   ),
+    .LogDepth ( LogDepth )
+  ) i_dst_data (
+    .dst_rst_ni,
+    .dst_clk_i,
+    .dst_clear_i,
+    .dst_data_o,
+    .dst_valid_o,
+    .dst_ready_i,
+    .dst_valid_i ( dst_valid    ),
+    .dst_ready_o ( dst_ready    ),
+    .dst_ridx_i  ( dst_ridx     ),
+    .async_data_i
+  );
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_src_data_clearable #(
+  parameter type data_t = logic,
+  parameter int unsigned LogDepth = 3
+)(
+  input  logic  src_rst_ni,
+  input  logic  src_clk_i,
+  input  data_t src_data_i,
+  input  logic [LogDepth-1:0] src_widx_i,
+  input  logic  src_write_i,
+  output data_t [2**LogDepth-1:0] async_data_o
+);
+
+  data_t [2**LogDepth-1:0] data_d, data_q;
+
+  always_comb begin
+    data_d = data_q;
+    data_d[src_widx_i] = src_data_i;
+  end
+
+  `FFL(data_q, data_d, src_write_i, '0, src_clk_i, src_rst_ni)
+
+  assign async_data_o = data_q;
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_src_ptr_clearable #(
+  parameter int unsigned LogDepth = 3,
+  parameter int unsigned SyncStages = 2
+)(
+  input  logic src_rst_ni,
+  input  logic src_clk_i,
+  input  logic src_clear_i,
+  input  logic src_valid_i,
+  output logic src_ready_o,
+  output logic [LogDepth-1:0] src_widx_o,
+  output logic [LogDepth:0]   async_wptr_o,
+  input  logic [LogDepth:0]   async_rptr_i
+);
+
+  localparam int unsigned PtrWidth = LogDepth+1;
+  localparam logic [PtrWidth-1:0] PtrFull = (1 << LogDepth);
+
+  logic [PtrWidth-1:0] wptr_q, wptr_d, wptr_bin, wptr_next, rptr, rptr_bin;
+
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
+
+  // Read pointer from the destination domain, synchronized into the source
+  // domain for the full check.
+  for (genvar i = 0; i < PtrWidth; i++) begin : gen_sync
+    tc_sync #(.Stages(SyncStages)) i_sync (
+      .clk_i    ( src_clk_i       ),
+      .rst_ni   ( src_rst_ni      ),
+      .serial_i ( async_rptr_i[i] ),
+      .serial_o ( rptr[i]         )
+    );
+  end
+  cc_gray_to_binary #(PtrWidth) i_rptr_g2b (.a_i(rptr), .z_o(rptr_bin));
+
+  // Local write pointer.
+  assign wptr_next = wptr_bin+1;
+  cc_gray_to_binary #(PtrWidth) i_wptr_g2b (.a_i(wptr_q), .z_o(wptr_bin));
+  cc_binary_to_gray #(PtrWidth) i_wptr_b2g (.a_i(wptr_next), .z_o(wptr_d));
+  `FFLARNC(wptr_q, wptr_d, src_valid_i & src_ready_o, src_clear_i, '0, src_clk_i, src_rst_ni)
+
+  assign src_widx_o   = wptr_bin[LogDepth-1:0];
+  assign async_wptr_o = wptr_q;
+
+  // The pointers into the FIFO are one bit wider than the actual address into
+  // the FIFO. This makes detecting critical states very simple: if all but the
+  // topmost bit of rptr and wptr agree, the FIFO is in a critical state. If the
+  // topmost bit is equal, the FIFO is empty, otherwise it is full.
+  assign src_ready_o = ((wptr_bin ^ rptr_bin) != PtrFull);
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_dst_ptr_clearable #(
+  parameter int unsigned LogDepth = 3,
+  parameter int unsigned SyncStages = 2
+)(
+  input  logic dst_rst_ni,
+  input  logic dst_clk_i,
+  input  logic dst_clear_i,
+  input  logic dst_ready_i,
+  output logic dst_valid_o,
+  output logic [LogDepth-1:0] dst_ridx_o,
+  input  logic [LogDepth:0]   async_wptr_i,
+  output logic [LogDepth:0]   async_rptr_o
+);
+
   localparam int unsigned PtrWidth = LogDepth+1;
   localparam logic [PtrWidth-1:0] PtrEmpty = '0;
 
-  data_t dst_data;
   logic [PtrWidth-1:0] rptr_q, rptr_d, rptr_bin, rptr_next, wptr, wptr_bin;
-  logic dst_valid, dst_ready;
-  // Data selector and register.
-  assign dst_data = async_data_i[rptr_bin[LogDepth-1:0]];
 
-  // Read pointer.
+  if (SyncStages < 2) begin : gen_sync_stage_assertion
+    $error("A minimum of 2 synchronizer stages is required for proper functionality.");
+  end
+
+  // Local read pointer.
   assign rptr_next = rptr_bin+1;
   cc_gray_to_binary #(PtrWidth) i_rptr_g2b (.a_i(rptr_q), .z_o(rptr_bin));
   cc_binary_to_gray #(PtrWidth) i_rptr_b2g (.a_i(rptr_next), .z_o(rptr_d));
-  `FFLARNC(rptr_q, rptr_d, dst_valid & dst_ready, dst_clear_i, '0, dst_clk_i, dst_rst_ni)
+  `FFLARNC(rptr_q, rptr_d, dst_valid_o & dst_ready_i, dst_clear_i, '0, dst_clk_i, dst_rst_ni)
+
+  assign dst_ridx_o   = rptr_bin[LogDepth-1:0];
   assign async_rptr_o = rptr_q;
 
-  // Write pointer.
+  // Write pointer from the source domain, synchronized into the destination
+  // domain for the empty check.
   for (genvar i = 0; i < PtrWidth; i++) begin : gen_sync
     tc_sync #(.Stages(SyncStages)) i_sync (
       .clk_i    ( dst_clk_i       ),
@@ -362,7 +652,32 @@ module cc_cdc_fifo_gray_dst_clearable #(
   // the FIFO. This makes detecting critical states very simple: if all but the
   // topmost bit of rptr and wptr agree, the FIFO is in a critical state. If the
   // topmost bit is equal, the FIFO is empty, otherwise it is full.
-  assign dst_valid = ((wptr_bin ^ rptr_bin) != PtrEmpty);
+  assign dst_valid_o = ((wptr_bin ^ rptr_bin) != PtrEmpty);
+
+endmodule
+
+
+(* no_ungroup *)
+(* no_boundary_optimization *)
+module cc_cdc_fifo_gray_dst_data_clearable #(
+  parameter type data_t = logic,
+  parameter int unsigned LogDepth = 3
+)(
+  input  logic  dst_rst_ni,
+  input  logic  dst_clk_i,
+  input  logic  dst_clear_i,
+  output data_t dst_data_o,
+  output logic  dst_valid_o,
+  input  logic  dst_ready_i,
+  input  logic  dst_valid_i,
+  output logic  dst_ready_o,
+  input  logic [LogDepth-1:0] dst_ridx_i,
+  input  data_t [2**LogDepth-1:0] async_data_i
+);
+
+  data_t dst_data;
+
+  assign dst_data = async_data_i[dst_ridx_i];
 
   // Cut the combinatorial path with a spill register.
   cc_spill_register_flushable #(
@@ -372,8 +687,8 @@ module cc_cdc_fifo_gray_dst_clearable #(
     .rst_ni  ( dst_rst_ni               ),
     .clr_i   ( '0                       ),
     .flush_i ( dst_clear_i              ),
-    .valid_i ( dst_valid & !dst_clear_i ),
-    .ready_o ( dst_ready                ),
+    .valid_i ( dst_valid_i & !dst_clear_i ),
+    .ready_o ( dst_ready_o              ),
     .data_i  ( dst_data                 ),
     .valid_o ( dst_valid_o              ),
     .ready_i ( dst_ready_i              ),

--- a/test/cc_cdc_fifo_clearable_tb.sv
+++ b/test/cc_cdc_fifo_clearable_tb.sv
@@ -725,17 +725,6 @@ module cc_cdc_fifo_clearable_tb_delay_injector #(
   localparam int unsigned ClearPhaseWidth = $bits(cdc_clear_seq_phase_e);
   typedef logic [31:0] data_t;
 
-  logic        s_src_clear_req;
-  logic        s_src_clear_ack_q;
-  logic        s_src_ready;
-  logic        s_src_isolate_req;
-  logic        s_src_isolate_ack_q;
-  logic        s_dst_clear_req;
-  logic        s_dst_clear_ack_q;
-  logic        s_dst_valid;
-  logic        s_dst_isolate_req;
-  logic        s_dst_isolate_ack_q;
-
   data_t [2**LOG_DEPTH-1:0] async_data_from_src;
   data_t [2**LOG_DEPTH-1:0] async_data_to_dst;
   logic [PtrWidth-1:0] async_wptr_from_src;
@@ -772,25 +761,31 @@ module cc_cdc_fifo_clearable_tb_delay_injector #(
   assign async_reset_dst2src_next_phase_to_src =
       cdc_clear_seq_phase_e'(async_reset_dst2src_next_phase_to_src_bits);
 
-  // Source and destination FIFO halves are connected through delayed async data
-  // and gray pointer channels below.
-  cc_cdc_fifo_gray_src_clearable #(
-    .data_t     ( data_t      ),
-    .LogDepth   ( LOG_DEPTH   ),
-    .SyncStages ( SYNC_STAGES )
+  // Source and destination sides are connected through delayed async
+  // data, gray pointer, and clear-controller channels below.
+  cc_cdc_fifo_gray_clearable_src #(
+    .data_t            ( data_t               ),
+    .LogDepth          ( LOG_DEPTH            ),
+    .SyncStages        ( SYNC_STAGES          ),
+    .ClearOnAsyncReset ( CLEAR_ON_ASYNC_RESET )
   ) i_src (
     .src_rst_ni,
     .src_clk_i,
-    .src_clear_i ( s_src_clear_req                  ),
+    .src_clear_i,
+    .src_clear_pending_o,
     .src_data_i,
-    .src_valid_i ( src_valid_i & !s_src_isolate_req ),
-    .src_ready_o ( s_src_ready                      ),
-    .async_data_o ( async_data_from_src ),
-    .async_wptr_o ( async_wptr_from_src ),
-    .async_rptr_i ( async_rptr_to_src   )
+    .src_valid_i,
+    .src_ready_o,
+    .async_data_o              ( async_data_from_src                   ),
+    .async_wptr_o              ( async_wptr_from_src                   ),
+    .async_rptr_i              ( async_rptr_to_src                     ),
+    .async_reset_next_phase_o  ( async_reset_src2dst_next_phase_from_src ),
+    .async_reset_req_o         ( async_reset_src2dst_req_from_src        ),
+    .async_reset_ack_i         ( async_reset_src2dst_ack_to_src          ),
+    .async_reset_next_phase_i  ( async_reset_dst2src_next_phase_to_src   ),
+    .async_reset_req_i         ( async_reset_dst2src_req_to_src          ),
+    .async_reset_ack_o         ( async_reset_dst2src_ack_from_src        )
   );
-
-  assign src_ready_o = s_src_ready & !s_src_isolate_req;
 
   for (genvar i = 0; i < 2**LOG_DEPTH; i++) begin : gen_data_delay
     cc_cdc_fifo_clearable_tb_bus_delay #(
@@ -818,23 +813,29 @@ module cc_cdc_fifo_clearable_tb_delay_injector #(
     .out_o ( async_rptr_to_src   )
   );
 
-  cc_cdc_fifo_gray_dst_clearable #(
-    .data_t     ( data_t      ),
-    .LogDepth   ( LOG_DEPTH   ),
-    .SyncStages ( SYNC_STAGES )
+  cc_cdc_fifo_gray_clearable_dst #(
+    .data_t            ( data_t               ),
+    .LogDepth          ( LOG_DEPTH            ),
+    .SyncStages        ( SYNC_STAGES          ),
+    .ClearOnAsyncReset ( CLEAR_ON_ASYNC_RESET )
   ) i_dst (
     .dst_rst_ni,
     .dst_clk_i,
-    .dst_clear_i ( s_dst_clear_req                  ),
+    .dst_clear_i,
+    .dst_clear_pending_o,
     .dst_data_o,
-    .dst_valid_o ( s_dst_valid                      ),
-    .dst_ready_i ( dst_ready_i & !s_dst_isolate_req ),
-    .async_data_i ( async_data_to_dst   ),
-    .async_wptr_i ( async_wptr_to_dst   ),
-    .async_rptr_o ( async_rptr_from_dst )
+    .dst_valid_o,
+    .dst_ready_i,
+    .async_data_i              ( async_data_to_dst                    ),
+    .async_wptr_i              ( async_wptr_to_dst                    ),
+    .async_rptr_o              ( async_rptr_from_dst                  ),
+    .async_reset_next_phase_o  ( async_reset_dst2src_next_phase_from_dst ),
+    .async_reset_req_o         ( async_reset_dst2src_req_from_dst        ),
+    .async_reset_ack_i         ( async_reset_dst2src_ack_to_dst          ),
+    .async_reset_next_phase_i  ( async_reset_src2dst_next_phase_to_dst   ),
+    .async_reset_req_i         ( async_reset_src2dst_req_to_dst          ),
+    .async_reset_ack_o         ( async_reset_src2dst_ack_from_dst        )
   );
-
-  assign dst_valid_o = s_dst_valid & !s_dst_isolate_req;
 
   // Clear-controller async handshakes get the same delay model as the FIFO CDC
   // channels so clear sequencing is exercised under timing skew as well.
@@ -881,68 +882,5 @@ module cc_cdc_fifo_clearable_tb_delay_injector #(
     .in_i  ( async_reset_dst2src_next_phase_from_dst_bits ),
     .out_o ( async_reset_dst2src_next_phase_to_src_bits   )
   );
-
-  cc_cdc_reset_ctrlr_half #(
-    .SyncStages        ( SYNC_STAGES - 1      ),
-    .ClearOnAsyncReset ( CLEAR_ON_ASYNC_RESET )
-  ) i_cdc_reset_ctrlr_half_src (
-    .clk_i              ( src_clk_i                                  ),
-    .rst_ni             ( src_rst_ni                                 ),
-    .clear_i            ( src_clear_i                                ),
-    .clear_o            ( s_src_clear_req                            ),
-    .clear_ack_i        ( s_src_clear_ack_q                          ),
-    .isolate_o          ( s_src_isolate_req                          ),
-    .isolate_ack_i      ( s_src_isolate_ack_q                        ),
-    .async_next_phase_o ( async_reset_src2dst_next_phase_from_src    ),
-    .async_req_o        ( async_reset_src2dst_req_from_src           ),
-    .async_ack_i        ( async_reset_src2dst_ack_to_src             ),
-    .async_next_phase_i ( async_reset_dst2src_next_phase_to_src      ),
-    .async_req_i        ( async_reset_dst2src_req_to_src             ),
-    .async_ack_o        ( async_reset_dst2src_ack_from_src           )
-  );
-
-  cc_cdc_reset_ctrlr_half #(
-    .SyncStages        ( SYNC_STAGES - 1      ),
-    .ClearOnAsyncReset ( CLEAR_ON_ASYNC_RESET )
-  ) i_cdc_reset_ctrlr_half_dst (
-    .clk_i              ( dst_clk_i                                  ),
-    .rst_ni             ( dst_rst_ni                                 ),
-    .clear_i            ( dst_clear_i                                ),
-    .clear_o            ( s_dst_clear_req                            ),
-    .clear_ack_i        ( s_dst_clear_ack_q                          ),
-    .isolate_o          ( s_dst_isolate_req                          ),
-    .isolate_ack_i      ( s_dst_isolate_ack_q                        ),
-    .async_next_phase_o ( async_reset_dst2src_next_phase_from_dst    ),
-    .async_req_o        ( async_reset_dst2src_req_from_dst           ),
-    .async_ack_i        ( async_reset_dst2src_ack_to_dst             ),
-    .async_next_phase_i ( async_reset_src2dst_next_phase_to_dst      ),
-    .async_req_i        ( async_reset_src2dst_req_to_dst             ),
-    .async_ack_o        ( async_reset_src2dst_ack_from_dst           )
-  );
-
-  // The top-level clearable wrapper acknowledges isolation/clear one cycle
-  // after the reset controller requests it; mirror that behavior here.
-  always_ff @(posedge src_clk_i, negedge src_rst_ni) begin
-    if (!src_rst_ni) begin
-      s_src_isolate_ack_q <= 1'b0;
-      s_src_clear_ack_q   <= 1'b0;
-    end else begin
-      s_src_isolate_ack_q <= s_src_isolate_req;
-      s_src_clear_ack_q   <= s_src_clear_req;
-    end
-  end
-
-  always_ff @(posedge dst_clk_i, negedge dst_rst_ni) begin
-    if (!dst_rst_ni) begin
-      s_dst_isolate_ack_q <= 1'b0;
-      s_dst_clear_ack_q   <= 1'b0;
-    end else begin
-      s_dst_isolate_ack_q <= s_dst_isolate_req;
-      s_dst_clear_ack_q   <= s_dst_clear_req;
-    end
-  end
-
-  assign src_clear_pending_o = s_src_isolate_req;
-  assign dst_clear_pending_o = s_dst_isolate_req;
 
 endmodule

--- a/test/cc_cdc_fifo_clearable_tb.sv
+++ b/test/cc_cdc_fifo_clearable_tb.sv
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright 2026 ETH Zurich and University of Bologna.
 //
 // Copyright and related rights are licensed under the Solderpad Hardware
 // License, Version 0.51 (the "License"); you may not use this file except in
@@ -9,283 +9,940 @@
 // CONDITIONS OF ANY KIND, either express or implied. See the License for the
 // specific language governing permissions and limitations under the License.
 //
-// Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
-// Manuel Eggimann <meggimann@iis.ee.ethz.ch>
+// Authors:
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+//
+// Description: Clearable Gray-Counter CDC FIFO Testbench
+// Exercise FIFO ordering, full/empty transitions, clear recovery, gray pointer
+// transitions, and timed async-channel delay sweeps for
+// cc_cdc_fifo_gray_clearable.
 
 module cc_cdc_fifo_clearable_tb;
 
-  parameter bit INJECT_SRC_STALLS = 0;
-  parameter bit INJECT_DST_STALLS = 0;
-  parameter int UNTIL = 100000;
-  parameter int DEPTH = 3;
-  parameter int CLEAR_PPM = 2000;
+  timeunit 1ns;
+  timeprecision 1ps;
 
-  time tck_src       = 10ns;
-  time tck_dst       = 27ns;
-  bit src_done       = 0;
-  bit dst_done       = 0;
-  bit done;
-  assign done = src_done & dst_done;
+  // --------------------------------------------------------------------------
+  // Configuration
+  // --------------------------------------------------------------------------
+  parameter int unsigned NUM_RANDOM_TRANSFERS = 160;
+  parameter int unsigned DEPTH = 3;
+  parameter int unsigned SYNC_STAGES = 3;
+  parameter bit          CLEAR_ON_ASYNC_RESET = 1'b1;
+  parameter int unsigned TCK_SRC_PS = 10000;
+  parameter int unsigned TCK_DST_PS = 17000;
+  parameter int unsigned TIMEOUT_CYCLES = 60000;
+  parameter int unsigned SEED = 32'hf10c_0001;
+  parameter bit          INJECT_DELAYS = 1'b0;
+  parameter int unsigned MAX_DELAY_PS = 0;
+  parameter int unsigned SRC_START_DELAY_PS = 0;
+  parameter int unsigned DST_START_DELAY_PS = 0;
 
-  // Signals of the design under test.
-  logic        src_rst_ni  = 1;
-  logic        src_clk_i   = 0;
-  logic        src_clear_i = 0;
+  localparam int unsigned FifoDepth = 2**DEPTH;
+  localparam int unsigned PtrWidth = DEPTH + 1;
+
+  typedef enum logic [1:0] {
+    DstReadyLow,
+    DstReadyHigh,
+    DstReadyRandom
+  } dst_ready_mode_e;
+
+  typedef enum logic [2:0] {
+    EventSrcClear,
+    EventDstClear,
+    EventBothClear,
+    EventSrcReset,
+    EventDstReset
+  } control_event_e;
+
+  time tck_src = TCK_SRC_PS * 1ps;
+  time tck_dst = TCK_DST_PS * 1ps;
+
+  logic        src_rst_ni = 1'b1;
+  logic        src_clk_i = 1'b0;
+  logic        src_clear_i = 1'b0;
   logic        src_clear_pending_o;
-  logic [31:0] src_data_i  = 0;
-  logic        src_valid_i = 0;
+  logic [31:0] src_data_i = '0;
+  logic        src_valid_i = 1'b0;
   logic        src_ready_o;
 
-  logic        dst_rst_ni  = 1;
-  logic        dst_clk_i   = 0;
-  logic        dst_clear_i = 0;
+  logic        dst_rst_ni = 1'b1;
+  logic        dst_clk_i = 1'b0;
+  logic        dst_clear_i = 1'b0;
   logic        dst_clear_pending_o;
   logic [31:0] dst_data_o;
   logic        dst_valid_o;
-  logic        dst_ready_i = 0;
+  logic        dst_ready_i = 1'b0;
 
-  assert property (@(posedge src_clk_i) !$isunknown(src_valid_i) && !$isunknown(src_ready_o));
-  assert property (@(posedge dst_clk_i) !$isunknown(dst_valid_o) && !$isunknown(dst_ready_i));
-  assert property (@(posedge src_clk_i) src_valid_i |-> !$isunknown(src_data_i));
-  assert property (@(posedge dst_clk_i) dst_valid_o |-> !$isunknown(dst_data_o));
+  logic [PtrWidth-1:0] async_wptr_mon;
+  logic [PtrWidth-1:0] async_rptr_mon;
+  logic [PtrWidth-1:0] async_wptr_q = '0;
+  logic [PtrWidth-1:0] async_rptr_q = '0;
 
-  // Instantiate the design under test.
-  cc_cdc_fifo_gray_clearable #(.data_t(logic [31:0]), .LogDepth(DEPTH)) i_dut (.*);
+  logic [31:0] expected_q[$];
+  bit          drop_window = 1'b0;
+  int unsigned num_src_handshakes = 0;
+  int unsigned num_dst_handshakes = 0;
+  int unsigned num_drop_window_handshakes = 0;
+  int unsigned num_errors = 0;
 
-  typedef struct {
-    int          data;
-    bit          is_stale;
-  } item_t;
+  dst_ready_mode_e dst_ready_mode = DstReadyLow;
 
-  // Mailbox with expected items on destination side.
-  item_t dst_mbox[$];
-  int num_sent = 0;
-  int num_received = 0;
-  int num_failed = 0;
+  // --------------------------------------------------------------------------
+  // DUT Selection
+  // --------------------------------------------------------------------------
+  if (INJECT_DELAYS) begin : gen_delayed_dut
+    cc_cdc_fifo_clearable_tb_delay_injector #(
+      .LOG_DEPTH            ( DEPTH                ),
+      .SYNC_STAGES          ( SYNC_STAGES          ),
+      .CLEAR_ON_ASYNC_RESET ( CLEAR_ON_ASYNC_RESET ),
+      .MAX_DELAY_PS         ( MAX_DELAY_PS         )
+    ) i_dut (
+      .src_rst_ni,
+      .src_clk_i,
+      .src_clear_i,
+      .src_clear_pending_o,
+      .src_data_i,
+      .src_valid_i,
+      .src_ready_o,
+      .dst_rst_ni,
+      .dst_clk_i,
+      .dst_clear_i,
+      .dst_clear_pending_o,
+      .dst_data_o,
+      .dst_valid_o,
+      .dst_ready_i,
+      .async_wptr_mon_o ( async_wptr_mon ),
+      .async_rptr_mon_o ( async_rptr_mon )
+    );
+  end else begin : gen_dut
+    cc_cdc_fifo_gray_clearable #(
+      .data_t            ( logic [31:0]        ),
+      .LogDepth          ( DEPTH               ),
+      .SyncStages        ( SYNC_STAGES         ),
+      .ClearOnAsyncReset ( CLEAR_ON_ASYNC_RESET )
+    ) i_dut (
+      .src_rst_ni,
+      .src_clk_i,
+      .src_clear_i,
+      .src_clear_pending_o,
+      .src_data_i,
+      .src_valid_i,
+      .src_ready_o,
+      .dst_rst_ni,
+      .dst_clk_i,
+      .dst_clear_i,
+      .dst_clear_pending_o,
+      .dst_data_o,
+      .dst_valid_o,
+      .dst_ready_i
+    );
 
-  // Clock generators.
-  initial begin
-    static int num_items, num_clks;
-    num_items = 10;
-    num_clks = 0;
-    #10ns;
-    src_rst_ni = 0;
-    #10ns;
-    src_rst_ni = 1;
-    #10ns;
-    while (!done) begin
-      src_clk_i = 1;
-      #(tck_src/2);
-      src_clk_i = 0;
-      #(tck_src/2);
+    assign async_wptr_mon = i_dut.async_wptr;
+    assign async_rptr_mon = i_dut.async_rptr;
+  end
 
-      // Modulate the clock frequency.
-      num_clks++;
-      if (num_sent >= num_items && num_clks > 10) begin
-        num_items = num_sent + 10;
-        num_clks = 0;
-        tck_src = $urandom_range(1000, 10000) * 1ps;
-        assert(tck_src > 0);
+  // --------------------------------------------------------------------------
+  // Clock And Ready Generation
+  // --------------------------------------------------------------------------
+  initial begin : gen_src_clk
+    #(SRC_START_DELAY_PS * 1ps);
+    forever #(tck_src / 2) src_clk_i = ~src_clk_i;
+  end
+
+  initial begin : gen_dst_clk
+    #(DST_START_DELAY_PS * 1ps);
+    forever #(tck_dst / 2) dst_clk_i = ~dst_clk_i;
+  end
+
+  always @(negedge dst_clk_i) begin
+    case (dst_ready_mode)
+      DstReadyLow:    dst_ready_i <= 1'b0;
+      DstReadyHigh:   dst_ready_i <= 1'b1;
+      DstReadyRandom: dst_ready_i <= ($urandom_range(0, 99) < 70);
+      default:        dst_ready_i <= 1'b0;
+    endcase
+  end
+
+  // --------------------------------------------------------------------------
+  // Scoreboard And Protocol Checks
+  // --------------------------------------------------------------------------
+  always @(posedge src_clk_i) begin
+    if (src_rst_ni) begin
+      if ($isunknown(src_ready_o)) begin
+        report_error("src_ready_o is unknown");
+      end
+      if ($isunknown(src_valid_i)) begin
+        report_error("src_valid_i is unknown");
+      end
+      if ($isunknown(src_clear_pending_o)) begin
+        report_error("src_clear_pending_o is unknown");
+      end
+      if (src_clear_pending_o && src_ready_o) begin
+        report_error("src_ready_o asserted while src_clear_pending_o is asserted");
+      end
+      if (src_valid_i && $isunknown(src_data_i)) begin
+        report_error("src_data_i is unknown while valid");
+      end
+      if (src_valid_i && src_ready_o) begin
+        num_src_handshakes++;
+        if (!drop_window) begin
+          expected_q.push_back(src_data_i);
+        end
       end
     end
   end
 
-  initial begin
-    static int num_items, num_clks;
-    num_items = 10;
-    num_clks = 0;
-    #10ns;
-    dst_rst_ni = 0;
-    #10ns;
-    dst_rst_ni = 1;
-    #10ns;
-    while (!done) begin
-      dst_clk_i = 1;
-      #(tck_dst/2);
-      dst_clk_i = 0;
-      #(tck_dst/2);
+  always @(posedge dst_clk_i) begin
+    logic [31:0] expected;
 
-      // Modulate the clock frequency.
-      num_clks++;
-      if (num_received >= num_items && num_clks > 10) begin
-        num_items = num_received + 10;
-        num_clks = 0;
-        tck_dst = $urandom_range(1000, 10000) * 1ps;
-        assert(tck_dst > 0);
+    if (dst_rst_ni) begin
+      if ($isunknown(dst_valid_o)) begin
+        report_error("dst_valid_o is unknown");
       end
-    end
-  end
-
-  // Source side sender.
-  task src_cycle_start;
-    #(tck_src*0.8);
-  endtask
-
-  task src_cycle_end;
-    @(posedge src_clk_i);
-  endtask
-
-  initial begin
-    @(negedge src_rst_ni);
-    @(posedge src_rst_ni);
-    repeat(3) @(posedge src_clk_i);
-    for (int i = 0; i < UNTIL; i++) begin
-      item_t item;
-      static integer stimulus;
-      static int cooldown;
-      static bit clear_cdc;
-      // Ramdomly clear the CDC. When clearing the CDC, mark all remainig items
-      // in the mailbox as stale. Some of them might still be received
-      // downstream until the clear request propagated to the other side.
-      clear_cdc    = $urandom_range(0,1e6) < CLEAR_PPM;
-      if (!clear_cdc || src_clear_pending_o) begin
-        stimulus       = $random();
-        item.data      = stimulus;
-        item.is_stale  = 1'b0;
-        src_data_i    <= #(tck_src*0.2) stimulus;
-        src_valid_i   <= #(tck_src*0.2) 1;
-        num_sent++;
-        src_cycle_start();
-        while (!src_ready_o) begin
-          src_cycle_end();
-          src_cycle_start();
-        end
-        dst_mbox.push_front(item);
-        src_cycle_end();
-        src_valid_i <= #(tck_src*0.2) 0;
-
-        // Insert a random cooldown period.
-        if (INJECT_SRC_STALLS) begin
-          cooldown = $urandom_range(0, 40);
-          if (cooldown < 20) repeat(cooldown) @(posedge src_clk_i);
-        end
-      end else begin
-        // The cdc shall be cleared. Mark all items in the mailbox as stale.
-        foreach(dst_mbox[i]) begin
-          if (!dst_mbox[i].is_stale) begin
-            dst_mbox[i].is_stale = 1'b1;
-            num_sent--;
+      if ($isunknown(dst_ready_i)) begin
+        report_error("dst_ready_i is unknown");
+      end
+      if ($isunknown(dst_clear_pending_o)) begin
+        report_error("dst_clear_pending_o is unknown");
+      end
+      if (dst_clear_pending_o && dst_valid_o) begin
+        report_error("dst_valid_o asserted while dst_clear_pending_o is asserted");
+      end
+      if (dst_valid_o && $isunknown(dst_data_o)) begin
+        report_error("dst_data_o is unknown while valid");
+      end
+      if (dst_valid_o && dst_ready_i) begin
+        num_dst_handshakes++;
+        if (drop_window) begin
+          num_drop_window_handshakes++;
+        end else if (expected_q.size() == 0) begin
+          report_error($sformatf("unexpected destination transaction: data=0x%08h",
+                                 dst_data_o));
+        end else begin
+          expected = expected_q.pop_front();
+          if (dst_data_o !== expected) begin
+            report_error($sformatf("transaction mismatch: expected=0x%08h actual=0x%08h",
+                                   expected, dst_data_o));
           end
         end
-        if ($urandom_range(0,1) == 1) begin
-          $info("Randomly clearing CDC synchronously and marking all pending items as stale");
-          // Now raise the clear signal for one clock cycle.
-          src_cycle_start();
-          src_clear_i = 1'b1;
-          src_cycle_end();
-          src_clear_i = #(tck_src*0.2) 1'b0;
-        end else begin
-          $info("Randomly resetting CDC asynchronously and marking all pending items as stale");
-          // Now assert the async reset signal for one clock cycle.
-          src_cycle_start();
-          src_rst_ni = 1'b0;
-          src_cycle_end();
-          src_rst_ni = #(tck_src*0.2) 1'b1;
-        end
       end
     end
-    src_done = 1;
   end
 
-  // Destination side receiver.
-  task dst_cycle_start;
-    #(tck_dst*0.8);
-  endtask
-
-  task dst_cycle_end;
-    @(posedge dst_clk_i);
-  endtask
-
-  initial begin
-    @(negedge dst_rst_ni);
-    @(posedge dst_rst_ni);
-    repeat(3) @(posedge dst_clk_i);
-    while (!src_done || dst_mbox.size() > 0) begin
-      static item_t expected_item;
-      static integer actual;
-      static int cooldown;
-      static bit clear_cdc;
-      // Ramdomly clear the CDC. When clearing the CDC, wait for exactly
-      // DEPTH clock cycle for the clear request to propagate and then clear the
-      // item queue.
-      clear_cdc    = $urandom_range(0,1e6) < CLEAR_PPM;
-      if (!clear_cdc || dst_clear_pending_o) begin
-        dst_ready_i <= #(tck_dst*0.2) 1;
-        dst_cycle_start();
-        while (!dst_valid_o && !src_done) begin
-          dst_cycle_end();
-          dst_cycle_start();
-        end
-        if (src_done) break;
-        actual = dst_data_o;
-        if (dst_mbox.size() == 0) begin
-          $error("unexpected transaction: data=%0h", actual);
-          num_failed++;
-        end else begin
-          expected_item = dst_mbox.pop_back();
-          if (actual != expected_item.data) begin
-            // Check if the expected item is a stale item. If so, pop all stale
-            // items until we receive a fresh one and check again.
-            while (dst_mbox.size() > 0  && expected_item.is_stale && expected_item.data != actual) begin
-              expected_item = dst_mbox.pop_back();
-            end
-            if (actual != expected_item.data) begin
-              $error("transaction mismatch: exp=%0h, act=%0h", expected_item.data, actual);
-              num_failed++;
-            end else begin
-              if (!expected_item.is_stale) begin
-                num_received++;
-              end
-            end
-          end else if (expected_item.is_stale) begin
-            $info("Received stale item after clear. This is expected to happen for some cycles after the clear until the clear propagated to the other side.");
-          end else begin
-            num_received++;
-          end
-        end
-        dst_cycle_end();
-        dst_ready_i <= #(tck_dst*0.2) 0;
-
-        // Insert a random cooldown period.
-        if (INJECT_DST_STALLS) begin
-          cooldown = $urandom_range(0, 40);
-          if (cooldown < 20) repeat(cooldown) @(posedge dst_clk_i);
-        end
-      end else begin
-        // Randomly alternate between async reset and synchronous clear
-        if ($urandom_range(0,1) == 1) begin
-          $info("Randomly clearing CDC synchronously from the destination side");
-          dst_cycle_start();
-          dst_clear_i = 1'b1;
-          dst_cycle_end();
-          dst_clear_i <= #(tck_dst*0.2) 1'b0;
-        end else begin
-          $info("Randomly resettting CDC asynchronously from the destination side");
-          dst_cycle_start();
-          dst_rst_ni = 1'b0;
-          dst_cycle_end();
-          dst_rst_ni <= #(tck_dst*0.2) 1'b1;
-        end
-        // Wait for exactly 1 dst clock cycle and DEPTH src clock cycles for the clear request to
-        // propagate
-        @(posedge dst_clk_i);
-        repeat(DEPTH) @(posedge src_clk_i);
-        // Now clear the item queue
-        num_sent-=dst_mbox.size();
-        dst_mbox.delete();
-
-        // and end the loop iteration at the rising edge of the dst clk
-        dst_cycle_end();
-      end
-    end
-
-    if (num_failed > 0) begin
-      $error("%0d/%0d items mismatched", num_failed, num_sent);
+  // --------------------------------------------------------------------------
+  // Gray Pointer Monitors
+  // --------------------------------------------------------------------------
+  always @(posedge src_clk_i) begin
+    if (!src_rst_ni || src_clear_i || src_clear_pending_o) begin
+      async_wptr_q <= async_wptr_mon;
     end else begin
-      $info("%0d items passed", num_sent);
+      check_gray_transition("async_wptr_o", async_wptr_q, async_wptr_mon);
+      async_wptr_q <= async_wptr_mon;
+    end
+  end
+
+  always @(posedge dst_clk_i) begin
+    if (!dst_rst_ni || dst_clear_i || dst_clear_pending_o) begin
+      async_rptr_q <= async_rptr_mon;
+    end else begin
+      check_gray_transition("async_rptr_o", async_rptr_q, async_rptr_mon);
+      async_rptr_q <= async_rptr_mon;
+    end
+  end
+
+  // --------------------------------------------------------------------------
+  // Test Helpers
+  // --------------------------------------------------------------------------
+  function automatic int unsigned count_set_bits(input logic [PtrWidth-1:0] value);
+    int unsigned count;
+
+    count = 0;
+    for (int unsigned i = 0; i < PtrWidth; i++) begin
+      if (value[i]) begin
+        count++;
+      end
+    end
+    return count;
+  endfunction
+
+  function automatic string control_event_name(input control_event_e ctrl_event);
+    case (ctrl_event)
+      EventSrcClear:  control_event_name = "source synchronous clear";
+      EventDstClear:  control_event_name = "destination synchronous clear";
+      EventBothClear: control_event_name = "simultaneous synchronous clear";
+      EventSrcReset:  control_event_name = "source asynchronous reset";
+      EventDstReset:  control_event_name = "destination asynchronous reset";
+      default:        control_event_name = "unknown control event";
+    endcase
+  endfunction
+
+  task automatic check_gray_transition(input string signal_name,
+                                       input logic [PtrWidth-1:0] previous,
+                                       input logic [PtrWidth-1:0] current);
+    if (!$isunknown(previous) && !$isunknown(current) &&
+        (count_set_bits(previous ^ current) > 1)) begin
+      report_error($sformatf("%s changed more than one bit: previous=0x%0h current=0x%0h",
+                             signal_name, previous, current));
+    end
+  endtask
+
+  task automatic report_error(input string msg);
+    num_errors++;
+    $error("%s", msg);
+  endtask
+
+  // --------------------------------------------------------------------------
+  // Reset And Clear Helpers
+  // --------------------------------------------------------------------------
+  task automatic wait_src_cycles(input int unsigned cycles);
+    repeat (cycles) begin
+      @(posedge src_clk_i);
+    end
+    #1ps;
+  endtask
+
+  task automatic wait_dst_cycles(input int unsigned cycles);
+    repeat (cycles) begin
+      @(posedge dst_clk_i);
+    end
+    #1ps;
+  endtask
+
+  task automatic wait_quiet_cycles(input int unsigned cycles);
+    fork
+      wait_src_cycles(cycles);
+      wait_dst_cycles(cycles);
+    join
+  endtask
+
+  task automatic wait_clear_done(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_rst_ni && dst_rst_ni &&
+          !src_clear_i && !dst_clear_i &&
+          !src_clear_pending_o && !dst_clear_pending_o) begin
+        wait_quiet_cycles(6);
+        return;
+      end
+      @(posedge src_clk_i or posedge dst_clk_i);
     end
 
-    dst_done = 1;
+    report_error($sformatf("timeout waiting for clear completion in %s", test_name));
+  endtask
+
+  task automatic wait_pending_seen(input bit expect_src, input bit expect_dst,
+                                   input string test_name);
+    bit saw_src;
+    bit saw_dst;
+
+    saw_src = !expect_src;
+    saw_dst = !expect_dst;
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_clear_pending_o) begin
+        saw_src = 1'b1;
+      end
+      if (dst_clear_pending_o) begin
+        saw_dst = 1'b1;
+      end
+      if (saw_src && saw_dst) begin
+        return;
+      end
+      @(posedge src_clk_i or posedge dst_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for clear pending assertion in %s", test_name));
+  endtask
+
+  task automatic reset_both_domains;
+    drop_window = 1'b1;
+    expected_q.delete();
+    async_wptr_q = '0;
+    async_rptr_q = '0;
+    src_data_i = '0;
+    src_valid_i = 1'b0;
+    src_clear_i = 1'b0;
+    dst_clear_i = 1'b0;
+    dst_ready_mode = DstReadyLow;
+    src_rst_ni = 1'b0;
+    dst_rst_ni = 1'b0;
+
+    fork
+      wait_src_cycles(4);
+      wait_dst_cycles(4);
+    join
+
+    src_rst_ni = 1'b1;
+    dst_rst_ni = 1'b1;
+    wait_clear_done("power-on reset");
+    expected_q.delete();
+    drop_window = 1'b0;
+  endtask
+
+  task automatic send_word(input logic [31:0] data);
+    @(negedge src_clk_i);
+    #1ps;
+    src_data_i = data;
+    src_valid_i = 1'b1;
+
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_ready_o) begin
+        @(posedge src_clk_i);
+        @(negedge src_clk_i);
+        src_valid_i = 1'b0;
+        src_data_i = '0;
+        return;
+      end
+      @(negedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout sending data=0x%08h", data));
+    src_valid_i = 1'b0;
+  endtask
+
+  // --------------------------------------------------------------------------
+  // Traffic Helpers
+  // --------------------------------------------------------------------------
+  task automatic wait_scoreboard_empty(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (expected_q.size() == 0) begin
+        return;
+      end
+      @(posedge dst_clk_i or posedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for scoreboard to drain in %s, pending=%0d",
+                           test_name, expected_q.size()));
+  endtask
+
+  task automatic wait_src_ready(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (src_ready_o) begin
+        return;
+      end
+      @(posedge src_clk_i or posedge dst_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for source ready in %s", test_name));
+  endtask
+
+  task automatic wait_src_not_ready(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (!src_ready_o) begin
+        return;
+      end
+      @(posedge src_clk_i or posedge dst_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for source not-ready in %s", test_name));
+  endtask
+
+  task automatic wait_dst_not_valid(input string test_name);
+    for (int unsigned i = 0; i < TIMEOUT_CYCLES; i++) begin
+      if (!dst_valid_o) begin
+        return;
+      end
+      @(posedge dst_clk_i or posedge src_clk_i);
+    end
+
+    report_error($sformatf("timeout waiting for destination not-valid in %s", test_name));
+  endtask
+
+  task automatic send_sequence(input int unsigned num_words, input logic [31:0] base);
+    for (int unsigned i = 0; i < num_words; i++) begin
+      send_word(base + i);
+      if ($urandom_range(0, 3) == 0) begin
+        wait_src_cycles($urandom_range(1, 3));
+      end
+    end
+  endtask
+
+  task automatic run_transfer_check(input string test_name, input int unsigned num_words,
+                                    input logic [31:0] base,
+                                    input dst_ready_mode_e ready_mode);
+    $display("%m: %s", test_name);
+    dst_ready_mode = ready_mode;
+    send_sequence(num_words, base);
+    wait_scoreboard_empty(test_name);
+    wait_src_ready(test_name);
+    dst_ready_mode = DstReadyLow;
+    wait_dst_cycles(2);
+  endtask
+
+  task automatic run_fill_drain_check(input string test_name, input logic [31:0] base);
+    int unsigned max_fill_words;
+
+    $display("%m: %s", test_name);
+    max_fill_words = FifoDepth + 2;
+    dst_ready_mode = DstReadyLow;
+    wait_src_ready(test_name);
+    for (int unsigned i = 0; i < max_fill_words; i++) begin
+      send_word(base + i);
+      if (!src_ready_o) begin
+        break;
+      end
+    end
+    wait_src_not_ready(test_name);
+    dst_ready_mode = DstReadyHigh;
+    wait_scoreboard_empty(test_name);
+    wait_src_ready(test_name);
+    wait_dst_not_valid(test_name);
+    dst_ready_mode = DstReadyLow;
+    wait_dst_cycles(2);
+  endtask
+
+  task automatic drive_control_event(input control_event_e ctrl_event);
+    case (ctrl_event)
+      EventSrcClear: begin
+        @(negedge src_clk_i);
+        src_clear_i = 1'b1;
+        @(posedge src_clk_i);
+        @(negedge src_clk_i);
+        src_clear_i = 1'b0;
+      end
+      EventDstClear: begin
+        @(negedge dst_clk_i);
+        dst_clear_i = 1'b1;
+        @(posedge dst_clk_i);
+        @(negedge dst_clk_i);
+        dst_clear_i = 1'b0;
+      end
+      EventBothClear: begin
+        fork
+          begin
+            @(negedge src_clk_i);
+            src_clear_i = 1'b1;
+            @(posedge src_clk_i);
+            @(negedge src_clk_i);
+            src_clear_i = 1'b0;
+          end
+          begin
+            @(negedge dst_clk_i);
+            dst_clear_i = 1'b1;
+            @(posedge dst_clk_i);
+            @(negedge dst_clk_i);
+            dst_clear_i = 1'b0;
+          end
+        join
+      end
+      EventSrcReset: begin
+        @(negedge src_clk_i);
+        src_rst_ni = 1'b0;
+        wait_src_cycles(3);
+        @(negedge src_clk_i);
+        src_rst_ni = 1'b1;
+      end
+      EventDstReset: begin
+        @(negedge dst_clk_i);
+        dst_rst_ni = 1'b0;
+        wait_dst_cycles(3);
+        @(negedge dst_clk_i);
+        dst_rst_ni = 1'b1;
+      end
+      default: begin
+        report_error("unsupported control event");
+      end
+    endcase
+  endtask
+
+  // --------------------------------------------------------------------------
+  // Clear And Recovery Scenarios
+  // --------------------------------------------------------------------------
+  task automatic run_control_event(input control_event_e ctrl_event, input string test_name);
+    $display("%m: %s (%s)", test_name, control_event_name(ctrl_event));
+    src_valid_i = 1'b0;
+    src_data_i = '0;
+    expected_q.delete();
+    drop_window = 1'b1;
+    drive_control_event(ctrl_event);
+    if (ctrl_event inside {EventSrcClear, EventDstClear, EventBothClear}) begin
+      wait_pending_seen(1'b1, 1'b1, test_name);
+    end
+    wait_clear_done(test_name);
+    expected_q.delete();
+    drop_window = 1'b0;
+  endtask
+
+  task automatic run_backpressured_control_check(input control_event_e ctrl_event,
+                                                 input logic [31:0] staged_base,
+                                                 input logic [31:0] recovery_base);
+    int unsigned staged_words;
+    string test_name;
+
+    test_name = $sformatf("backpressured %s", control_event_name(ctrl_event));
+    $display("%m: %s", test_name);
+    staged_words = (FifoDepth < 4) ? FifoDepth : 4;
+    dst_ready_mode = DstReadyLow;
+    send_sequence(staged_words, staged_base);
+    wait_dst_cycles(4);
+    run_control_event(ctrl_event, test_name);
+    run_transfer_check($sformatf("post-%s transfer", test_name), 12, recovery_base,
+                       DstReadyRandom);
+  endtask
+
+  // --------------------------------------------------------------------------
+  // Test Sequence
+  // --------------------------------------------------------------------------
+  initial begin : run_tests
+    int unsigned seed;
+
+    seed = SEED;
+    seed = $urandom(seed);
+    $display("%m: SEED=0x%08h derived=0x%08h DEPTH=%0d SYNC_STAGES=%0d",
+             SEED, seed, DEPTH, SYNC_STAGES);
+
+    reset_both_domains();
+
+    run_transfer_check("basic fixed-ready transfer", FifoDepth + 8, 32'h1000_0000,
+                       DstReadyHigh);
+    run_fill_drain_check("fill and drain", 32'h2000_0000);
+    run_transfer_check("randomized ready transfer", NUM_RANDOM_TRANSFERS, 32'h3000_0000,
+                       DstReadyRandom);
+
+    run_control_event(EventSrcClear, "source synchronous idle clear");
+    run_transfer_check("post-source-clear transfer", 16, 32'h4000_0000, DstReadyHigh);
+
+    run_control_event(EventDstClear, "destination synchronous idle clear");
+    run_transfer_check("post-destination-clear transfer", 16, 32'h5000_0000, DstReadyHigh);
+
+    run_control_event(EventBothClear, "simultaneous synchronous idle clear");
+    run_transfer_check("post-simultaneous-clear transfer", 16, 32'h6000_0000, DstReadyHigh);
+
+    if (CLEAR_ON_ASYNC_RESET) begin
+      run_control_event(EventSrcReset, "source asynchronous idle reset");
+      run_transfer_check("post-source-reset transfer", 16, 32'h7000_0000, DstReadyHigh);
+
+      run_control_event(EventDstReset, "destination asynchronous idle reset");
+      run_transfer_check("post-destination-reset transfer", 16, 32'h8000_0000, DstReadyHigh);
+    end
+
+    run_backpressured_control_check(EventDstClear, 32'hc1ea_0000, 32'hc1ea_1000);
+    run_backpressured_control_check(EventSrcClear, 32'hc1ea_2000, 32'hc1ea_3000);
+    run_backpressured_control_check(EventBothClear, 32'hc1ea_4000, 32'hc1ea_5000);
+    if (CLEAR_ON_ASYNC_RESET) begin
+      run_backpressured_control_check(EventSrcReset, 32'hc1ea_6000, 32'hc1ea_7000);
+      run_backpressured_control_check(EventDstReset, 32'hc1ea_8000, 32'hc1ea_9000);
+    end
+
+    if ((num_errors != 0) || (expected_q.size() != 0)) begin
+      $fatal(1, "%m: failed with %0d errors and %0d pending scoreboard items",
+             num_errors, expected_q.size());
+    end
+
+    $display("%m: passed: src_handshakes=%0d dst_handshakes=%0d dropped=%0d",
+             num_src_handshakes, num_dst_handshakes, num_drop_window_handshakes);
+    $finish;
   end
+
+endmodule
+
+
+// ----------------------------------------------------------------------------
+// Delay Model Helpers
+// ----------------------------------------------------------------------------
+
+module cc_cdc_fifo_clearable_tb_bit_delay #(
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic in_i,
+  output logic out_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  initial begin
+    out_o = 1'b0;
+  end
+
+  always @(in_i) begin
+    automatic int unsigned delay_ps;
+    delay_ps = (MAX_DELAY_PS == 0) ? 0 : $urandom_range(0, MAX_DELAY_PS);
+    out_o <= #(delay_ps * 1ps) in_i;
+  end
+
+endmodule
+
+
+module cc_cdc_fifo_clearable_tb_bus_delay #(
+  parameter int unsigned Width = 1,
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic [Width-1:0] in_i,
+  output logic [Width-1:0] out_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  for (genvar i = 0; i < Width; i++) begin : gen_bit_delay
+    cc_cdc_fifo_clearable_tb_bit_delay #(
+      .MAX_DELAY_PS ( MAX_DELAY_PS )
+    ) i_delay (
+      .in_i  ( in_i[i]  ),
+      .out_o ( out_o[i] )
+    );
+  end
+
+endmodule
+
+
+// ----------------------------------------------------------------------------
+// Timed Delay-Injection Harness
+// ----------------------------------------------------------------------------
+
+module cc_cdc_fifo_clearable_tb_delay_injector #(
+  parameter int unsigned LOG_DEPTH = 3,
+  parameter int unsigned SYNC_STAGES = 3,
+  parameter bit          CLEAR_ON_ASYNC_RESET = 1'b1,
+  parameter int unsigned MAX_DELAY_PS = 0
+)(
+  input  logic        src_rst_ni,
+  input  logic        src_clk_i,
+  input  logic        src_clear_i,
+  output logic        src_clear_pending_o,
+  input  logic [31:0] src_data_i,
+  input  logic        src_valid_i,
+  output logic        src_ready_o,
+
+  input  logic        dst_rst_ni,
+  input  logic        dst_clk_i,
+  input  logic        dst_clear_i,
+  output logic        dst_clear_pending_o,
+  output logic [31:0] dst_data_o,
+  output logic        dst_valid_o,
+  input  logic        dst_ready_i,
+
+  output logic [LOG_DEPTH:0] async_wptr_mon_o,
+  output logic [LOG_DEPTH:0] async_rptr_mon_o
+);
+
+  timeunit 1ns;
+  timeprecision 1ps;
+
+  import cc_pkg::*;
+
+  localparam int unsigned PtrWidth = LOG_DEPTH + 1;
+  localparam int unsigned ClearPhaseWidth = $bits(cdc_clear_seq_phase_e);
+  typedef logic [31:0] data_t;
+
+  logic        s_src_clear_req;
+  logic        s_src_clear_ack_q;
+  logic        s_src_ready;
+  logic        s_src_isolate_req;
+  logic        s_src_isolate_ack_q;
+  logic        s_dst_clear_req;
+  logic        s_dst_clear_ack_q;
+  logic        s_dst_valid;
+  logic        s_dst_isolate_req;
+  logic        s_dst_isolate_ack_q;
+
+  data_t [2**LOG_DEPTH-1:0] async_data_from_src;
+  data_t [2**LOG_DEPTH-1:0] async_data_to_dst;
+  logic [PtrWidth-1:0] async_wptr_from_src;
+  logic [PtrWidth-1:0] async_wptr_to_dst;
+  logic [PtrWidth-1:0] async_rptr_from_dst;
+  logic [PtrWidth-1:0] async_rptr_to_src;
+
+  logic async_reset_src2dst_req_from_src;
+  logic async_reset_src2dst_req_to_dst;
+  logic async_reset_src2dst_ack_from_dst;
+  logic async_reset_src2dst_ack_to_src;
+  logic async_reset_dst2src_req_from_dst;
+  logic async_reset_dst2src_req_to_src;
+  logic async_reset_dst2src_ack_from_src;
+  logic async_reset_dst2src_ack_to_dst;
+  cdc_clear_seq_phase_e async_reset_src2dst_next_phase_from_src;
+  cdc_clear_seq_phase_e async_reset_src2dst_next_phase_to_dst;
+  cdc_clear_seq_phase_e async_reset_dst2src_next_phase_from_dst;
+  cdc_clear_seq_phase_e async_reset_dst2src_next_phase_to_src;
+  logic [ClearPhaseWidth-1:0] async_reset_src2dst_next_phase_from_src_bits;
+  logic [ClearPhaseWidth-1:0] async_reset_src2dst_next_phase_to_dst_bits;
+  logic [ClearPhaseWidth-1:0] async_reset_dst2src_next_phase_from_dst_bits;
+  logic [ClearPhaseWidth-1:0] async_reset_dst2src_next_phase_to_src_bits;
+
+  assign async_wptr_mon_o = async_wptr_from_src;
+  assign async_rptr_mon_o = async_rptr_from_dst;
+
+  assign async_reset_src2dst_next_phase_from_src_bits =
+      async_reset_src2dst_next_phase_from_src;
+  assign async_reset_dst2src_next_phase_from_dst_bits =
+      async_reset_dst2src_next_phase_from_dst;
+  assign async_reset_src2dst_next_phase_to_dst =
+      cdc_clear_seq_phase_e'(async_reset_src2dst_next_phase_to_dst_bits);
+  assign async_reset_dst2src_next_phase_to_src =
+      cdc_clear_seq_phase_e'(async_reset_dst2src_next_phase_to_src_bits);
+
+  // Source and destination FIFO halves are connected through delayed async data
+  // and gray pointer channels below.
+  cc_cdc_fifo_gray_src_clearable #(
+    .data_t     ( data_t      ),
+    .LogDepth   ( LOG_DEPTH   ),
+    .SyncStages ( SYNC_STAGES )
+  ) i_src (
+    .src_rst_ni,
+    .src_clk_i,
+    .src_clear_i ( s_src_clear_req                  ),
+    .src_data_i,
+    .src_valid_i ( src_valid_i & !s_src_isolate_req ),
+    .src_ready_o ( s_src_ready                      ),
+    .async_data_o ( async_data_from_src ),
+    .async_wptr_o ( async_wptr_from_src ),
+    .async_rptr_i ( async_rptr_to_src   )
+  );
+
+  assign src_ready_o = s_src_ready & !s_src_isolate_req;
+
+  for (genvar i = 0; i < 2**LOG_DEPTH; i++) begin : gen_data_delay
+    cc_cdc_fifo_clearable_tb_bus_delay #(
+      .Width        ( 32           ),
+      .MAX_DELAY_PS ( MAX_DELAY_PS )
+    ) i_data_delay (
+      .in_i  ( async_data_from_src[i] ),
+      .out_o ( async_data_to_dst[i]   )
+    );
+  end
+
+  cc_cdc_fifo_clearable_tb_bus_delay #(
+    .Width        ( PtrWidth     ),
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_wptr_delay (
+    .in_i  ( async_wptr_from_src ),
+    .out_o ( async_wptr_to_dst   )
+  );
+
+  cc_cdc_fifo_clearable_tb_bus_delay #(
+    .Width        ( PtrWidth     ),
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_rptr_delay (
+    .in_i  ( async_rptr_from_dst ),
+    .out_o ( async_rptr_to_src   )
+  );
+
+  cc_cdc_fifo_gray_dst_clearable #(
+    .data_t     ( data_t      ),
+    .LogDepth   ( LOG_DEPTH   ),
+    .SyncStages ( SYNC_STAGES )
+  ) i_dst (
+    .dst_rst_ni,
+    .dst_clk_i,
+    .dst_clear_i ( s_dst_clear_req                  ),
+    .dst_data_o,
+    .dst_valid_o ( s_dst_valid                      ),
+    .dst_ready_i ( dst_ready_i & !s_dst_isolate_req ),
+    .async_data_i ( async_data_to_dst   ),
+    .async_wptr_i ( async_wptr_to_dst   ),
+    .async_rptr_o ( async_rptr_from_dst )
+  );
+
+  assign dst_valid_o = s_dst_valid & !s_dst_isolate_req;
+
+  // Clear-controller async handshakes get the same delay model as the FIFO CDC
+  // channels so clear sequencing is exercised under timing skew as well.
+  cc_cdc_fifo_clearable_tb_bit_delay #(
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_src2dst_req_delay (
+    .in_i  ( async_reset_src2dst_req_from_src ),
+    .out_o ( async_reset_src2dst_req_to_dst   )
+  );
+
+  cc_cdc_fifo_clearable_tb_bit_delay #(
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_src2dst_ack_delay (
+    .in_i  ( async_reset_src2dst_ack_from_dst ),
+    .out_o ( async_reset_src2dst_ack_to_src   )
+  );
+
+  cc_cdc_fifo_clearable_tb_bus_delay #(
+    .Width        ( ClearPhaseWidth ),
+    .MAX_DELAY_PS ( MAX_DELAY_PS    )
+  ) i_src2dst_phase_delay (
+    .in_i  ( async_reset_src2dst_next_phase_from_src_bits ),
+    .out_o ( async_reset_src2dst_next_phase_to_dst_bits   )
+  );
+
+  cc_cdc_fifo_clearable_tb_bit_delay #(
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_dst2src_req_delay (
+    .in_i  ( async_reset_dst2src_req_from_dst ),
+    .out_o ( async_reset_dst2src_req_to_src   )
+  );
+
+  cc_cdc_fifo_clearable_tb_bit_delay #(
+    .MAX_DELAY_PS ( MAX_DELAY_PS )
+  ) i_dst2src_ack_delay (
+    .in_i  ( async_reset_dst2src_ack_from_src ),
+    .out_o ( async_reset_dst2src_ack_to_dst   )
+  );
+
+  cc_cdc_fifo_clearable_tb_bus_delay #(
+    .Width        ( ClearPhaseWidth ),
+    .MAX_DELAY_PS ( MAX_DELAY_PS    )
+  ) i_dst2src_phase_delay (
+    .in_i  ( async_reset_dst2src_next_phase_from_dst_bits ),
+    .out_o ( async_reset_dst2src_next_phase_to_src_bits   )
+  );
+
+  cc_cdc_reset_ctrlr_half #(
+    .SyncStages        ( SYNC_STAGES - 1      ),
+    .ClearOnAsyncReset ( CLEAR_ON_ASYNC_RESET )
+  ) i_cdc_reset_ctrlr_half_src (
+    .clk_i              ( src_clk_i                                  ),
+    .rst_ni             ( src_rst_ni                                 ),
+    .clear_i            ( src_clear_i                                ),
+    .clear_o            ( s_src_clear_req                            ),
+    .clear_ack_i        ( s_src_clear_ack_q                          ),
+    .isolate_o          ( s_src_isolate_req                          ),
+    .isolate_ack_i      ( s_src_isolate_ack_q                        ),
+    .async_next_phase_o ( async_reset_src2dst_next_phase_from_src    ),
+    .async_req_o        ( async_reset_src2dst_req_from_src           ),
+    .async_ack_i        ( async_reset_src2dst_ack_to_src             ),
+    .async_next_phase_i ( async_reset_dst2src_next_phase_to_src      ),
+    .async_req_i        ( async_reset_dst2src_req_to_src             ),
+    .async_ack_o        ( async_reset_dst2src_ack_from_src           )
+  );
+
+  cc_cdc_reset_ctrlr_half #(
+    .SyncStages        ( SYNC_STAGES - 1      ),
+    .ClearOnAsyncReset ( CLEAR_ON_ASYNC_RESET )
+  ) i_cdc_reset_ctrlr_half_dst (
+    .clk_i              ( dst_clk_i                                  ),
+    .rst_ni             ( dst_rst_ni                                 ),
+    .clear_i            ( dst_clear_i                                ),
+    .clear_o            ( s_dst_clear_req                            ),
+    .clear_ack_i        ( s_dst_clear_ack_q                          ),
+    .isolate_o          ( s_dst_isolate_req                          ),
+    .isolate_ack_i      ( s_dst_isolate_ack_q                        ),
+    .async_next_phase_o ( async_reset_dst2src_next_phase_from_dst    ),
+    .async_req_o        ( async_reset_dst2src_req_from_dst           ),
+    .async_ack_i        ( async_reset_dst2src_ack_to_dst             ),
+    .async_next_phase_i ( async_reset_src2dst_next_phase_to_dst      ),
+    .async_req_i        ( async_reset_src2dst_req_to_dst             ),
+    .async_ack_o        ( async_reset_src2dst_ack_from_dst           )
+  );
+
+  // The top-level clearable wrapper acknowledges isolation/clear one cycle
+  // after the reset controller requests it; mirror that behavior here.
+  always_ff @(posedge src_clk_i, negedge src_rst_ni) begin
+    if (!src_rst_ni) begin
+      s_src_isolate_ack_q <= 1'b0;
+      s_src_clear_ack_q   <= 1'b0;
+    end else begin
+      s_src_isolate_ack_q <= s_src_isolate_req;
+      s_src_clear_ack_q   <= s_src_clear_req;
+    end
+  end
+
+  always_ff @(posedge dst_clk_i, negedge dst_rst_ni) begin
+    if (!dst_rst_ni) begin
+      s_dst_isolate_ack_q <= 1'b0;
+      s_dst_clear_ack_q   <= 1'b0;
+    end else begin
+      s_dst_isolate_ack_q <= s_dst_isolate_req;
+      s_dst_clear_ack_q   <= s_dst_clear_req;
+    end
+  end
+
+  assign src_clear_pending_o = s_src_isolate_req;
+  assign dst_clear_pending_o = s_dst_isolate_req;
 
 endmodule

--- a/test/simulate_cdc_fifo_gray_clearable.sh
+++ b/test/simulate_cdc_fifo_gray_clearable.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Copyright 2026 ETH Zurich and University of Bologna.
+#
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 0.51 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Authors:
+# - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+#
+# Description: Clearable Gray-Counter CDC FIFO Simulation Sweep
+# Compile the test target and run plain plus timed-delay Questa regressions for
+# cc_cdc_fifo_gray_clearable.
+
+set -euo pipefail
+
+: "${BENDER:=bender}"
+: "${VSIM:=vsim}"
+
+read -r -a bender_cmd <<< "${BENDER}"
+read -r -a vsim_cmd <<< "${VSIM}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+build_dir="${CDC_FIFO_GRAY_CLEARABLE_BUILDDIR:-${repo_root}/build/vsim/cdc_fifo_gray_clearable}"
+compile_tcl="${build_dir}/compile.tcl"
+
+mkdir -p "${build_dir}"
+
+cd "${repo_root}"
+"${bender_cmd[@]}" checkout
+"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+
+cd "${build_dir}"
+"${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"
+
+call_vsim() {
+  local name="$1"
+  local log_file="vsim.${name}.log"
+  shift
+  echo "== ${name} =="
+  "${vsim_cmd[@]}" -c -quiet cc_cdc_fifo_clearable_tb -suppress 8386 "$@" \
+    -do 'run -all; quit -f' |
+    tee "${log_file}"
+  grep "Errors: 0," "${log_file}"
+}
+
+call_vsim depth3_default \
+  -gSEED=1 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=80
+
+call_vsim depth4_default \
+  -gSEED=2 \
+  -gDEPTH=4 \
+  -gNUM_RANDOM_TRANSFERS=100
+
+call_vsim src_fast \
+  -gSEED=3 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gTCK_SRC_PS=5000 \
+  -gTCK_DST_PS=17000
+
+call_vsim dst_fast \
+  -gSEED=4 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=80 \
+  -gTCK_SRC_PS=17000 \
+  -gTCK_DST_PS=5000
+
+call_vsim timed_depth3_800ps \
+  -gSEED=11 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=60 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=800 \
+  -gTCK_SRC_PS=10000 \
+  -gTCK_DST_PS=10000
+
+call_vsim timed_relprime_offset_1800ps \
+  -gSEED=12 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=60 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=1800 \
+  -gTCK_SRC_PS=7000 \
+  -gTCK_DST_PS=11000 \
+  -gSRC_START_DELAY_PS=1500 \
+  -gDST_START_DELAY_PS=3300
+
+call_vsim timed_src_fast_near_bound \
+  -gSEED=13 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=60 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=4500 \
+  -gTCK_SRC_PS=5000 \
+  -gTCK_DST_PS=17000 \
+  -gSRC_START_DELAY_PS=1000 \
+  -gDST_START_DELAY_PS=2500
+
+call_vsim timed_dst_fast_near_bound \
+  -gSEED=14 \
+  -gDEPTH=3 \
+  -gNUM_RANDOM_TRANSFERS=60 \
+  -gINJECT_DELAYS=1 \
+  -gMAX_DELAY_PS=4500 \
+  -gTCK_SRC_PS=17000 \
+  -gTCK_DST_PS=5000 \
+  -gSRC_START_DELAY_PS=2500 \
+  -gDST_START_DELAY_PS=1000


### PR DESCRIPTION
Forwards async-reset control into the reset controller, clamps reset-controller sync stages, and splits the clearable gray FIFO reset handling into source/destination sides. Adds timed clear/reset coverage and updates the TB to inject delays across the exposed async channels.