### PR TITLE
formal: add SymbiYosys proof for cc_heaviside

### DIFF
--- a/formal/Makefile
+++ b/formal/Makefile
@@ -26,7 +26,7 @@ FORMAL_BUILDDIR ?= build
 FORMAL_FLIST := $(FORMAL_BUILDDIR)/cdc_reset_ctrlr.flist
 
 all: fifo.check counter.check fall_through_register.check lzc.check \
-	cdc_reset_ctrlr_half.check cdc_reset_ctrlr_composed.check
+	cdc_reset_ctrlr_half.check cdc_reset_ctrlr_composed.check heaviside.check
 
 $(FORMAL_BUILDDIR):
 	mkdir -p $@
@@ -74,8 +74,15 @@ $(FORMAL_BUILDDIR)/cdc_reset_ctrlr_composed.check: cdc_reset_ctrlr_composed.sby 
 	$(SBY) -f -d $(FORMAL_BUILDDIR)/cdc_reset_ctrlr_composed $<
 	touch $@
 
+heaviside.check: $(FORMAL_BUILDDIR)/heaviside.check
+
+$(FORMAL_BUILDDIR)/heaviside.check: heaviside.sby ../src/cc_pkg.sv ../src/cc_heaviside.sv \
+				cc_heaviside_properties.sv cc_heaviside_formal.sv | $(FORMAL_BUILDDIR)
+	$(SBY) -f -d $(FORMAL_BUILDDIR)/heaviside $<
+	touch $@
+
 .PHONY: all clean fifo.check counter.check fall_through_register.check lzc.check cdc_reset_ctrlr_half.check \
-	cdc_reset_ctrlr_composed.check
+	cdc_reset_ctrlr_composed.check heaviside.check
 clean:
 	$(RM) $(FORMAL_BUILDDIR)
 	$(RM) fifo.check fifo/

--- a/formal/cc_heaviside_formal.sv
+++ b/formal/cc_heaviside_formal.sv
@@ -1,0 +1,39 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Brian Bui <buiminhnhut114@gmail.com>
+
+// Elaboration harness instantiating cc_heaviside over representative
+// parametrizations including non-power-of-two widths.
+module cc_heaviside_formal import cc_pkg::*; #(
+    parameter int unsigned MaxWidth = 33
+) (
+    input logic [MaxWidth-1:0] dummy_i
+);
+
+    for (genvar width = 1; width <= MaxWidth; width++) begin : gen_width
+        localparam int unsigned Width    = unsigned'(width);
+        localparam int unsigned IdxWidth = cc_pkg::idx_width(Width);
+
+        logic [IdxWidth-1:0] x;
+        logic [Width-1:0]    mask;
+
+        // Use the lower bits of the formal input as the index
+        assign x = dummy_i[IdxWidth-1:0];
+
+        cc_heaviside #(
+            .Width ( Width )
+        ) i_heaviside (
+            .x_i    ( x    ),
+            .mask_o ( mask )
+        );
+    end
+
+endmodule : cc_heaviside_formal

