### PR TITLE
ci: Include testbench target in elaboration flows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ sg-lint:
         ./test/simulate_cdc_clearable.sh
       else
         bender checkout
-        bender script vsim -t test > compile.tcl
+        bender script vsim -t test -t tb > compile.tcl
         $VSIM -c -quiet -do 'source compile.tcl; quit'
         $VSIM -c $TOPLEVEL -voptargs="-timescale 1ns/100ps" -do "run -all" $PARAM1 $PARAM2
         (! grep -n "Error:" transcript)

--- a/Bender.yml
+++ b/Bender.yml
@@ -123,6 +123,10 @@ sources:
 
   - target: test
     files:
+      - test/cc_test_pkg.sv
+
+  - target: tb
+    files:
       # Level 0
       - test/cc_addr_decode_tb.sv
       - test/cc_cb_filter_tb.sv
@@ -139,7 +143,6 @@ sources:
       - test/cc_stream_register_tb.sv
       - test/cc_stream_to_mem_tb.sv
       - test/cc_sub_per_hash_tb.sv
-      - test/cc_test_pkg.sv
       # Level 1
       - test/cc_isochronous_crossing_tb.sv
       - test/cc_stream_omega_net_tb.sv
@@ -148,7 +151,6 @@ sources:
       - test/cc_clk_int_div_static_tb.sv
       - test/cc_clk_mux_glitch_free_tb.sv
       - test/cc_lossy_valid_to_stream_tb.sv
-
 
   - target: synth_test
     files:

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,37 @@
+###############
+# Executables #
+###############
+
 BENDER    ?= bender
 VERILATOR ?= verilator
 VSIM      ?= vsim
 VCS_SEPP  ?=
 SG_SHELL  ?= sg_shell
 
+#########
+# Flags #
+#########
+
+BENDER_TARGETS = -t test -t tb -t formal -t synth_test
+
 # Suppress vlog-2583: always_comb/always_latch conflict checks are deferred to vopt
 VLOG_FLAGS += -suppress 2583
+
+# If any module has a timescale directive, all modules must have a timescale directive,
+# so we add a default timescale to all modules
+VLOGAN_FLAGS += -timescale=1ns/1ps
+
+###############
+# Directories #
+###############
 
 VSIM_BUILDDIR = $(abspath build/vsim)
 VCS_BUILDDIR  = $(abspath build/vcs)
 SG_BUILDDIR   = $(abspath build/spyglass)
