### PR TITLE
Fix legacy IP wrapper elaboration with Fusion Compiler

### DIFF
--- a/src/deprecated/stream_arbiter.sv
+++ b/src/deprecated/stream_arbiter.sv
@@ -7,7 +7,7 @@
 module stream_arbiter #(
   parameter type    DATA_T  = logic,
   parameter integer N_INP   = 1,
-  parameter string  ARBITER = "rr"
+  parameter         ARBITER = "rr"
 ) (
   input  logic               clk_i,
   input  logic               rst_ni,

--- a/src/deprecated/stream_arbiter.sv
+++ b/src/deprecated/stream_arbiter.sv
@@ -7,6 +7,7 @@
 module stream_arbiter #(
   parameter type    DATA_T  = logic,
   parameter integer N_INP   = 1,
+// verilog_lint: waive explicit-parameter-storage-type
   parameter         ARBITER = "rr"
 ) (
   input  logic               clk_i,

--- a/src/deprecated/stream_arbiter_flushable.sv
+++ b/src/deprecated/stream_arbiter_flushable.sv
@@ -7,6 +7,7 @@
 module stream_arbiter_flushable #(
   parameter type    DATA_T  = logic,
   parameter integer N_INP   = 1,
+// verilog_lint: waive explicit-parameter-storage-type
   parameter         ARBITER = "rr"
 ) (
   input  logic               clk_i,

--- a/src/deprecated/stream_arbiter_flushable.sv
+++ b/src/deprecated/stream_arbiter_flushable.sv
@@ -7,7 +7,7 @@
 module stream_arbiter_flushable #(
   parameter type    DATA_T  = logic,
   parameter integer N_INP   = 1,
-  parameter string  ARBITER = "rr"
+  parameter         ARBITER = "rr"
 ) (
   input  logic               clk_i,
   input  logic               rst_ni,


### PR DESCRIPTION
Fixes the following elaboration errors with Fusion Compiler:
```
Error: common_cells/src/deprecated/stream_arbiter.sv:10: The construct 'string' is not supported in synthesis. (VER-700)
```