### PR TITLE
registers: avoid boolean expressions in sync resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The use of linter rules that flag explicit uses of `always_ff` in source code is
 - *Argument suffix `_sig` indicates signal names for present and next state as well as clocks, resets and synchronous clear signals.*
 - *Argument `rst_val` specifies the value literal to be assigned upon reset.*
 - *Argument `load_ena` specifies the boolean expression that forms the load enable of the register.*
+- *Arguments `clr_sig`, `rst_sig` and `rstn_sig` must be plain signal names, not expressions.*
 
 ### SystemVerilog Assertion Macros
 

--- a/src/cc_delta_counter.sv
+++ b/src/cc_delta_counter.sv
@@ -30,8 +30,10 @@ module cc_delta_counter #(
     logic [Width:0] counter_q, counter_d;
     if (StickyOverflow) begin : gen_sticky_overflow
         logic overflow_d, overflow_q;
+        logic overflow_clr;
 
-        `FFARNC(overflow_q, overflow_d, clr_i || load_i, 1'b0, clk_i, rst_ni)
+        assign overflow_clr = clr_i || load_i;
+        `FFARNC(overflow_q, overflow_d, overflow_clr, 1'b0, clk_i, rst_ni)
 
         always_comb begin
             overflow_d = overflow_q;

--- a/src/cc_fifo.sv
+++ b/src/cc_fifo.sv
@@ -117,9 +117,11 @@ module cc_fifo #(
     end
 
     // sequential process
-    `FFARNC(read_pointer_q, read_pointer_n, clr_i || flush_i, '0, clk_i, rst_ni)
-    `FFARNC(write_pointer_q, write_pointer_n, clr_i || flush_i, '0, clk_i, rst_ni)
-    `FFARNC(status_cnt_q, status_cnt_n, clr_i || flush_i, '0, clk_i, rst_ni)
+    logic clr_or_flush;
+    assign clr_or_flush = clr_i || flush_i;
+    `FFARNC(read_pointer_q, read_pointer_n, clr_or_flush, '0, clk_i, rst_ni)
+    `FFARNC(write_pointer_q, write_pointer_n, clr_or_flush, '0, clk_i, rst_ni)
+    `FFARNC(status_cnt_q, status_cnt_n, clr_or_flush, '0, clk_i, rst_ni)
 
     `FFLARNC(mem_q, mem_n, !gate_clock, clr_i, {FifoDepth{data_t'('0)}}, clk_i, rst_ni)
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/pulp-platform/common_cells/pull/314.

Synopsys Fusion Compiler fails to parse the `synopsys sync_set_reset` pragma emitted by FFARNC/FFLARNC when the synchronous reset argument is a compound boolean expression rather than a plain signal name. Introduce named intermediate clear signals in cc_fifo and cc_delta_counter, and document the requirement in the README.