+
+###########
+# Targets #
+###########
 
 # All modules in src/ with a top-level module declaration, minus skipped ones
 SV_MODULES       = $(patsubst src/%.sv,%,$(shell grep -l "^module " src/*.sv))
@@ -39,13 +61,13 @@ $(VSIM_BUILDDIR) $(VCS_BUILDDIR) $(SG_BUILDDIR):
 	mkdir -p $@
 
 $(VSIM_BUILDDIR)/elaborate.tcl: Bender.yml | $(VSIM_BUILDDIR) .bender/.checkout
-	$(BENDER) script vsim --vlog-arg="$(VLOG_FLAGS) " > $@
+	$(BENDER) script vsim $(BENDER_TARGETS) --vlog-arg="$(VLOG_FLAGS) " > $@
 
 vsim-elab: $(VSIM_BUILDDIR)/elaborate.tcl
 	cd $(VSIM_BUILDDIR) && $(VSIM) -c -do "source $<; quit"
 
 $(VCS_BUILDDIR)/elaborate.sh: Bender.yml | $(VCS_BUILDDIR) .bender/.checkout
-	$(BENDER) script vcs > $@
+	$(BENDER) script vcs $(BENDER_TARGETS) --vlogan-args="$(VLOGAN_FLAGS)" > $@
 	chmod +x $@
 
 vcs-elab: $(VCS_BUILDDIR)/elaborate.sh

--- a/test/cc_cdc_2phase_clearable_tb.sv
+++ b/test/cc_cdc_2phase_clearable_tb.sv
@@ -1039,10 +1039,10 @@ module cc_cdc_reset_ctrlr_half_monitor
   input logic                 receiver_clear_out
 );
 
-  import cc_cdc_2phase_clearable_tb_monitor_pkg::report_monitor_error;
-
   timeunit 1ns;
   timeprecision 1ps;
+
+  import cc_cdc_2phase_clearable_tb_monitor_pkg::report_monitor_error;
 
   localparam logic [3:0] InitIdle                = 4'd0;
   localparam logic [3:0] InitIsolate             = 4'd1;

--- a/test/simulate.sh
+++ b/test/simulate.sh
@@ -14,7 +14,7 @@ set -e
 
 [ ! -z "$VSIM" ] || VSIM=vsim
 
-bender script vsim -t test > compile.tcl
+bender script vsim -t test -t tb > compile.tcl
 
 "$VSIM" -c -quiet -do 'source compile.tcl; quit'
 

--- a/test/simulate_cdc_2phase.sh
+++ b/test/simulate_cdc_2phase.sh
@@ -34,7 +34,7 @@ mkdir -p "${build_dir}"
 
 cd "${repo_root}"
 "${bender_cmd[@]}" checkout
-"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+"${bender_cmd[@]}" script vsim -t test -t tb > "${compile_tcl}"
 
 cd "${build_dir}"
 "${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"

--- a/test/simulate_cdc_4phase.sh
+++ b/test/simulate_cdc_4phase.sh
@@ -34,7 +34,7 @@ mkdir -p "${build_dir}"
 
 cd "${repo_root}"
 "${bender_cmd[@]}" checkout
-"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+"${bender_cmd[@]}" script vsim -t test -t tb > "${compile_tcl}"
 
 cd "${build_dir}"
 "${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"

--- a/test/simulate_cdc_clearable.sh
+++ b/test/simulate_cdc_clearable.sh
@@ -34,7 +34,7 @@ mkdir -p "${build_dir}"
 
 cd "${repo_root}"
 "${bender_cmd[@]}" checkout
-"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+"${bender_cmd[@]}" script vsim -t test -t tb > "${compile_tcl}"
 
 cd "${build_dir}"
 "${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"

--- a/test/simulate_cdc_fifo_2phase.sh
+++ b/test/simulate_cdc_fifo_2phase.sh
@@ -34,7 +34,7 @@ mkdir -p "${build_dir}"
 
 cd "${repo_root}"
 "${bender_cmd[@]}" checkout
-"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+"${bender_cmd[@]}" script vsim -t test -t tb > "${compile_tcl}"
 
 cd "${build_dir}"
 "${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"

--- a/test/simulate_cdc_fifo_gray.sh
+++ b/test/simulate_cdc_fifo_gray.sh
@@ -34,7 +34,7 @@ mkdir -p "${build_dir}"
 
 cd "${repo_root}"
 "${bender_cmd[@]}" checkout
-"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+"${bender_cmd[@]}" script vsim -t test -t tb > "${compile_tcl}"
 
 cd "${build_dir}"
 "${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"

--- a/test/simulate_cdc_fifo_gray_clearable.sh
+++ b/test/simulate_cdc_fifo_gray_clearable.sh
@@ -34,7 +34,7 @@ mkdir -p "${build_dir}"
 
 cd "${repo_root}"
 "${bender_cmd[@]}" checkout
-"${bender_cmd[@]}" script vsim -t test > "${compile_tcl}"
+"${bender_cmd[@]}" script vsim -t test -t tb > "${compile_tcl}"
 
 cd "${build_dir}"
 "${vsim_cmd[@]}" -c -quiet -do "source ${compile_tcl}; quit"


### PR DESCRIPTION
@ricted98 reported failing elaboration of `cc_cdc_2phase_clearable_tb` with VCS when testing v2-dev in Cheshire.

Firstly, Cheshire doesn't depend on that file at all. This PR splits the existing Bender `test` target into separate `test` and `tb` targets. `test` includes reusable test sources that might be used by dependent repos. `tb` includes common_cells-specific testbenches that are not expected to be reused by dependent repos.

@ricted98 suggested that we further prefix it as `cc-tb`, if we don't intend these files to be included by any dependencies. Bender now supports dependency-specific targets: `-t my_pkg:my_target` activates `my_target` only for `my_pkg`. Thus, I don't think prefixing `tb` is necessary; a repo should use `<repo_package>:tb` so no external testbench sources are included.

Finally, the PR extends the elaboration tests to include all testbench, formal and synthesis wrapper sources. The ordering of the timescale and import statements in  `cc_cdc_2phase_clearable_tb` are exchanged so as to fix the same elaboration issue encountered by @ricted98.