--- a/formal/cc_heaviside_properties.sv
+++ b/formal/cc_heaviside_properties.sv
@@ -1,0 +1,89 @@
+// Copyright 2026 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Brian Bui <buiminhnhut114@gmail.com>
+
+// Property checker applied to each instantiation of cc_heaviside
+// Proves that mask_o contains all and only the asserted bits in the
+// [0, x_i] interval for every valid input.
+module cc_heaviside_properties import cc_pkg::*; #(
+    parameter int unsigned Width = 32,
+    localparam int unsigned IdxWidth = cc_pkg::idx_width(Width),
+    localparam type idx_t  = logic [IdxWidth-1:0],
+    localparam type mask_t = logic [Width-1:0]
+) (
+    input idx_t  x_i,
+    input mask_t mask_o
+);
+
+    // ---- Reference model ----
+    // Compute the expected mask: bits [0 .. x_i] should be 1, rest 0.
+    function automatic mask_t expected_mask(input idx_t x);
+        expected_mask = '0;
+        for (int unsigned i = 0; i < Width; i++) begin
+            if (i <= unsigned'(x)) begin
+                expected_mask[i] = 1'b1;
+            end
+        end
+    endfunction
+
+    // ---- Property 1: Full functional equivalence ----
+    // The DUT output must match the reference model for every input.
+    always_comb begin
+        assert (mask_o == expected_mask(x_i));
+    end
+
+    // ---- Property 2: Bit 0 is always asserted ----
+    // For any valid input x_i >= 0 (unsigned, always true), bit 0 must be set.
+    always_comb begin
+        assert (mask_o[0] == 1'b1);
+    end
+
+    // ---- Property 3: Boundary – when x_i == Width-1, mask is all-ones ----
+    always_comb begin
+        if (x_i == idx_t'(Width - 1)) begin
+            assert (mask_o == {Width{1'b1}});
+        end
+    end
+
+    // ---- Property 4: Boundary – when x_i == 0, only bit 0 is set ----
+    always_comb begin
+        if (x_i == '0) begin
+            assert (mask_o == mask_t'(1));
+        end
+    end
+
+    // ---- Property 5: Monotonicity ----
+    // If the index is nonzero, the mask with x_i must be a strict
+    // superset of the mask with (x_i - 1).  Equivalently the extra
+    // bit at position x_i must be set and everything above must be clear.
+    always_comb begin
+        if (x_i > '0 && unsigned'(x_i) < Width) begin
+            assert (mask_o[x_i] == 1'b1);
+        end
+    end
+
+    // ---- Property 6: Bits above x_i must be zero ----
+    always_comb begin
+        for (int unsigned i = 0; i < Width; i++) begin
+            if (i > unsigned'(x_i) && unsigned'(x_i) < Width) begin
+                assert (mask_o[i] == 1'b0);
+            end
+        end
+    end
+
+endmodule : cc_heaviside_properties
+
+bind cc_heaviside cc_heaviside_properties #(
+    .Width ( Width )
+) i_cc_heaviside_properties (
+    .x_i    ( x_i    ),
+    .mask_o ( mask_o )
+);

--- a/formal/heaviside.sby
+++ b/formal/heaviside.sby
@@ -1,0 +1,34 @@
+# Copyright 2026 ETH Zurich and University of Bologna.
+#
+# Copyright and related rights are licensed under the Solderpad Hardware
+# License, Version 0.51 (the "License"); you may not use this file except in
+# compliance with the License. You may obtain a copy of the License at
+# http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+# or agreed to in writing, software, hardware and materials distributed under
+# this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# Authors:
+# - Brian Bui <buiminhnhut114@gmail.com>
+#
+# Description: Heaviside Mask Generator Proof Configuration
+# Configure the SymbiYosys proof for a set of cc_heaviside parametrizations.
+
+[options]
+mode prove
+depth 1
+
+[engines]
+smtbmc
+
+[script]
+plugin -i slang.so
+read_slang --std 1800-2017 -I../../../../include --top cc_heaviside_formal cc_pkg.sv cc_heaviside.sv cc_heaviside_properties.sv cc_heaviside_formal.sv
+prep -top cc_heaviside_formal
+
+[files]
+../src/cc_pkg.sv
+../src/cc_heaviside.sv
+cc_heaviside_properties.sv
+cc_heaviside_formal.sv


### PR DESCRIPTION
## Summary

Add open-source formal verification for `cc_heaviside` (Closes #350, subtask of #288).

## Changes

### Formal verification

- Add `formal/cc_heaviside_properties.sv`, a bound property checker that proves full functional
  equivalence against a loop-based reference model.
- Add `formal/cc_heaviside_formal.sv`, an elaboration harness covering widths 1 through 33,
  including power-of-two and non-power-of-two configurations.
- Add `formal/heaviside.sby`, a depth-1 SymbiYosys proof using the `smtbmc` engine.
- Add `heaviside.check` to `formal/Makefile`.

### Documented behavior

- Document that inputs greater than or equal to `Width` saturate `mask_o` to all ones.
- Capture the same saturation behavior explicitly in the formal reference model.

## How to run

```bash
cd formal
make heaviside.check
```

## Validation

- The property covers widths 1 through 33, including out-of-range encodings for
  non-power-of-two widths.
- Verible lint passes.
- The formal harness compiles and elaborates successfully with VCS X-2025.06.
